### PR TITLE
feat: add OpenAI and Brave search providers

### DIFF
--- a/brave.ts
+++ b/brave.ts
@@ -2,7 +2,6 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { activityMonitor } from "./activity.js";
-import type { ExtractedContent } from "./extract.js";
 import type { SearchOptions, SearchResult, SearchResponse } from "./perplexity.js";
 
 const BRAVE_API_URL = "https://api.search.brave.com/res/v1/web/search";
@@ -102,7 +101,6 @@ export async function searchWithBrave(
 
 		const webResults = data.web?.results ?? [];
 		const results: SearchResult[] = [];
-		const inlineContent: ExtractedContent[] = [];
 
 		for (const item of webResults.slice(0, numResults)) {
 			if (!item.url) continue;
@@ -111,14 +109,6 @@ export async function searchWithBrave(
 				url: item.url,
 				snippet: item.description || "",
 			});
-			if (item.description && options.includeContent) {
-				inlineContent.push({
-					url: item.url,
-					title: item.title || item.url,
-					content: item.description,
-					error: null,
-				});
-			}
 		}
 
 		// Build an answer from snippets
@@ -129,9 +119,7 @@ export async function searchWithBrave(
 			})
 			.join("\n\n");
 
-		const responseObj: SearchResponse = { answer, results };
-		if (inlineContent.length > 0) responseObj.inlineContent = inlineContent;
-		return responseObj;
+		return { answer, results };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		if (message.toLowerCase().includes("abort")) {

--- a/brave.ts
+++ b/brave.ts
@@ -1,0 +1,144 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { activityMonitor } from "./activity.js";
+import type { ExtractedContent } from "./extract.js";
+import type { SearchOptions, SearchResult, SearchResponse } from "./perplexity.js";
+
+const BRAVE_API_URL = "https://api.search.brave.com/res/v1/web/search";
+const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+
+interface WebSearchConfig {
+	braveApiKey?: unknown;
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+function normalizeApiKey(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function getApiKey(): string | null {
+	return normalizeApiKey(process.env.BRAVE_API_KEY) ?? normalizeApiKey(loadConfig().braveApiKey);
+}
+
+/** Returns true if a Brave API key is configured. */
+export function isBraveAvailable(): boolean {
+	return !!getApiKey();
+}
+
+export async function searchWithBrave(
+	query: string,
+	options: SearchOptions = {},
+): Promise<SearchResponse> {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		throw new Error(
+			"Brave Search API key not found. Either:\n" +
+			`  1. Create ${CONFIG_PATH} with { "braveApiKey": "your-key" }\n` +
+			"  2. Set BRAVE_API_KEY environment variable\n" +
+			"Get a key at https://brave.com/search/api/",
+		);
+	}
+
+	const activityId = activityMonitor.logStart({ type: "api", query });
+
+	const numResults = Math.min(options.numResults ?? 5, 20);
+	const params = new URLSearchParams({ q: query, count: String(numResults) });
+
+	if (options.recencyFilter) {
+		const freshnessMap: Record<string, string> = {
+			day: "pd",
+			week: "pw",
+			month: "pm",
+			year: "py",
+		};
+		const tf = freshnessMap[options.recencyFilter];
+		if (tf) params.set("freshness", tf);
+	}
+
+	try {
+		const response = await fetch(`${BRAVE_API_URL}?${params.toString()}`, {
+			method: "GET",
+			headers: {
+				"X-Subscription-Token": apiKey,
+				"Accept": "application/json",
+				"Accept-Encoding": "gzip",
+			},
+			signal: options.signal
+				? AbortSignal.any([AbortSignal.timeout(30000), options.signal])
+				: AbortSignal.timeout(30000),
+		});
+
+		if (!response.ok) {
+			activityMonitor.logError(activityId, `HTTP ${response.status}`);
+			const errorText = await response.text();
+			throw new Error(`Brave Search API error ${response.status}: ${errorText.slice(0, 300)}`);
+		}
+
+		const data = (await response.json()) as {
+			web?: { results?: Array<{ title?: string; url?: string; description?: string }> };
+		};
+		activityMonitor.logComplete(activityId, response.status);
+
+		const webResults = data.web?.results ?? [];
+		const results: SearchResult[] = [];
+		const inlineContent: ExtractedContent[] = [];
+
+		for (const item of webResults.slice(0, numResults)) {
+			if (!item.url) continue;
+			results.push({
+				title: item.title || item.url,
+				url: item.url,
+				snippet: item.description || "",
+			});
+			if (item.description && options.includeContent) {
+				inlineContent.push({
+					url: item.url,
+					title: item.title || item.url,
+					content: item.description,
+					error: null,
+				});
+			}
+		}
+
+		// Build an answer from snippets
+		const answer = results
+			.map((r) => {
+				if (r.snippet) return `${r.snippet}\nSource: ${r.title} (${r.url})`;
+				return `Source: ${r.title} (${r.url})`;
+			})
+			.join("\n\n");
+
+		const responseObj: SearchResponse = { answer, results };
+		if (inlineContent.length > 0) responseObj.inlineContent = inlineContent;
+		return responseObj;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		throw err;
+	}
+}

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -8,11 +8,13 @@ function safeInlineJSON(data: unknown): string {
 }
 
 function buildProviderButtons(
-	available: { perplexity: boolean; exa: boolean; gemini: boolean },
+	available: { openai: boolean; brave: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
 	selected: string,
 	hasInitialQueries: boolean,
 ): string {
 	const providers = [
+		{ value: "openai", label: "OpenAI", available: available.openai },
+		{ value: "brave", label: "Brave", available: available.brave },
 		{ value: "perplexity", label: "Perplexity", available: available.perplexity },
 		{ value: "exa", label: "Exa", available: available.exa },
 		{ value: "gemini", label: "Gemini", available: available.gemini },
@@ -34,7 +36,7 @@ export function generateCuratorPage(
 	queries: string[],
 	sessionToken: string,
 	timeout: number,
-	availableProviders: { perplexity: boolean; exa: boolean; gemini: boolean },
+	availableProviders: { openai: boolean; brave: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
 	defaultProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
 	defaultSummaryModel: string | null,
@@ -640,6 +642,16 @@ main {
   color: #f5c27b;
   background: rgba(245, 194, 123, 0.14);
   border-color: rgba(245, 194, 123, 0.3);
+}
+.provider-tag.provider-openai {
+  color: #a6e3a1;
+  background: rgba(166, 227, 161, 0.14);
+  border-color: rgba(166, 227, 161, 0.3);
+}
+.provider-tag.provider-brave {
+  color: #f38ba8;
+  background: rgba(243, 139, 168, 0.14);
+  border-color: rgba(243, 139, 168, 0.3);
 }
 .provider-tag.provider-unknown {
   color: var(--fg-muted);
@@ -1364,7 +1376,7 @@ const SCRIPT = `(function() {
   var token = DATA.sessionToken;
   var timeoutSec = DATA.timeout;
   var queries = Array.isArray(DATA.queries) ? DATA.queries : [];
-  var providers = ["perplexity", "exa", "gemini"];
+  var providers = ["openai", "brave", "perplexity", "exa", "gemini"];
   var availProviders = DATA.availableProviders && typeof DATA.availableProviders === "object" ? DATA.availableProviders : {};
   var workflow = "summary-review";
   var initialDefaultProvider = typeof DATA.defaultProvider === "string" ? DATA.defaultProvider : "exa";
@@ -1561,6 +1573,8 @@ const SCRIPT = `(function() {
   }
 
   function providerLabel(provider) {
+    if (provider === "openai") return "OpenAI";
+    if (provider === "brave") return "Brave";
     if (provider === "perplexity") return "Perplexity";
     if (provider === "exa") return "Exa";
     if (provider === "gemini") return "Gemini";

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -12,7 +12,7 @@ export interface CuratorServerOptions {
 	queries: string[];
 	sessionToken: string;
 	timeout: number;
-	availableProviders: { perplexity: boolean; exa: boolean; gemini: boolean };
+	availableProviders: { openai: boolean; brave: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
 	defaultProvider: string;
 	summaryModels: Array<{ value: string; label: string }>;
 	defaultSummaryModel: string | null;
@@ -226,6 +226,8 @@ export function startCuratorServer(
 	}
 
 	function isAvailableProvider(provider: string): boolean {
+		if (provider === "openai") return availableProviders.openai;
+		if (provider === "brave") return availableProviders.brave;
 		if (provider === "perplexity") return availableProviders.perplexity;
 		if (provider === "exa") return availableProviders.exa;
 		if (provider === "gemini") return availableProviders.gemini;

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -6,8 +6,10 @@ import { getApiKey, API_BASE, DEFAULT_MODEL } from "./gemini-api.js";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.js";
 import { isPerplexityAvailable, searchWithPerplexity, type SearchResult, type SearchResponse, type SearchOptions } from "./perplexity.js";
 import { hasExaApiKey, isExaAvailable, searchWithExa } from "./exa.js";
+import { isBraveAvailable, searchWithBrave } from "./brave.js";
+import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.js";
 
-export type SearchProvider = "auto" | "perplexity" | "gemini" | "exa";
+export type SearchProvider = "auto" | "openai" | "brave" | "perplexity" | "gemini" | "exa";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
 
 export interface AttributedSearchResponse extends SearchResponse {
@@ -57,14 +59,14 @@ function normalizeSearchModel(value: unknown): string | undefined {
 
 function normalizeSearchProvider(value: unknown): SearchProvider {
 	const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-	return normalized === "auto" || normalized === "perplexity" || normalized === "gemini" || normalized === "exa"
-		? normalized
-		: "auto";
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "perplexity", "gemini", "exa"];
+	return valid.includes(normalized as SearchProvider) ? (normalized as SearchProvider) : "auto";
 }
 
 export interface FullSearchOptions extends SearchOptions {
 	provider?: SearchProvider;
 	includeContent?: boolean;
+	openAIContext?: import("@mariozechner/pi-coding-agent").ExtensionContext;
 }
 
 function errorMessage(err: unknown): string {
@@ -109,6 +111,21 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	const config = getSearchConfig();
 	const provider = options.provider ?? config.searchProvider;
 
+	if (provider === "openai") {
+		if (!options.openAIContext) {
+			throw new Error(
+				"OpenAI web search requires an extension context for auth. This is a bug — report it.",
+			);
+		}
+		const result = await searchWithOpenAI(query, options.openAIContext, options);
+		return { ...result, provider: "openai" };
+	}
+
+	if (provider === "brave") {
+		const result = await searchWithBrave(query, options);
+		return { ...result, provider: "brave" };
+	}
+
 	if (provider === "perplexity") {
 		const result = await searchWithPerplexity(query, options);
 		return { ...result, provider: "perplexity" };
@@ -146,7 +163,21 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	// Auto mode: try providers in order of quality/cost
 	const fallbackErrors: string[] = [];
+
+	// OpenAI web_search (highest quality if auth is available — uses Codex subscription)
+	if (provider !== "openai" && options.openAIContext) {
+		try {
+			if (await isOpenAISearchAvailable(options.openAIContext)) {
+				const result = await searchWithOpenAI(query, options.openAIContext, options);
+				return { ...result, provider: "openai" };
+			}
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`OpenAI: ${errorMessage(err)}`);
+		}
+	}
 
 	if (provider !== "exa" && isExaAvailable()) {
 		try {
@@ -155,6 +186,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		} catch (err) {
 			if (isAbortError(err)) throw err;
 			fallbackErrors.push(`Exa: ${errorMessage(err)}`);
+		}
+	}
+
+	if (isBraveAvailable()) {
+		try {
+			const result = await searchWithBrave(query, options);
+			return { ...result, provider: "brave" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Brave: ${errorMessage(err)}`);
 		}
 	}
 
@@ -182,9 +223,9 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 
 	throw new Error(
 		"No search provider available. Either:\n" +
-		"  1. Set perplexityApiKey in ~/.pi/web-search.json\n" +
-		"  2. Set EXA_API_KEY (or exaApiKey) in ~/.pi/web-search.json\n" +
-		"  3. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
+		"  1. Use /login to sign in with a Codex subscription for OpenAI web search\n" +
+		"  2. Set braveApiKey, perplexityApiKey, exaApiKey, or geminiApiKey in ~/.pi/web-search.json\n" +
+		"  3. Set BRAVE_API_KEY, EXA_API_KEY, or GEMINI_API_KEY env vars\n" +
 		"  4. Sign into gemini.google.com in a supported Chromium-based browser"
 	);
 }

--- a/index.ts
+++ b/index.ts
@@ -38,6 +38,8 @@ import { isExaAvailable } from "./exa.js";
 import { isGeminiApiAvailable } from "./gemini-api.js";
 import { getActiveGoogleEmail, isGeminiWebAvailable } from "./gemini-web.js";
 import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
+import { isBraveAvailable } from "./brave.js";
+import { isOpenAISearchAvailable } from "./openai-search.js";
 
 const WEB_SEARCH_CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
 
@@ -53,6 +55,8 @@ interface WebSearchConfig {
 }
 
 interface ProviderAvailability {
+	openai: boolean;
+	brave: boolean;
 	perplexity: boolean;
 	exa: boolean;
 	gemini: boolean;
@@ -114,10 +118,8 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	if (normalized === "auto" || normalized === "exa" || normalized === "perplexity" || normalized === "gemini") {
-		return normalized;
-	}
-	return "auto";
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "exa", "perplexity", "gemini"];
+	return valid.includes(normalized as SearchProvider) ? (normalized as SearchProvider) : "auto";
 }
 
 function normalizeCuratorTimeoutSeconds(value: unknown): number | undefined {
@@ -148,17 +150,20 @@ function getCuratorTimeoutSeconds(): number {
 	return normalizeCuratorTimeoutSeconds(source.curatorTimeoutSeconds) ?? DEFAULT_CURATOR_TIMEOUT_SECONDS;
 }
 
-async function getProviderAvailability(): Promise<ProviderAvailability> {
+async function getProviderAvailability(ctx: import("@mariozechner/pi-coding-agent").ExtensionContext): Promise<ProviderAvailability> {
 	const geminiWebAvail = await isGeminiWebAvailable();
+	const openaiAvail = await isOpenAISearchAvailable(ctx);
 	return {
+		openai: openaiAvail,
+		brave: isBraveAvailable(),
 		perplexity: isPerplexityAvailable(),
 		exa: isExaAvailable(),
 		gemini: isGeminiApiAvailable() || !!geminiWebAvail,
 	};
 }
 
-async function loadCuratorBootstrap(requestedProvider: unknown): Promise<CuratorBootstrap> {
-	const availableProviders = await getProviderAvailability();
+async function loadCuratorBootstrap(requestedProvider: unknown, ctx: import("@mariozechner/pi-coding-agent").ExtensionContext): Promise<CuratorBootstrap> {
+	const availableProviders = await getProviderAvailability(ctx);
 	return {
 		availableProviders,
 		defaultProvider: resolveProvider(requestedProvider, availableProviders),
@@ -173,21 +178,38 @@ function resolveProvider(
 	const provider = normalizeProviderInput(requested ?? loadConfig().provider ?? "auto") ?? "auto";
 
 	if (provider === "auto") {
+		if (available.openai) return "openai";
 		if (available.exa) return "exa";
+		if (available.brave) return "brave";
 		if (available.perplexity) return "perplexity";
 		if (available.gemini) return "gemini";
 		return "exa";
 	}
+	if (provider === "openai" && !available.openai) {
+		if (available.exa) return "exa";
+		if (available.brave) return "brave";
+		return available.perplexity ? "perplexity" : available.gemini ? "gemini" : "openai";
+	}
 	if (provider === "exa" && !available.exa) {
-		if (available.perplexity) return "perplexity";
-		return available.gemini ? "gemini" : "exa";
+		if (available.openai) return "openai";
+		if (available.brave) return "brave";
+		return available.perplexity ? "perplexity" : available.gemini ? "gemini" : "exa";
+	}
+	if (provider === "brave" && !available.brave) {
+		if (available.openai) return "openai";
+		if (available.exa) return "exa";
+		return available.perplexity ? "perplexity" : available.gemini ? "gemini" : "brave";
 	}
 	if (provider === "perplexity" && !available.perplexity) {
+		if (available.openai) return "openai";
 		if (available.exa) return "exa";
+		if (available.brave) return "brave";
 		return available.gemini ? "gemini" : "perplexity";
 	}
 	if (provider === "gemini" && !available.gemini) {
+		if (available.openai) return "openai";
 		if (available.exa) return "exa";
+		if (available.brave) return "brave";
 		return available.perplexity ? "perplexity" : "gemini";
 	}
 	return provider;
@@ -964,6 +986,7 @@ export default function (pi: ExtensionAPI) {
 								domainFilter: pc.domainFilter,
 								includeContent: pc.includeContent,
 								signal: addSearchSignal,
+							openAIContext: ctx,
 							});
 							if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
 							pc.searchResults.set(queryIndex, { query, answer, results, error: null, provider: actualProvider });
@@ -1089,7 +1112,7 @@ export default function (pi: ExtensionAPI) {
 		name: "web_search",
 		label: "Web Search",
 		description:
-			`Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).`,
+			`Search the web using OpenAI, Brave, Exa, Perplexity, or Gemini. Returns an AI-synthesized answer with source citations. OpenAI web_search uses your existing Codex subscription or API key with no extra setup. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: OpenAI (if Codex/API key available), then Exa (direct API with key, MCP fallback without), then Brave (needs key), then Perplexity (needs key), then Gemini API (needs key), then Gemini Web (needs a supported Chromium-based browser login).`,
 		promptSnippet:
 			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
 		parameters: Type.Object({
@@ -1102,7 +1125,7 @@ export default function (pi: ExtensionAPI) {
 			),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
 			provider: Type.Optional(
-				StringEnum(["auto", "perplexity", "gemini", "exa"], { description: "Search provider (default: auto)" }),
+				StringEnum(["auto", "openai", "brave", "exa", "perplexity", "gemini"], { description: "Search provider (default: auto)" }),
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review"], {
@@ -1150,7 +1173,7 @@ export default function (pi: ExtensionAPI) {
 					: searchAbort.signal;
 				let cancelled = false;
 
-				const bootstrap = await loadCuratorBootstrap(params.provider);
+				const bootstrap = await loadCuratorBootstrap(params.provider, ctx);
 				const availableProviders = bootstrap.availableProviders;
 				const defaultProvider = bootstrap.defaultProvider;
 				const curatorTimeoutSeconds = bootstrap.timeoutSeconds;
@@ -1224,6 +1247,7 @@ export default function (pi: ExtensionAPI) {
 							domainFilter: params.domainFilter,
 							includeContent: params.includeContent,
 							signal: searchSignal,
+						openAIContext: ctx,
 						});
 						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
 						searchResults.set(qi, { query: queryList[qi], answer, results, error: null, provider });
@@ -1283,6 +1307,7 @@ export default function (pi: ExtensionAPI) {
 						domainFilter: params.domainFilter,
 						includeContent: params.includeContent,
 						signal,
+					openAIContext: ctx,
 					});
 
 					searchResults.push({ query, answer, results, error: null, provider });
@@ -1987,7 +2012,7 @@ export default function (pi: ExtensionAPI) {
 
 			let bootstrap: CuratorBootstrap;
 			try {
-				bootstrap = await loadCuratorBootstrap(undefined);
+				bootstrap = await loadCuratorBootstrap(undefined, ctx);
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				ctx.ui.notify(`Failed to load web search config: ${message}`, "error");
@@ -2113,6 +2138,7 @@ export default function (pi: ExtensionAPI) {
 								const { answer, results, provider: actualProvider } = await search(query, {
 									provider: requestedProvider,
 									signal: searchAbort.signal,
+								openAIContext: ctx,
 								});
 								if (commandHandle && activeCurator !== commandHandle) {
 									throw new Error("Curator session is no longer active.");
@@ -2172,6 +2198,7 @@ export default function (pi: ExtensionAPI) {
 								const { answer, results, provider } = await search(queries[qi], {
 									provider: requestedProvider,
 									signal: searchAbort.signal,
+								openAIContext: ctx,
 								});
 								if (aborted || activeCurator !== handle) break;
 								handle.pushResult(qi, {

--- a/openai-search.ts
+++ b/openai-search.ts
@@ -1,0 +1,230 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { activityMonitor } from "./activity.js";
+import type { ExtractedContent } from "./extract.js";
+import type { SearchOptions, SearchResponse, SearchResult } from "./perplexity.js";
+
+const SEARCH_TIMEOUT_MS = 60_000;
+
+/** Auth info obtained from pi's model registry. */
+interface OpenAIAuth {
+	provider: string;
+	apiKey: string;
+	model: string;
+}
+
+/**
+ * Resolves OpenAI auth from pi's modelRegistry.
+ * Tries: openai-codex (Codex OAuth subscription) → openai (API key) → OPENAI_API_KEY env var.
+ */
+export async function resolveOpenAIAuth(ctx: ExtensionContext): Promise<OpenAIAuth | undefined> {
+	const { getModel } = await import("@mariozechner/pi-ai");
+	for (const providerId of ["openai-codex", "openai"]) {
+		const modelId = providerId === "openai-codex" ? "gpt-5.2" : "gpt-4o";
+		try {
+			const m = getModel(providerId, modelId);
+			if (m) {
+				const key = await ctx.modelRegistry.getApiKey(m);
+				if (key) return { provider: providerId, apiKey: key, model: modelId };
+			}
+		} catch {
+			// Model not found or no key — try next
+		}
+	}
+
+	const envKey = process.env.OPENAI_API_KEY;
+	if (envKey) return { provider: "openai", apiKey: envKey, model: "gpt-4o" };
+	return undefined;
+}
+
+/** Check whether OpenAI web_search auth is available. */
+export async function isOpenAISearchAvailable(ctx: ExtensionContext): Promise<boolean> {
+	return !!(await resolveOpenAIAuth(ctx));
+}
+
+function isCodexJwt(token: string): boolean {
+	const parts = token.split(".");
+	if (parts.length !== 3) return false;
+	try {
+		return !!JSON.parse(Buffer.from(parts[1]!, "base64").toString("utf8"))?.[
+			"https://api.openai.com/auth"
+		];
+	} catch {
+		return false;
+	}
+}
+
+function extractAccountId(token: string): string | undefined {
+	try {
+		const parts = token.split(".");
+		if (parts.length !== 3) return undefined;
+		const id = JSON.parse(Buffer.from(parts[1]!, "base64").toString("utf8"))?.[
+			"https://api.openai.com/auth"
+		]?.chatgpt_account_id;
+		return typeof id === "string" && id.trim() ? id.trim() : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function parseSSEResponse(response: Response): Promise<any> {
+	const text = await response.text();
+	const trimmed = text.trim();
+	if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+		try {
+			return JSON.parse(trimmed);
+		} catch {
+			// Not valid JSON — try SSE
+		}
+	}
+	for (const line of text.split("\n")) {
+		if (!line.startsWith("data: ")) continue;
+		const data = line.slice(6).trim();
+		if (!data || data === "[DONE]") continue;
+		try {
+			const parsed = JSON.parse(data);
+			if (parsed.type === "response.done" || parsed.type === "response.completed")
+				return parsed.response ?? parsed;
+		} catch {
+			// Continue
+		}
+	}
+	throw new Error("Failed to parse OpenAI SSE response");
+}
+
+function extractSearchResults(responseObj: any): SearchResult[] {
+	const output = responseObj?.output;
+	if (!Array.isArray(output)) return [];
+
+	const results: SearchResult[] = [];
+	const seenUrls = new Set<string>();
+
+	// Extract from url_citation annotations
+	for (const item of output) {
+		if (item.type !== "message") continue;
+		for (const part of item.content ?? []) {
+			for (const ann of part.annotations ?? []) {
+				if (ann.type !== "url_citation" || !ann.url) continue;
+				const url = ann.url.replace(/\?utm_source=openai$/, "");
+				if (seenUrls.has(url)) continue;
+				seenUrls.add(url);
+				const snippet = extractSnippetAround(part.text ?? "", ann.start_index, ann.end_index);
+				results.push({ title: ann.title ?? url, url, snippet });
+			}
+		}
+	}
+
+	// Backfill from web_search_call sources
+	for (const item of output) {
+		if (item.type !== "web_search_call") continue;
+		for (const source of item.action?.sources ?? []) {
+			if (!source.url) continue;
+			const url = source.url.replace(/\?utm_source=openai$/, "");
+			if (seenUrls.has(url)) continue;
+			seenUrls.add(url);
+			results.push({ title: source.title ?? url, url, snippet: "" });
+		}
+	}
+
+	return results;
+}
+
+function extractSnippetAround(
+	text: string,
+	start?: number,
+	end?: number,
+): string {
+	if (start == null || end == null || !text) return "";
+	const before = Math.max(0, start - 100);
+	const after = Math.min(text.length, end + 100);
+	let snippet = text.slice(before, after).trim();
+	snippet = snippet.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1").trim();
+	if (snippet.length > 300) snippet = snippet.slice(0, 297) + "...";
+	return snippet;
+}
+
+/** Search using OpenAI's Responses API with the web_search tool. */
+export async function searchWithOpenAI(
+	query: string,
+	ctx: ExtensionContext,
+	options: SearchOptions = {},
+): Promise<SearchResponse> {
+	const auth = await resolveOpenAIAuth(ctx);
+	if (!auth) {
+		throw new Error(
+			"OpenAI web search unavailable. Either:\n" +
+			"  1. Use /login to sign in with a Codex subscription\n" +
+			"  2. Set OPENAI_API_KEY in ~/.pi/web-search.json or as an env var",
+		);
+	}
+
+	const activityId = activityMonitor.logStart({ type: "api", query });
+
+	const isOAuth = isCodexJwt(auth.apiKey);
+	const body = {
+		model: auth.model,
+		instructions: "Perform the web search. Return a brief summary mentioning each source.",
+		input: [{ role: "user", content: [{ type: "input_text", text: query }] }],
+		tools: [{ type: "web_search" }],
+		include: ["web_search_call.action.sources"],
+		store: false,
+		stream: true,
+		tool_choice: "auto" as const,
+		parallel_tool_calls: true,
+	};
+
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${auth.apiKey}`,
+		"Content-Type": "application/json",
+		"OpenAI-Beta": "responses=experimental",
+	};
+
+	let url: string;
+	if (isOAuth) {
+		url = "https://chatgpt.com/backend-api/codex/responses";
+		const accountId = extractAccountId(auth.apiKey);
+		if (accountId) headers["chatgpt-account-id"] = accountId;
+		headers["originator"] = "pi";
+	} else {
+		url = "https://api.openai.com/v1/responses";
+	}
+
+	try {
+		const response = await fetch(url, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+			signal: options.signal
+				? AbortSignal.any([AbortSignal.timeout(SEARCH_TIMEOUT_MS), options.signal])
+				: AbortSignal.timeout(SEARCH_TIMEOUT_MS),
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			activityMonitor.logError(activityId, `HTTP ${response.status}`);
+			throw new Error(`OpenAI API error ${response.status}: ${errorText.slice(0, 300)}`);
+		}
+
+		const responseObj = await parseSSEResponse(response);
+		activityMonitor.logComplete(activityId, 200);
+
+		const results = extractSearchResults(responseObj);
+
+		// Extract synthesized answer from message content
+		const answer = (responseObj.output ?? [])
+			.filter((item: any) => item.type === "message")
+			.flatMap((item: any) => item.content ?? [])
+			.filter((part: any) => part.type === "output_text")
+			.map((part: any) => part.text ?? "")
+			.join("\n");
+
+		return { answer: answer || "Search completed", results };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		throw err;
+	}
+}

--- a/openai-search.ts
+++ b/openai-search.ts
@@ -23,7 +23,8 @@ export async function resolveOpenAIAuth(ctx: ExtensionContext): Promise<OpenAIAu
 		try {
 			const m = getModel(providerId, modelId);
 			if (m) {
-				const key = await ctx.modelRegistry.getApiKey(m);
+				const auth = await ctx.modelRegistry.getApiKeyAndHeaders(m);
+				const key = auth?.apiKey;
 				if (key) return { provider: providerId, apiKey: key, model: modelId };
 			}
 		} catch {
@@ -76,18 +77,37 @@ async function parseSSEResponse(response: Response): Promise<any> {
 			// Not valid JSON — try SSE
 		}
 	}
+
+	const outputItems: any[] = [];
+	let completedResponse: any | null = null;
+
 	for (const line of text.split("\n")) {
 		if (!line.startsWith("data: ")) continue;
 		const data = line.slice(6).trim();
 		if (!data || data === "[DONE]") continue;
 		try {
 			const parsed = JSON.parse(data);
-			if (parsed.type === "response.done" || parsed.type === "response.completed")
-				return parsed.response ?? parsed;
+			if (parsed.type === "response.output_item.done" && parsed.item) {
+				outputItems.push(parsed.item);
+			}
+			if (parsed.type === "response.done" || parsed.type === "response.completed") {
+				completedResponse = parsed.response ?? parsed;
+			}
 		} catch {
 			// Continue
 		}
 	}
+
+	if (completedResponse) {
+		const output = Array.isArray(completedResponse.output) ? completedResponse.output : [];
+		if (output.length > 0) return completedResponse;
+		return { ...completedResponse, output: outputItems };
+	}
+
+	if (outputItems.length > 0) {
+		return { output: outputItems };
+	}
+
 	throw new Error("Failed to parse OpenAI SSE response");
 }
 

--- a/openai-search.ts
+++ b/openai-search.ts
@@ -10,6 +10,7 @@ interface OpenAIAuth {
 	provider: string;
 	apiKey: string;
 	model: string;
+	headers: Record<string, string>;
 }
 
 /**
@@ -23,9 +24,15 @@ export async function resolveOpenAIAuth(ctx: ExtensionContext): Promise<OpenAIAu
 		try {
 			const m = getModel(providerId, modelId);
 			if (m) {
-				const auth = await ctx.modelRegistry.getApiKeyAndHeaders(m);
-				const key = auth?.apiKey;
-				if (key) return { provider: providerId, apiKey: key, model: modelId };
+				const resolved = await ctx.modelRegistry.getApiKeyAndHeaders(m);
+				if (resolved?.ok && resolved.apiKey) {
+					return {
+						provider: providerId,
+						apiKey: resolved.apiKey,
+						model: modelId,
+						headers: resolved.headers ?? {},
+					};
+				}
 			}
 		} catch {
 			// Model not found or no key — try next
@@ -33,7 +40,7 @@ export async function resolveOpenAIAuth(ctx: ExtensionContext): Promise<OpenAIAu
 	}
 
 	const envKey = process.env.OPENAI_API_KEY;
-	if (envKey) return { provider: "openai", apiKey: envKey, model: "gpt-4o" };
+	if (envKey) return { provider: "openai", apiKey: envKey, model: "gpt-4o", headers: {} };
 	return undefined;
 }
 
@@ -180,9 +187,36 @@ export async function searchWithOpenAI(
 	const activityId = activityMonitor.logStart({ type: "api", query });
 
 	const isOAuth = isCodexJwt(auth.apiKey);
+
+	// OpenAI's web_search tool has no hard result-count or guaranteed domain enforcement
+	// (notably via the Codex backend), so requested filters are encoded as guidance in the
+	// instructions instead of being silently dropped. For strict domain filtering, pin Exa/Brave.
+	const constraints: string[] = [];
+	if (options.recencyFilter) {
+		const recencyLabel: Record<string, string> = {
+			day: "24 hours",
+			week: "week",
+			month: "month",
+			year: "year",
+		};
+		const label = recencyLabel[options.recencyFilter];
+		if (label) constraints.push(`published within the last ${label}`);
+	}
+	if (options.domainFilter && options.domainFilter.length > 0) {
+		const allowed = options.domainFilter.filter((d) => !d.startsWith("-"));
+		const excluded = options.domainFilter.filter((d) => d.startsWith("-")).map((d) => d.slice(1));
+		if (allowed.length) constraints.push(`only from: ${allowed.join(", ")}`);
+		if (excluded.length) constraints.push(`excluding: ${excluded.join(", ")}`);
+	}
+	if (options.numResults && options.numResults > 0) {
+		constraints.push(`prefer around ${options.numResults} sources`);
+	}
+	const constraintText = constraints.length ? ` Focus on results ${constraints.join("; ")}.` : "";
+	const instructions = `Perform the web search.${constraintText} Return a brief summary mentioning each source.`;
+
 	const body = {
 		model: auth.model,
-		instructions: "Perform the web search. Return a brief summary mentioning each source.",
+		instructions,
 		input: [{ role: "user", content: [{ type: "input_text", text: query }] }],
 		tools: [{ type: "web_search" }],
 		include: ["web_search_call.action.sources"],
@@ -192,7 +226,10 @@ export async function searchWithOpenAI(
 		parallel_tool_calls: true,
 	};
 
+	// Preserve model-registry auth headers (e.g. gateway/auth-proxy headers) alongside
+	// the resolved bearer token so auth works in environments that require per-request headers.
 	const headers: Record<string, string> = {
+		...auth.headers,
 		Authorization: `Bearer ${auth.apiKey}`,
 		"Content-Type": "application/json",
 		"OpenAI-Beta": "responses=experimental",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-access",
-  "version": "0.10.7",
-  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent",
+  "version": "0.11.0",
+  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Exa, Perplexity, and Gemini.",
   "type": "module",
   "scripts": {
     "test": "node --test"


### PR DESCRIPTION
## Summary

Adds two new search providers to pi-web-access:

### OpenAI web_search (server-side)

Uses the OpenAI Responses API `web_search` tool — the same mechanism Codex uses internally. Auth is resolved automatically from pi's model registry:

- **Codex subscription** (`openai-codex`): routes to `chatgpt.com/backend-api/codex/responses`
- **OpenAI API key**: routes to `api.openai.com/v1/responses`
- Falls back to `OPENAI_API_KEY` env var

Returns structured results from `url_citation` annotations and `web_search_call` sources. No extra API key needed if you already have `/login` with Codex.

### Brave Search

Simple REST API integration using the Brave Search Web Search API (`X-Subscription-Token` auth). Supports `numResults`, `recencyFilter` (day/week/month/year), and `includeContent`.

API key via `braveApiKey` in `~/.pi/web-search.json` or `BRAVE_API_KEY` env var.

### Auto-mode fallback chain

When `provider: "auto"` (default), the new order is:

> **OpenAI** → Exa → **Brave** → Perplexity → Gemini API → Gemini Web

OpenAI is first because it requires zero extra setup if you have a Codex subscription. Brave sits after Exa (Exa has MCP zero-config) and before Perplexity (which needs a paid key).

### Config

Both providers use `~/.pi/web-search.json`:

```json
{
  "braveApiKey": "BSA_...",
  "provider": "openai"
}
```

Or env vars: `BRAVE_API_KEY`, `OPENAI_API_KEY`.

### Files changed

| File | Change |
|------|--------|
| `openai-search.ts` | New — OpenAI Responses API search with Codex/API key auth |
| `brave.ts` | New — Brave Search Web Search API provider |
| `gemini-search.ts` | Updated — `SearchProvider` type, `search()` fallback chain, imports |
| `index.ts` | Updated — UI wiring, provider availability, `openAIContext` passthrough |
| `package.json` | Version bump to 0.11.0 |