### PR TITLE
Prefer active Gemini account markers in `/google-account`

### DIFF
--- a/gemini-web.ts
+++ b/gemini-web.ts
@@ -245,10 +245,15 @@ async function fetchWithCookieRedirects(
 
 function extractEmailFromGeminiHtml(html: string): string | null {
 	const patterns = [
-		/"email"\s*:\s*"([^"]+)"/,
+		// Gemini bootstraps the active account in oPEP7c. Prefer it over generic
+		// feature/config entries that may contain other signed-in Google accounts.
+		/"oPEP7c"\s*:\s*"([^"]+)"/,
+		// The Google account menu aria-label is rendered for the active account.
+		/aria-label="Google Account:[^"]*?\(([^)]+)\)"/,
 		/"displayEmail"\s*:\s*"([^"]+)"/,
-		/"identifier"\s*:\s*"([^"]+)"/,
 		/"defaultEmail"\s*:\s*"([^"]+)"/,
+		/"email"\s*:\s*"([^"]+)"/,
+		/"identifier"\s*:\s*"([^"]+)"/,
 		/"gaiaIdentifier"\s*:\s*"([^"]+)"/,
 	];
 


### PR DESCRIPTION
Fixes #39.

This updates `/google-account` so Gemini Web account detection prefers active-account markers before generic email matches.

Changed matching order:
1. Gemini bootstrap `oPEP7c`
2. Google Account menu `aria-label`
3. Existing generic email fields and first-email fallback

Why: Gemini Web HTML can include multiple account-related email strings, so first-email matching can select a non-active account.

Validation, with emails redacted:

```text
Default: <active-account>
Profile 1: <other-account>
```
