### PR TITLE
feat: add Tavily as configurable search provider alongside existing providers

### DIFF
--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -6,8 +6,9 @@ import { getApiKey, API_BASE, DEFAULT_MODEL } from "./gemini-api.js";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.js";
 import { isPerplexityAvailable, searchWithPerplexity, type SearchResult, type SearchResponse, type SearchOptions } from "./perplexity.js";
 import { hasExaApiKey, isExaAvailable, searchWithExa } from "./exa.js";
+import { isTavilyAvailable, searchWithTavily } from "./tavily.js";
 
-export type SearchProvider = "auto" | "perplexity" | "gemini" | "exa";
+export type SearchProvider = "auto" | "perplexity" | "gemini" | "exa" | "tavily";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
 
 export interface AttributedSearchResponse extends SearchResponse {
@@ -57,7 +58,7 @@ function normalizeSearchModel(value: unknown): string | undefined {
 
 function normalizeSearchProvider(value: unknown): SearchProvider {
 	const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-	return normalized === "auto" || normalized === "perplexity" || normalized === "gemini" || normalized === "exa"
+	return normalized === "auto" || normalized === "perplexity" || normalized === "gemini" || normalized === "exa" || normalized === "tavily"
 		? normalized
 		: "auto";
 }
@@ -146,6 +147,11 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	if (provider === "tavily") {
+		const result = await searchWithTavily(query, options);
+		return { ...result, provider: "tavily" };
+	}
+
 	const fallbackErrors: string[] = [];
 
 	if (provider !== "exa" && isExaAvailable()) {
@@ -155,6 +161,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		} catch (err) {
 			if (isAbortError(err)) throw err;
 			fallbackErrors.push(`Exa: ${errorMessage(err)}`);
+		}
+	}
+
+	if (provider !== "tavily" && isTavilyAvailable()) {
+		try {
+			const result = await searchWithTavily(query, options);
+			return { ...result, provider: "tavily" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Tavily: ${errorMessage(err)}`);
 		}
 	}
 
@@ -184,8 +200,9 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		"No search provider available. Either:\n" +
 		"  1. Set perplexityApiKey in ~/.pi/web-search.json\n" +
 		"  2. Set EXA_API_KEY (or exaApiKey) in ~/.pi/web-search.json\n" +
-		"  3. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
-		"  4. Sign into gemini.google.com in a supported Chromium-based browser"
+		"  3. Set TAVILY_API_KEY (or tavilyApiKey) in ~/.pi/web-search.json\n" +
+		"  4. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
+		"  5. Sign into gemini.google.com in a supported Chromium-based browser"
 	);
 }
 

--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { isPerplexityAvailable } from "./perplexity.js";
 import { isExaAvailable } from "./exa.js";
+import { isTavilyAvailable } from "./tavily.js";
 import { isGeminiApiAvailable } from "./gemini-api.js";
 import { getActiveGoogleEmail, isGeminiWebAvailable } from "./gemini-web.js";
 
@@ -53,6 +54,7 @@ interface WebSearchConfig {
 interface ProviderAvailability {
 	perplexity: boolean;
 	exa: boolean;
+	tavily: boolean;
 	gemini: boolean;
 }
 
@@ -112,7 +114,7 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	if (normalized === "auto" || normalized === "exa" || normalized === "perplexity" || normalized === "gemini") {
+	if (normalized === "auto" || normalized === "exa" || normalized === "perplexity" || normalized === "gemini" || normalized === "tavily") {
 		return normalized;
 	}
 	return "auto";
@@ -151,6 +153,7 @@ async function getProviderAvailability(): Promise<ProviderAvailability> {
 	return {
 		perplexity: isPerplexityAvailable(),
 		exa: isExaAvailable(),
+		tavily: isTavilyAvailable(),
 		gemini: isGeminiApiAvailable() || !!geminiWebAvail,
 	};
 }
@@ -172,20 +175,29 @@ function resolveProvider(
 
 	if (provider === "auto") {
 		if (available.exa) return "exa";
+		if (available.tavily) return "tavily";
 		if (available.perplexity) return "perplexity";
 		if (available.gemini) return "gemini";
 		return "exa";
 	}
 	if (provider === "exa" && !available.exa) {
+		if (available.tavily) return "tavily";
 		if (available.perplexity) return "perplexity";
 		return available.gemini ? "gemini" : "exa";
 	}
+	if (provider === "tavily" && !available.tavily) {
+		if (available.exa) return "exa";
+		if (available.perplexity) return "perplexity";
+		return available.gemini ? "gemini" : "tavily";
+	}
 	if (provider === "perplexity" && !available.perplexity) {
 		if (available.exa) return "exa";
+		if (available.tavily) return "tavily";
 		return available.gemini ? "gemini" : "perplexity";
 	}
 	if (provider === "gemini" && !available.gemini) {
 		if (available.exa) return "exa";
+		if (available.tavily) return "tavily";
 		return available.perplexity ? "perplexity" : "gemini";
 	}
 	return provider;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "web-search",
     "perplexity",
     "fetch",
-    "scraping"
+    "scraping",
+    "tavily"
   ],
   "author": "Nico Bailon",
   "license": "MIT",

--- a/tavily.ts
+++ b/tavily.ts
@@ -1,0 +1,165 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { activityMonitor } from "./activity.js";
+import type { SearchOptions, SearchResponse, SearchResult } from "./perplexity.js";
+
+const TAVILY_SEARCH_URL = "https://api.tavily.com/search";
+const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+
+interface WebSearchConfig {
+	tavilyApiKey?: unknown;
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+function normalizeApiKey(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function getApiKey(): string | null {
+	return normalizeApiKey(process.env.TAVILY_API_KEY) ?? normalizeApiKey(loadConfig().tavilyApiKey);
+}
+
+export function isTavilyAvailable(): boolean {
+	return !!getApiKey();
+}
+
+function requestSignal(signal?: AbortSignal): AbortSignal {
+	const timeout = AbortSignal.timeout(60000);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function mapRecencyFilter(filter: string): string | undefined {
+	const mapping: Record<string, string> = {
+		day: "day",
+		week: "week",
+		month: "month",
+		year: "year",
+	};
+	return mapping[filter];
+}
+
+function mapDomainFilter(domainFilter: string[] | undefined): { include_domains?: string[]; exclude_domains?: string[] } {
+	if (!domainFilter?.length) return {};
+	const include_domains = domainFilter
+		.filter(d => !d.startsWith("-") && d.trim().length > 0)
+		.map(d => d.trim());
+	const exclude_domains = domainFilter
+		.filter(d => d.startsWith("-"))
+		.map(d => d.slice(1).trim())
+		.filter(Boolean);
+	return {
+		...(include_domains.length ? { include_domains } : {}),
+		...(exclude_domains.length ? { exclude_domains } : {}),
+	};
+}
+
+interface TavilySearchResponse {
+	answer?: string;
+	results?: Array<{
+		title?: string;
+		url?: string;
+		content?: string;
+		score?: number;
+	}>;
+}
+
+export async function searchWithTavily(query: string, options: SearchOptions = {}): Promise<SearchResponse> {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		throw new Error(
+			"Tavily API key not found. Either:\n" +
+			`  1. Create ${CONFIG_PATH} with { "tavilyApiKey": "your-key" }\n` +
+			"  2. Set TAVILY_API_KEY environment variable\n" +
+			"Get a key at https://app.tavily.com"
+		);
+	}
+
+	const activityId = activityMonitor.logStart({ type: "api", query });
+
+	const numResults = Math.min(options.numResults ?? 5, 20);
+	const domainFilters = mapDomainFilter(options.domainFilter);
+	const timeRange = options.recencyFilter ? mapRecencyFilter(options.recencyFilter) : undefined;
+
+	const requestBody: Record<string, unknown> = {
+		query,
+		max_results: numResults,
+		search_depth: "advanced",
+		include_answer: "advanced",
+		...domainFilters,
+		...(timeRange ? { time_range: timeRange } : {}),
+	};
+
+	let response: Response;
+	try {
+		response = await fetch(TAVILY_SEARCH_URL, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": `Bearer ${apiKey}`,
+			},
+			body: JSON.stringify(requestBody),
+			signal: requestSignal(options.signal),
+		});
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		throw err;
+	}
+
+	if (!response.ok) {
+		activityMonitor.logComplete(activityId, response.status);
+		const errorText = await response.text();
+		throw new Error(`Tavily API error ${response.status}: ${errorText.slice(0, 300)}`);
+	}
+
+	let data: TavilySearchResponse;
+	try {
+		data = await response.json() as TavilySearchResponse;
+	} catch (err) {
+		activityMonitor.logComplete(activityId, response.status);
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Tavily API returned invalid JSON: ${message}`);
+	}
+
+	const answer = data.answer || "";
+	const results: SearchResult[] = [];
+	if (Array.isArray(data.results)) {
+		for (let i = 0; i < data.results.length; i++) {
+			const item = data.results[i];
+			if (!item?.url) continue;
+			results.push({
+				title: item.title || `Source ${i + 1}`,
+				url: item.url,
+				snippet: item.content || "",
+			});
+		}
+	}
+
+	activityMonitor.logComplete(activityId, response.status);
+	return { answer, results };
+}


### PR DESCRIPTION
## Summary

- Added Tavily as a first-class search provider option in the multi-provider orchestration layer
- Tavily is available for explicit selection (`provider: "tavily"`) and as a candidate in the auto fallback chain (positioned after Exa, before Perplexity)
- Existing providers (Exa, Perplexity, Gemini) remain fully functional and unchanged

## Files changed

- **`tavily.ts`** (new): Implements `isTavilyAvailable()` and `searchWithTavily()` using the Tavily Search REST API via raw `fetch()`, matching the project's existing pattern. Reads `TAVILY_API_KEY` from env or `~/.pi/web-search.json` `tavilyApiKey` field. Returns data in the shared `SearchResponse` shape.
- **`gemini-search.ts`**: Extended `SearchProvider` type to include `'tavily'`. Added `'tavily'` to `normalizeSearchProvider()`. Added explicit `'tavily'` provider branch in `search()`. Inserted Tavily into the auto fallback chain. Updated "no provider available" error message to mention `TAVILY_API_KEY`.
- **`index.ts`**: Imported `isTavilyAvailable`. Added `tavily` to `ProviderAvailability` interface and `getProviderAvailability()`. Updated `normalizeProviderInput()` and `resolveProvider()` to handle tavily.
- **`package.json`**: Added `"tavily"` to keywords array.

## Environment variable changes

- Added `TAVILY_API_KEY` environment variable support
- Added `tavilyApiKey` field support in `~/.pi/web-search.json`

## Notes for reviewers

- No SDK dependency added — uses raw `fetch()` consistent with all other providers in this project
- Tavily search uses `search_depth: "advanced"` and `include_answer: "advanced"` for highest quality results
- The auto fallback order is: Exa → Tavily → Perplexity → Gemini


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is well-implemented and consistent with the existing provider pattern. All four described files are correctly modified. The `tavily.ts` module follows the exact same structure as `exa.ts` and `perplexity.ts` (raw fetch, config caching, `activityMonitor` lifecycle, `requestSignal` timeout helper, `mapDomainFilter` convention). API authentication via `Authorization: Bearer` header matches the current Tavily REST API v2 spec. The `SearchProvider` type, fallback chains in both `gemini-search.ts` and `index.ts`, and the `ProviderAvailability` interface are all extended cleanly without breaking existing behaviour. No prerequisite infrastructure is missing. Two minor issues are noted but neither blocks approval.
