### PR TITLE
feat: add configurable default summary model via web-search.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ All config lives in `~/.pi/web-search.json`. Every field is optional.
   "provider": "exa",
   "chromeProfile": "Profile 2",
   "searchModel": "gemini-2.5-flash",
+  "summaryModel": "anthropic/claude-haiku-4-5",
   "workflow": "summary-review",
   "curatorTimeoutSeconds": 20,
   "githubClone": {
@@ -287,7 +288,7 @@ All config lives in `~/.pi/web-search.json`. Every field is optional.
 }
 ```
 
-`EXA_API_KEY`, `GEMINI_API_KEY`, and `PERPLEXITY_API_KEY` env vars take precedence over config file values. `provider` sets the default search provider: `"exa"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. `workflow` sets the default curator mode: `"summary-review"` (default, opens curator with auto-generated summary draft) or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI.
+`EXA_API_KEY`, `GEMINI_API_KEY`, and `PERPLEXITY_API_KEY` env vars take precedence over config file values. `provider` sets the default search provider: `"exa"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. `workflow` sets the default curator mode: `"summary-review"` (default, opens curator with auto-generated summary draft) or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI (e.g. `"anthropic/claude-haiku-4-5"` or `"openai-codex/gpt-5.3-codex-spark"`). Only models available in your model registry are eligible; if the configured model is unavailable, the default falls back to the built-in preference list. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI.
 
 ### Shortcuts
 

--- a/index.ts
+++ b/index.ts
@@ -44,6 +44,7 @@ interface WebSearchConfig {
 	provider?: string;
 	workflow?: string;
 	curatorTimeoutSeconds?: unknown;
+	summaryModel?: string;
 	shortcuts?: {
 		curate?: string;
 		activity?: string;
@@ -681,15 +682,23 @@ export default function (pi: ExtensionAPI) {
 			addModel(summaryContext.model.provider, summaryContext.model.id);
 		}
 
+		const config = loadConfig();
+		const configuredSummaryModel = typeof config.summaryModel === "string" ? config.summaryModel.trim() : "";
 		const preferredDefaults = [
 			"anthropic/claude-haiku-4-5",
 			"openai-codex/gpt-5.3-codex-spark",
 		];
+
 		let defaultSummaryModel: string | null = null;
-		for (const preferred of preferredDefaults) {
-			if (availableValues.has(preferred)) {
-				defaultSummaryModel = preferred;
-				break;
+		if (configuredSummaryModel.length > 0 && availableValues.has(configuredSummaryModel)) {
+			defaultSummaryModel = configuredSummaryModel;
+		}
+		if (!defaultSummaryModel) {
+			for (const preferred of preferredDefaults) {
+				if (availableValues.has(preferred)) {
+					defaultSummaryModel = preferred;
+					break;
+				}
 			}
 		}
 		if (!defaultSummaryModel && summaryModels.length > 0) {


### PR DESCRIPTION
Adds a new "summaryModel" config option to ~/.pi/web-search.json that lets users override the default model used for curator summary draft generation.

- summaryModel takes priority over the built-in preferred defaults (anthropic/claude-haiku-4-5, openai-codex/gpt-5.3-codex-spark)
- Only models available in the model registry are eligible; falls back to built-in preferences if the configured model is unavailable
- Updated README.md with config example and documentation

Example usage in ~/.pi/web-search.json:
  { "summaryModel": "anthropic/claude-sonnet-4" }