### PR TITLE
fix: switch code_search to Exa web_search_exa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Switched `code_search` from deprecated Exa MCP `get_code_context_exa` to `web_search_exa`, approximating `maxTokens` with `contextMaxCharacters` so hosted Exa MCP works again without extra tool configuration.
+
 ## [0.10.6] - 2026-04-04
 
 ### Changed
@@ -22,7 +25,7 @@ All notable changes to this project will be documented in this file.
 - **Auto-open curator for all `web_search` runs (single + multi query).** Searches now open the curator window immediately and stream results live for review workflows; the old countdown/auto-condense fallback path was removed.
 - **Exa.ai search provider.** Neural/semantic search available alongside Perplexity and Gemini. 1,000 free requests/month. Set `EXA_API_KEY` env var or `exaApiKey` in `~/.pi/web-search.json`, or select explicitly with `provider: "exa"`. Includes built-in content extraction — when `includeContent` is true, full page text comes back with search results instead of requiring a separate background fetch. Monthly usage tracked in `~/.pi/exa-usage.json` with a warning at 80%.
 - **Exa MCP fallback.** When no Exa API key is configured, search routes through `mcp.exa.ai` with zero setup. Supports basic search and `includeContent` but not domain/recency filtering (falls through to Gemini for those).
-- **`code_search` tool.** Code/documentation search via Exa MCP (`get_code_context_exa`). No API key required. Returns code examples, docs, and API references from GitHub, Stack Overflow, and official documentation.
+- **`code_search` tool.** Code/documentation search via Exa MCP (`web_search_exa`). No API key required. Returns code examples, docs, and API references from GitHub, Stack Overflow, and official documentation.
 - **Glimpse native curator window.** On macOS with Glimpse installed, the search curator opens in a native WKWebView window instead of a browser tab. Faster launch, closer integration. Falls back to browser automatically when Glimpse is unavailable.
 - **Curator provider UX rewrite.** Replaced the provider dropdown with provider buttons (hidden when unavailable), made provider re-search additive, added provider badges on all cards (including errors), and switched button states to coverage-based logic keyed by logical query slots so duplicate query text is handled correctly.
 - **Per-card provider re-search.** Completed result cards now show "Also try" chips for other available providers. Clicking one searches the same query with that provider and adds a new card below, keeping both results for comparison.

--- a/code-search.test.ts
+++ b/code-search.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, expect, test } from "bun:test";
+import { executeCodeSearch } from "./code-search.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+test("code_search uses web_search_exa instead of deprecated get_code_context_exa", async () => {
+	let requestBody: any;
+	globalThis.fetch = async (_input, init) => {
+		requestBody = JSON.parse(String(init?.body));
+		const payload = JSON.stringify({
+			result: {
+				content: [{ type: "text", text: "Title: Example\nURL: https://example.com\nText: OAuth example" }],
+			},
+		});
+		return new Response(`data: ${payload}\n\n`, {
+			status: 200,
+			headers: { "Content-Type": "text/event-stream" },
+		});
+	};
+
+	const result = await executeCodeSearch("call-1", { query: "OAuth 2.0 example", maxTokens: 4321 });
+
+	expect(requestBody.params.name).toBe("web_search_exa");
+	expect(requestBody.params.name).not.toBe("get_code_context_exa");
+	expect(requestBody.params.arguments.query).toBe("OAuth 2.0 example");
+	expect(requestBody.params.arguments.contextMaxCharacters).toBeNumber();
+	expect(requestBody.params.arguments.contextMaxCharacters).toBeGreaterThan(0);
+	expect(requestBody.params.arguments).not.toHaveProperty("tokensNum");
+	expect(result.details).toEqual({ query: "OAuth 2.0 example", maxTokens: 4321 });
+	expect(result.content[0]?.text).toContain("OAuth example");
+});

--- a/code-search.ts
+++ b/code-search.ts
@@ -1,6 +1,10 @@
 import { activityMonitor } from "./activity.js";
 import { callExaMcp } from "./exa.js";
 
+function maxTokensToContextMaxCharacters(maxTokens: number): number {
+	return Math.max(3000, Math.min(Math.round(maxTokens * 4), 50000));
+}
+
 export async function executeCodeSearch(
 	_toolCallId: string,
 	params: { query: string; maxTokens?: number },
@@ -22,10 +26,13 @@ export async function executeCodeSearch(
 
 	try {
 		const text = await callExaMcp(
-			"get_code_context_exa",
+			"web_search_exa",
 			{
 				query,
-				tokensNum: maxTokens,
+				numResults: 5,
+				livecrawl: "fallback",
+				type: "auto",
+				contextMaxCharacters: maxTokensToContextMaxCharacters(maxTokens),
 			},
 			signal,
 		);


### PR DESCRIPTION
Fixes #24.

Switch `code_search` off deprecated `get_code_context_exa` and onto `web_search_exa`, per Exa's recommendation in https://github.com/nicobailon/pi-web-access/issues/24#issuecomment-4210440807.

Changes:
- call `web_search_exa` instead of `get_code_context_exa`
- map `maxTokens` to `contextMaxCharacters`
- add a Bun test covering the MCP tool name/args
- update changelog notes

Tested:
- `bun test`