### PR TITLE
fix(search): default Gemini API search model to gemini-2.5-flash

### DIFF
--- a/gemini-api.ts
+++ b/gemini-api.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 export const API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
-export const DEFAULT_MODEL = "gemini-3-flash-preview";
+export const DEFAULT_MODEL = "gemini-2.5-flash";
 
 interface GeminiApiConfig {
 	geminiApiKey?: string;


### PR DESCRIPTION
## Summary

Switch `DEFAULT_MODEL` in `gemini-api.ts` from `gemini-3-flash-preview` to `gemini-2.5-flash`.

## Why

In some environments, `gemini-3-flash-preview` times out for `generateContent` web-search requests, which can cascade into a misleading "Gemini search unavailable" error even when `geminiApiKey` is valid.

`gemini-2.5-flash` is stable in those same environments and returns grounded search results successfully.

## Change

- `gemini-api.ts`
  - `export const DEFAULT_MODEL = "gemini-3-flash-preview"`
  - → `export const DEFAULT_MODEL = "gemini-2.5-flash"`

## Validation

- Reproduced failure path with valid API key + `provider: "gemini"`.
- Verified success after change via local search invocation with grounded results.

Closes #11
