### PR TITLE
fix: route code_search through Exa web search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `code_search` now uses Exa web search tuned for programming sources instead of the hosted MCP `get_code_context_exa` endpoint, which Exa no longer exposes by default on `https://mcp.exa.ai/mcp`. The tool still works without an API key via Exa MCP web search fallback and now labels its search mode more accurately in the UI.
+
 ## [0.10.6] - 2026-04-04
 
 ### Changed
@@ -22,7 +25,7 @@ All notable changes to this project will be documented in this file.
 - **Auto-open curator for all `web_search` runs (single + multi query).** Searches now open the curator window immediately and stream results live for review workflows; the old countdown/auto-condense fallback path was removed.
 - **Exa.ai search provider.** Neural/semantic search available alongside Perplexity and Gemini. 1,000 free requests/month. Set `EXA_API_KEY` env var or `exaApiKey` in `~/.pi/web-search.json`, or select explicitly with `provider: "exa"`. Includes built-in content extraction — when `includeContent` is true, full page text comes back with search results instead of requiring a separate background fetch. Monthly usage tracked in `~/.pi/exa-usage.json` with a warning at 80%.
 - **Exa MCP fallback.** When no Exa API key is configured, search routes through `mcp.exa.ai` with zero setup. Supports basic search and `includeContent` but not domain/recency filtering (falls through to Gemini for those).
-- **`code_search` tool.** Code/documentation search via Exa MCP (`get_code_context_exa`). No API key required. Returns code examples, docs, and API references from GitHub, Stack Overflow, and official documentation.
+- **`code_search` tool.** Initially shipped using Exa MCP `get_code_context_exa` for code/documentation search with no API key required. This was later replaced by Exa web search tuned for programming sources after Exa stopped exposing `get_code_context_exa` by default on the hosted MCP endpoint.
 - **Glimpse native curator window.** On macOS with Glimpse installed, the search curator opens in a native WKWebView window instead of a browser tab. Faster launch, closer integration. Falls back to browser automatically when Glimpse is unavailable.
 - **Curator provider UX rewrite.** Replaced the provider dropdown with provider buttons (hidden when unavailable), made provider re-search additive, added provider badges on all cards (including errors), and switched button states to coverage-based logic keyed by logical query slots so duplicate query text is handled correctly.
 - **Per-card provider re-search.** Completed result cards now show "Also try" chips for other available providers. Clicking one searches the same query with that provider and adds a new card below, keeping both results for comparison.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "summary-review" })
 
 ### code_search
 
-Search for code examples, documentation, and API references via Exa MCP. No API key required.
+Search for code examples, documentation, and API references via Exa search tuned for programming sources. Prefers official docs, GitHub, and Stack Overflow. No API key required — without a key it falls back to Exa MCP web search.
 
 ```typescript
 code_search({ query: "React useEffect cleanup pattern" })
@@ -327,7 +327,7 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Content f
 | `curator-server.ts` | Ephemeral HTTP server with SSE streaming and state machine |
 | `summary-review.ts` | Summary prompt construction, model-based draft generation, and deterministic fallback summary |
 | `exa.ts` | Exa.ai search provider — direct API and MCP proxy, budget tracking |
-| `code-search.ts` | Code/docs search via Exa MCP |
+| `code-search.ts` | Code/docs search via Exa search tuned for programming sources |
 | `extract.ts` | URL/file path routing, HTTP extraction, fallback orchestration |
 | `gemini-search.ts` | Search routing across Exa, Perplexity, Gemini API, Gemini Web |
 | `gemini-url-context.ts` | Gemini URL Context + Web extraction fallbacks |

--- a/code-search.ts
+++ b/code-search.ts
@@ -1,5 +1,61 @@
-import { activityMonitor } from "./activity.js";
-import { callExaMcp } from "./exa.js";
+import { hasExaApiKey, searchWithExa, searchWithExaMcp } from "./exa.js";
+
+const DEFAULT_MAX_TOKENS = 5000;
+const MIN_OUTPUT_CHARS = 4000;
+const MAX_OUTPUT_CHARS = 120000;
+
+function buildCodeSearchQuery(query: string): string {
+	return [
+		query,
+		"Prefer official documentation, GitHub repositories, Stack Overflow answers, and pages with concrete code examples.",
+		"Prioritize copyable snippets, API references, migration notes, and version-specific implementation details.",
+		"Ignore generic marketing pages unless they contain the clearest technical explanation.",
+	].join("\n");
+}
+
+function getNumResults(maxTokens: number): number {
+	if (maxTokens >= 20000) return 10;
+	if (maxTokens >= 10000) return 8;
+	return 6;
+}
+
+function getMaxOutputChars(maxTokens: number): number {
+	return Math.max(MIN_OUTPUT_CHARS, Math.min(MAX_OUTPUT_CHARS, maxTokens * 4));
+}
+
+function truncateText(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	const truncated = text.slice(0, Math.max(0, maxChars - 18)).trimEnd();
+	return `${truncated}\n\n[truncated ...]`;
+}
+
+function buildSourcesSection(results: Array<{ title: string; url: string }>): string {
+	if (results.length === 0) return "";
+	return [
+		"Sources:",
+		...results.map((result, index) => `${index + 1}. ${result.title} — ${result.url}`),
+	].join("\n");
+}
+
+function formatCodeSearchText(
+	answer: string,
+	results: Array<{ title: string; url: string }>,
+	maxTokens: number,
+): string {
+	const sections: string[] = [];
+	const trimmedAnswer = answer.trim();
+	if (trimmedAnswer) sections.push(trimmedAnswer);
+
+	const sourcesSection = buildSourcesSection(results.slice(0, 10));
+	if (sourcesSection) sections.push(sourcesSection);
+
+	const combined = sections.join("\n\n").trim();
+	if (!combined) {
+		return "No relevant code examples or documentation found. Try a more specific query with the library, framework, version, language, or exact API name.";
+	}
+
+	return truncateText(combined, getMaxOutputChars(maxTokens));
+}
 
 export async function executeCodeSearch(
 	_toolCallId: string,
@@ -7,43 +63,47 @@ export async function executeCodeSearch(
 	signal?: AbortSignal,
 ): Promise<{
 	content: Array<{ type: "text"; text: string }>;
-	details: { query: string; maxTokens: number; error?: string };
+	details: { query: string; maxTokens: number; error?: string; searchMode?: string };
 }> {
 	const query = params.query.trim();
 	if (!query) {
 		return {
 			content: [{ type: "text", text: "Error: No query provided." }],
-			details: { query: "", maxTokens: params.maxTokens ?? 5000, error: "No query provided" },
+			details: { query: "", maxTokens: params.maxTokens ?? DEFAULT_MAX_TOKENS, error: "No query provided" },
 		};
 	}
 
-	const maxTokens = params.maxTokens ?? 5000;
-	const activityId = activityMonitor.logStart({ type: "api", query });
+	const maxTokens = params.maxTokens ?? DEFAULT_MAX_TOKENS;
+	const numResults = getNumResults(maxTokens);
+	const searchQuery = buildCodeSearchQuery(query);
+	const usesApiKey = hasExaApiKey();
 
 	try {
-		const text = await callExaMcp(
-			"get_code_context_exa",
-			{
-				query,
-				tokensNum: maxTokens,
-			},
-			signal,
-		);
-		activityMonitor.logComplete(activityId, 200);
+		const result = await searchWithExa(searchQuery, { numResults, signal });
+		const fallbackToMcp = !!(result && "exhausted" in result);
+		const resolvedSearch = fallbackToMcp
+			? await searchWithExaMcp(searchQuery, { numResults, signal })
+			: result;
+		const resolved = resolvedSearch && !("exhausted" in resolvedSearch) ? resolvedSearch : null;
+		const searchMode = !usesApiKey || fallbackToMcp ? "exa-web-search-mcp" : "exa-web-search-api";
+
+		const text = formatCodeSearchText(resolved?.answer ?? "", resolved?.results ?? [], maxTokens);
 		return {
 			content: [{ type: "text", text }],
-			details: { query, maxTokens },
+			details: {
+				query,
+				maxTokens,
+				searchMode,
+			},
 		};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		if (message.toLowerCase().includes("abort")) {
-			activityMonitor.logComplete(activityId, 0);
 			throw err;
 		}
-		activityMonitor.logError(activityId, message);
 		return {
 			content: [{ type: "text", text: `Error: ${message}` }],
-			details: { query, maxTokens, error: message },
+			details: { query, maxTokens, error: message, searchMode: usesApiKey ? "exa-web-search-api" : "exa-web-search-mcp" },
 		};
 	}
 }

--- a/exa.ts
+++ b/exa.ts
@@ -366,7 +366,7 @@ function buildMcpQuery(query: string, options: ExaSearchOptions): string {
 	return parts.join(" ");
 }
 
-async function searchWithExaMcp(query: string, options: ExaSearchOptions = {}): Promise<SearchResponse | null> {
+export async function searchWithExaMcp(query: string, options: ExaSearchOptions = {}): Promise<SearchResponse | null> {
 	const enrichedQuery = buildMcpQuery(query, options);
 	const activityId = activityMonitor.logStart({ type: "api", query: enrichedQuery });
 

--- a/index.ts
+++ b/index.ts
@@ -1521,9 +1521,9 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "code_search",
 		label: "Code Search",
-		description: "Search for code examples, documentation, and API references. Returns relevant code snippets and docs from GitHub, Stack Overflow, and official documentation. Use for any programming question — API usage, library examples, debugging help.",
+		description: "Search for code examples, documentation, and API references. Uses Exa search tuned for programming sources and prefers official docs, GitHub, and Stack Overflow. Use for any programming question — API usage, library examples, debugging help.",
 		promptSnippet:
-			"Use for programming/API/library questions to retrieve concrete examples and docs before implementing or debugging code.",
+			"Use for programming/API/library questions to retrieve concrete examples and docs via Exa search tuned for code sources before implementing or debugging code.",
 		parameters: Type.Object({
 			query: Type.String({ description: "Programming question, API, library, or debugging topic to search for" }),
 			maxTokens: Type.Optional(Type.Integer({
@@ -1546,13 +1546,16 @@ export default function (pi: ExtensionAPI) {
 		},
 
 		renderResult(result, { expanded }, theme) {
-			const details = result.details as { query?: string; maxTokens?: number; error?: string };
+			const details = result.details as { query?: string; maxTokens?: number; error?: string; searchMode?: string };
 			if (details?.error) {
 				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
 			}
 
-			const summary = theme.fg("success", "code context returned") +
-				theme.fg("muted", ` (${details?.maxTokens ?? 5000} tokens max)`);
+			const modeLabel = details?.searchMode === "exa-web-search-mcp"
+				? "Exa MCP web search"
+				: "Exa web search API";
+			const summary = theme.fg("success", "code search results returned") +
+				theme.fg("muted", ` (${details?.maxTokens ?? 5000} tokens max · ${modeLabel})`);
 			if (!expanded) return new Text(summary, 0, 0);
 
 			const textContent = result.content.find((c) => c.type === "text")?.text || "";


### PR DESCRIPTION
## Summary
- replace the hosted MCP `get_code_context_exa` dependency in `code_search` with Exa web search tuned for programming sources
- keep no-key behavior by falling back to Exa MCP web search
- update UI/README/changelog text to match the actual hosted Exa MCP behavior

## Why
`code_search` currently calls `get_code_context_exa` directly, but the hosted `https://mcp.exa.ai/mcp` endpoint no longer exposes that tool by default. That makes `code_search` fail with:

```text
MCP error -32602: Tool get_code_context_exa not found
```

Exa also documents/recommends `web_search_exa` for current hosted usage, and their issue tracker confirms the default hosted tools changed:
- exa-labs/exa-mcp-server#275

## Notes
- `code_search` still prefers official docs, GitHub, and Stack Overflow by enriching the query for programming-oriented results
- the result UI now labels whether the answer came from Exa API search or Exa MCP web search

## Verification
- `npm pack --dry-run`
- smoke-tested `executeCodeSearch()` with an Exa API key configured (`searchMode: exa-web-search-api`)
- smoke-tested `executeCodeSearch()` with no Exa API key configured (`searchMode: exa-web-search-mcp`)
