### PR TITLE
chore: fix npm audit vulnerability (@mozilla/readability)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "pi-web-access",
-  "version": "0.7.2",
+  "version": "0.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-web-access",
-      "version": "0.7.2",
+      "version": "0.10.6",
+      "license": "MIT",
       "dependencies": {
-        "@mozilla/readability": "^0.5.0",
+        "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
         "p-limit": "^6.1.0",
         "turndown": "^7.2.0",
@@ -22,9 +23,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mozilla/readability": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.5.0.tgz",
-      "integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/nicobailon/pi-web-access#readme",
   "dependencies": {
-    "@mozilla/readability": "^0.5.0",
+    "@mozilla/readability": "^0.6.0",
     "linkedom": "^0.16.0",
     "p-limit": "^6.1.0",
     "turndown": "^7.2.0",


### PR DESCRIPTION
Updates `@mozilla/readability` from `^0.5.0` to `^0.6.0` to fix 1 low-severity DoS vulnerability ([GHSA-3p6v-hrg8-8qj7](https://github.com/advisories/GHSA-3p6v-hrg8-8qj7)).

0.6.0 is a semver major bump but the public API (`new Readability(doc).parse()`) is unchanged. The [0.6.0 changes](https://github.com/mozilla/readability/blob/main/CHANGELOG.md#060---2025-03-03) are additive: better metadata extraction, performance improvements, and bug fixes.