### PR TITLE
fix(pdf): suppress noisy PDF.js warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Reduced noisy PDF.js warning spam during PDF fetches by running PDF extraction with errors-only PDF.js verbosity.
+
 ## [0.10.6] - 2026-04-04
 
 ### Changed

--- a/pdf-extract.ts
+++ b/pdf-extract.ts
@@ -5,7 +5,7 @@
  * Uses unpdf (pdfjs-dist wrapper) for text extraction.
  */
 
-import { getDocumentProxy } from "unpdf";
+import { getDocumentProxy, VerbosityLevel } from "unpdf";
 import { writeFile, mkdir } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { homedir } from "node:os";
@@ -44,7 +44,7 @@ export async function extractPDFToMarkdown(
     ? Math.max(1, Math.floor(maxPages))
     : DEFAULT_MAX_PAGES;
 
-  const pdf = await getDocumentProxy(new Uint8Array(buffer));
+  const pdf = await getDocumentProxy(new Uint8Array(buffer), { verbosity: VerbosityLevel.ERRORS });
   const metadata = await pdf.getMetadata();
   const metadataInfo = metadata.info && typeof metadata.info === "object"
     ? metadata.info as Record<string, unknown>


### PR DESCRIPTION
Hi, I keep seeing this during PDF fetches in Pi:

![warning spam screenshot](https://files.catbox.moe/w6lzqh.png)

The fetch still seems to continue, but the repeated PDF.js warnings spill directly into Pi's interactive UI and make it look broken.

## Proposed fix

Run the PDF extraction path with errors-only PDF.js verbosity:

- import `VerbosityLevel` from `unpdf`
- call `getDocumentProxy(..., { verbosity: VerbosityLevel.ERRORS })`

That should keep real PDF failures visible while suppressing warning spam like:

```text
Warning: CCITTFaxStream: Falling back to JS CCITTFax decoder.
```