### PR TITLE
fix: make browser cookie access opt-in to prevent macOS Keychain popups

### DIFF
--- a/gemini-web.ts
+++ b/gemini-web.ts
@@ -22,10 +22,11 @@ const MODEL_HEADERS: Record<string, string> = {
 };
 
 const REQUIRED_COOKIES = ["__Secure-1PSID", "__Secure-1PSIDTS"];
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const CONFIG_PATH = process.env.FEYNMAN_WEB_SEARCH_CONFIG ?? process.env.PI_WEB_SEARCH_CONFIG ?? join(homedir(), ".pi", "web-search.json");
 
 interface GeminiWebConfig {
 	chromeProfile?: string;
+	allowBrowserCookies?: boolean;
 }
 
 let cachedConfig: GeminiWebConfig | null = null;
@@ -46,9 +47,9 @@ function loadConfig(): GeminiWebConfig {
 	}
 
 	const rawText = readFileSync(CONFIG_PATH, "utf-8");
-	let raw: { chromeProfile?: unknown };
+	let raw: { chromeProfile?: unknown; allowBrowserCookies?: unknown };
 	try {
-		raw = JSON.parse(rawText) as { chromeProfile?: unknown };
+		raw = JSON.parse(rawText) as { chromeProfile?: unknown; allowBrowserCookies?: unknown };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
@@ -56,6 +57,7 @@ function loadConfig(): GeminiWebConfig {
 
 	cachedConfig = {
 		chromeProfile: normalizeChromeProfile(raw.chromeProfile),
+		allowBrowserCookies: raw.allowBrowserCookies === true,
 	};
 	return cachedConfig;
 }
@@ -70,7 +72,16 @@ function getChromeProfileFromConfig(): string | undefined {
 	return loadConfig().chromeProfile;
 }
 
+function isBrowserCookieAccessAllowed(): boolean {
+	if (process.env.FEYNMAN_ALLOW_BROWSER_COOKIES === "1" || process.env.PI_ALLOW_BROWSER_COOKIES === "1") {
+		return true;
+	}
+	return loadConfig().allowBrowserCookies === true;
+}
+
 export async function isGeminiWebAvailable(chromeProfile?: string): Promise<CookieMap | null> {
+	if (!isBrowserCookieAccessAllowed()) return null;
+
 	const result = await getGoogleCookies({
 		profile: normalizeChromeProfile(chromeProfile) ?? getChromeProfileFromConfig(),
 		requiredCookies: REQUIRED_COOKIES,


### PR DESCRIPTION
## Problem

On macOS, `isGeminiWebAvailable()` calls `getGoogleCookies()` which runs `security find-generic-password -w -a Chrome -s "Chrome Safe Storage"`. This triggers a **macOS Keychain Access popup** asking the user to grant access to Chrome stored credentials.

This happens:
1. On every session startup — `getProviderAvailability()` in `index.ts:150` calls `isGeminiWebAvailable()`
2. On every `fetch_content` fallback — `extract.ts:426` calls `extractWithGeminiWeb()`

Users see a system dialog that looks like the tool is trying to access their saved passwords. This erodes trust even when the intent is just to check if Gemini Web authentication is available.

## Fix

`isGeminiWebAvailable()` now checks an opt-in flag before attempting any Keychain access. If the flag is not set, it returns `null` immediately — no Keychain access, no popup.

Users opt in via either:

**Config file** (`~/.pi/web-search.json`):
```json
{
  "allowBrowserCookies": true
}
```

**Environment variable**:
```bash
FEYNMAN_ALLOW_BROWSER_COOKIES=1
# or
PI_ALLOW_BROWSER_COOKIES=1
```

## Changes

**`gemini-web.ts`**:
- Added `allowBrowserCookies` to config interface and parser
- Added `isBrowserCookieAccessAllowed()` helper that checks config + env vars
- `isGeminiWebAvailable()` returns `null` immediately when not allowed

## Impact

- **Default behavior changes**: Gemini Web fallback is now disabled by default. Users who relied on it (signed into gemini.google.com in Chrome, no API key) will need to add `"allowBrowserCookies": true` to their config.
- **No impact** on users with API keys configured (Exa, Perplexity, Gemini API) — those paths never touch Keychain.
- The corresponding config-layer change in the feynman repo is at getcompanion-ai/feynman#141.