### PR TITLE
Fix code_search after Exa MCP tool removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Restored `code_search` after Exa removed the `get_code_context_exa` MCP tool by falling back to `web_search_exa` with a code/documentation-focused query.
+
 ## [0.10.6] - 2026-04-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "summary-review" })
 
 ### code_search
 
-Search for code examples, documentation, and API references via Exa MCP. No API key required.
+Search for code examples, documentation, and API references via Exa MCP. No API key required. Uses Exa's code-context MCP tool when available and falls back to a code/documentation-focused web search when that tool is unavailable.
 
 ```typescript
 code_search({ query: "React useEffect cleanup pattern" })

--- a/code-search.ts
+++ b/code-search.ts
@@ -1,38 +1,94 @@
 import { activityMonitor } from "./activity.js";
 import { callExaMcp } from "./exa.js";
 
+const CODE_CONTEXT_TOOL = "get_code_context_exa";
+const WEB_SEARCH_TOOL = "web_search_exa";
+const DEFAULT_MAX_TOKENS = 5000;
+
+let codeContextToolMissing = false;
+
+function isMissingMcpToolError(message: string): boolean {
+	const normalized = message.toLowerCase();
+	return normalized.includes("tool") && normalized.includes("not found");
+}
+
+function buildFallbackQuery(query: string): string {
+	const normalized = query.toLowerCase();
+	const hasCodeSearchTerms = /\b(api|code|docs?|documentation|example|github|implementation|library|source|stackoverflow|stack overflow)\b/
+		.test(normalized);
+	return hasCodeSearchTerms ? query : `${query} code examples documentation GitHub Stack Overflow official docs`;
+}
+
+function maxTokensToResultCount(maxTokens: number): number {
+	return Math.min(20, Math.max(5, Math.ceil(maxTokens / 1000)));
+}
+
+function trimApproxTokens(text: string, maxTokens: number): string {
+	const maxCharacters = Math.max(1000, maxTokens * 4);
+	if (text.length <= maxCharacters) return text;
+	return `${text.slice(0, maxCharacters).trimEnd()}\n\n[Truncated by code_search to approximately ${maxTokens} tokens.]`;
+}
+
+async function executeFallbackSearch(query: string, maxTokens: number, signal?: AbortSignal): Promise<string> {
+	const text = await callExaMcp(
+		WEB_SEARCH_TOOL,
+		{
+			query: buildFallbackQuery(query),
+			numResults: maxTokensToResultCount(maxTokens),
+		},
+		signal,
+	);
+	return trimApproxTokens(text, maxTokens);
+}
+
 export async function executeCodeSearch(
 	_toolCallId: string,
 	params: { query: string; maxTokens?: number },
 	signal?: AbortSignal,
 ): Promise<{
 	content: Array<{ type: "text"; text: string }>;
-	details: { query: string; maxTokens: number; error?: string };
+	details: { query: string; maxTokens: number; error?: string; mode?: "code-context" | "web-search-fallback" };
 }> {
 	const query = params.query.trim();
 	if (!query) {
 		return {
 			content: [{ type: "text", text: "Error: No query provided." }],
-			details: { query: "", maxTokens: params.maxTokens ?? 5000, error: "No query provided" },
+			details: { query: "", maxTokens: params.maxTokens ?? DEFAULT_MAX_TOKENS, error: "No query provided" },
 		};
 	}
 
-	const maxTokens = params.maxTokens ?? 5000;
+	const maxTokens = params.maxTokens ?? DEFAULT_MAX_TOKENS;
 	const activityId = activityMonitor.logStart({ type: "api", query });
 
 	try {
-		const text = await callExaMcp(
-			"get_code_context_exa",
-			{
-				query,
-				tokensNum: maxTokens,
-			},
-			signal,
-		);
+		let mode: "code-context" | "web-search-fallback" = "web-search-fallback";
+		let text: string;
+
+		if (codeContextToolMissing) {
+			text = await executeFallbackSearch(query, maxTokens, signal);
+		} else {
+			try {
+				text = await callExaMcp(
+					CODE_CONTEXT_TOOL,
+					{
+						query,
+						tokensNum: maxTokens,
+					},
+					signal,
+				);
+				mode = "code-context";
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				if (!isMissingMcpToolError(message)) throw err;
+				codeContextToolMissing = true;
+				text = await executeFallbackSearch(query, maxTokens, signal);
+			}
+		}
+
 		activityMonitor.logComplete(activityId, 200);
 		return {
 			content: [{ type: "text", text }],
-			details: { query, maxTokens },
+			details: { query, maxTokens, mode },
 		};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Problem

`code_search` is broken against the current Exa MCP server. The package still calls `get_code_context_exa`, but that tool is no longer advertised by Exa. Right now the server only returns `web_search_exa` and `web_fetch_exa`, so every `code_search` call fails with:

```text
MCP error -32602: Tool get_code_context_exa not found
```

That means Pi users lose code/docs search unless they avoid this tool entirely.

## Fix

This keeps the old path when it works, but handles the removed tool cleanly:

- try `get_code_context_exa` first for backwards compatibility
- if Exa says the tool is missing, cache that and use `web_search_exa` instead
- shape fallback queries toward code, docs, GitHub, Stack Overflow, and official references when the user query does not already do that
- trim the returned text to the requested `maxTokens` budget
- document the fallback in the README and changelog

It is not a perfect replacement for Exa's old code-context tool, but it is much better than returning a hard error. In practice it restores useful code and documentation results with the MCP tools Exa exposes today.

## Verification

- `bun build code-search.ts --target node --outdir /tmp/pi-web-access-check`
- live `executeCodeSearch()` call against the current Exa MCP server returned results with `mode: "web-search-fallback"`

Example query tested:

```text
Evolution API instance connect QR code webhook Baileys GitHub implementation
```
