### PR TITLE
fix: use workflow config instead of hardcoded summary-review

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1144,7 +1144,7 @@ export default function (pi: ExtensionAPI) {
 				const availableProviders = bootstrap.availableProviders;
 				const defaultProvider = bootstrap.defaultProvider;
 				const curatorTimeoutSeconds = bootstrap.timeoutSeconds;
-				const curatorWorkflow: CuratorWorkflow = "summary-review";
+				const curatorWorkflow: CuratorWorkflow = workflow;
 
 				const summaryContext: SummaryGenerationContext = {
 					model: ctx.model,


### PR DESCRIPTION
**Summary**
The \`curatorWorkflow\` variable was hardcoded to \`"summary-review"\` instead of using the resolved \`workflow\` value from config, causing the curator to always open regardless of the user's \`workflow\` setting.

**Fix**
Changed line 1147 to use the \`workflow\` variable instead of hardcoding \`"summary-review"\`:

\`\`\`diff
- const curatorWorkflow: CuratorWorkflow = "summary-review";
+ const curatorWorkflow: CuratorWorkflow = workflow;
\`\`\`

**Testing**
1. Set \`"workflow": "none"\` in \`~/.pi/web-search.json\`
2. Run \`web_search\` - no curator opens ✓
3. Set \`"workflow": "summary-review"\` - curator opens as expected ✓

**Related Issue**
Fixes #28