### PR TITLE
fix(pdf): support Node 22 extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "pi-web-access",
-  "version": "0.7.2",
+  "version": "0.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-web-access",
-      "version": "0.7.2",
+      "version": "0.10.6",
+      "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.5.0",
         "linkedom": "^0.16.0",
         "p-limit": "^6.1.0",
         "turndown": "^7.2.0",
-        "unpdf": "^1.4.0"
+        "unpdf": "^1.6.2"
       }
     },
     "node_modules/@mixmark-io/domino": {
@@ -218,9 +219,9 @@
       "license": "ISC"
     },
     "node_modules/unpdf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.4.0.tgz",
-      "integrity": "sha512-TahIk0xdH/4jh/MxfclzU79g40OyxtP00VnEUZdEkJoYtXAHWLiir6t3FC6z3vDqQTzc2ZHcla6uEiVTNjejuA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
+      "integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
       "license": "MIT",
       "peerDependencies": {
         "@napi-rs/canvas": "^0.1.69"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.10.6",
   "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent",
   "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
   "keywords": [
     "pi-package",
     "pi",
@@ -28,7 +31,7 @@
     "linkedom": "^0.16.0",
     "p-limit": "^6.1.0",
     "turndown": "^7.2.0",
-    "unpdf": "^1.4.0"
+    "unpdf": "^1.6.2"
   },
   "pi": {
     "extensions": [

--- a/test/pdf-extract.test.mjs
+++ b/test/pdf-extract.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const extractorUrl = new URL("../pdf-extract.ts", import.meta.url).href;
+
+test("extractPDFToMarkdown works on Node 22 without native Promise.try", () => {
+  const child = spawnSync(process.execPath, ["--input-type=module"], {
+    input: buildChildScript(extractorUrl),
+    encoding: "utf8",
+    maxBuffer: 2 * 1024 * 1024,
+  });
+
+  assert.equal(
+    child.status,
+    0,
+    "PDF extraction failed in a child process. stderr summary:\n" + errorSummary(child.stderr),
+  );
+
+  assert.match(child.stdout, /Hello PDF/);
+});
+
+function buildChildScript(moduleUrl) {
+  return `
+    import { mkdtemp, readFile } from "node:fs/promises";
+    import { tmpdir } from "node:os";
+    import { join } from "node:path";
+
+    process.on("uncaughtException", (error) => {
+      console.error(error?.stack || error);
+      process.exit(1);
+    });
+    process.on("unhandledRejection", (error) => {
+      console.error(error?.stack || error);
+      process.exit(1);
+    });
+
+    Reflect.deleteProperty(Promise, "try");
+    if (typeof Promise.try !== "undefined") {
+      throw new Error("Expected Promise.try to be unavailable before PDF extraction");
+    }
+
+    const { extractPDFToMarkdown } = await import(${JSON.stringify(moduleUrl)});
+
+    const outputDir = await mkdtemp(join(tmpdir(), "pi-web-access-pdf-"));
+    const result = await extractPDFToMarkdown(
+      makePdf("Hello PDF"),
+      "https://example.test/hello.pdf",
+      { outputDir },
+    );
+
+    console.log(await readFile(result.outputPath, "utf8"));
+
+    function makePdf(text) {
+      const content = "BT /F1 24 Tf 72 720 Td (" + text + ") Tj ET";
+      const objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        "<< /Length " + Buffer.byteLength(content, "ascii") + " >>\\nstream\\n" + content + "\\nendstream",
+      ];
+      let body = "%PDF-1.4\\n";
+      const offsets = [0];
+
+      for (let index = 0; index < objects.length; index += 1) {
+        offsets.push(Buffer.byteLength(body, "ascii"));
+        body += String(index + 1) + " 0 obj\\n" + objects[index] + "\\nendobj\\n";
+      }
+
+      const xrefOffset = Buffer.byteLength(body, "ascii");
+      body += "xref\\n0 " + String(objects.length + 1) + "\\n";
+      body += "0000000000 65535 f \\n";
+
+      for (const offset of offsets.slice(1)) {
+        body += String(offset).padStart(10, "0") + " 00000 n \\n";
+      }
+
+      body += "trailer\\n<< /Size " + String(objects.length + 1) + " /Root 1 0 R >>\\n";
+      body += "startxref\\n" + String(xrefOffset) + "\\n%%EOF\\n";
+
+      return new TextEncoder().encode(body).buffer;
+    }
+  `;
+}
+
+function errorSummary(value, size = 1200) {
+  const marker = "TypeError: Promise.try is not a function";
+  const index = value.indexOf(marker);
+  if (index >= 0) {
+    return value.slice(index, index + size);
+  }
+
+  return value.length > size ? value.slice(-size) : value;
+}


### PR DESCRIPTION
## Summary

- Bump `unpdf` to `^1.6.2`, which includes a `Promise.try` fallback in its bundled PDF.js build.
- Add a Node test that exercises `extractPDFToMarkdown` with an in-memory PDF.
- Run the test in a child process after removing `Promise.try` so the regression covers Node runtimes where `Promise.try` is unavailable.

Fixes #41.
Fixes #46.

## Evidence

| Case | Result |
| --- | --- |
| `unpdf@1.6.0` + Node v22.22.0 | test fails with `TypeError: Promise.try is not a function` from `unpdf/dist/pdfjs.mjs` |
| `unpdf@1.6.2` + Node v22.22.0 | test passes |

## Testing

```bash
npm test
```

```text
# tests 1
# pass 1
# fail 0
```
