### PR TITLE
Fix code_search for Exa MCP default tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Updated `code_search` to use Exa MCP's default `web_search_exa` tool instead of the deprecated `get_code_context_exa` tool, fixing hosted Exa MCP `Tool get_code_context_exa not found` errors.
+
 ## [0.10.6] - 2026-04-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "summary-review" })
 
 ### code_search
 
-Search for code examples, documentation, and API references via Exa MCP. No API key required.
+Search for code examples, documentation, and API references via Exa MCP. No API key required. Uses Exa MCP's default `web_search_exa` tool with code-focused queries.
 
 ```typescript
 code_search({ query: "React useEffect cleanup pattern" })

--- a/code-search.ts
+++ b/code-search.ts
@@ -21,11 +21,12 @@ export async function executeCodeSearch(
 	const activityId = activityMonitor.logStart({ type: "api", query });
 
 	try {
+		const numResults = Math.max(1, Math.min(20, Math.ceil(maxTokens / 625)));
 		const text = await callExaMcp(
-			"get_code_context_exa",
+			"web_search_exa",
 			{
-				query,
-				tokensNum: maxTokens,
+				query: `code examples documentation API reference ${query}`,
+				numResults,
 			},
 			signal,
 		);


### PR DESCRIPTION
## Summary
- switch `code_search` from deprecated `get_code_context_exa` to Exa MCP's default `web_search_exa` tool
- add code-focused query terms and map `maxTokens` to a bounded `numResults` value
- update README and changelog to reflect the current Exa MCP tool behavior

## Why
The hosted Exa MCP endpoint no longer exposes `get_code_context_exa` by default. Exa confirmed in issue discussion that `web_search_exa` is the recommended tool even for code use cases.

Fixes #24.

## Verification
- `npx -y tsx -e 'import { executeCodeSearch } from "./code-search.ts"; (async()=>{ const r=await executeCodeSearch("test", {query:"WezTerm inline images tmux allow-passthrough kitty graphics protocol", maxTokens:1000}); console.log(JSON.stringify(r.details)); console.log(r.content[0].text.slice(0,800)); })();'`\n