### PR TITLE
Localize web access status and curator strings

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,114 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Params = Record<string, string | number>;
+type Translate = (key: string, fallback: string, params?: Params) => string;
+
+let translate: Translate = (_key, fallback, params) => format(fallback, params);
+
+function format(text: string, params?: Params): string {
+	if (!params) return text;
+	return text.replace(/\{(\w+)\}/g, (_match, key: string) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+	return translate(key, fallback, params);
+}
+
+const bundles = [
+	{
+		locale: "ja",
+		namespace: "pi-web-access",
+		messages: {
+			"cmd.curator.review": "検索結果を確認",
+			"cmd.activity.toggle": "Web 検索アクティビティを切り替え",
+			"cmd.curator.open": "Web 検索キュレーターを開く",
+			"cmd.curator.config": "検索キュレーターワークフローを切り替えまたは設定",
+			"cmd.gemini.account": "Gemini Web のアクティブな Google アカウントを表示",
+			"cmd.storage.browse": "保存済み Web 検索結果を閲覧",
+			"notify.curator.opening": "キュレーターを開いています — 残りの検索はストリーミングされます",
+			"notify.curator.openingSearch": "Web 検索キュレーターを開いています...",
+			"notify.curator.failedConfig": "Web 検索設定の読み込みに失敗しました: {message}",
+			"notify.curator.failedOpen": "キュレーターを開けませんでした: {message}",
+			"notify.config.unknownOption": "不明なオプション: {option}。on、off、summary-review のいずれかを使用してください。",
+			"notify.config.failedSave": "設定の保存に失敗しました: {message}",
+			"notify.storage.empty": "保存済み検索結果はありません",
+			"notify.storage.deleted": "{id} を削除しました",
+			"result.noQuery": "エラー: クエリがありません。'query' または 'queries' パラメーターを使用してください。",
+			"result.noUrl": "エラー: URL がありません。",
+			"result.fetching": "{count} 件の URL を取得中...",
+			"result.searching": "検索中 {index}/{total}: \"{query}\"...",
+			"result.searchesComplete": "すべての検索が完了しました — ブラウザーで要約の承認を待っています...",
+			"result.curatorStreaming": "検索結果をブラウザーにストリーミング中...",
+			"result.waitingApproval": "ブラウザーで要約の承認を待っています...",
+			"result.geminiUnavailable": "Gemini Web は利用できません。対応する Chromium 系ブラウザーで gemini.google.com にログインしてください。",
+		},
+	},
+	{
+		locale: "zh-CN",
+		namespace: "pi-web-access",
+		messages: {
+			"cmd.curator.review": "审查搜索结果",
+			"cmd.activity.toggle": "切换 Web 搜索活动",
+			"cmd.curator.open": "打开 Web 搜索 curator",
+			"cmd.curator.config": "切换或配置搜索 curator 工作流",
+			"cmd.gemini.account": "显示 Gemini Web 当前 Google 账号",
+			"cmd.storage.browse": "浏览已保存的 Web 搜索结果",
+			"notify.curator.opening": "正在打开 curator — 剩余搜索会继续流式传入",
+			"notify.curator.openingSearch": "正在打开 Web 搜索 curator...",
+			"notify.curator.failedConfig": "加载 Web 搜索配置失败: {message}",
+			"notify.curator.failedOpen": "打开 curator 失败: {message}",
+			"notify.config.unknownOption": "未知选项: {option}。请使用 on、off 或 summary-review。",
+			"notify.config.failedSave": "保存配置失败: {message}",
+			"notify.storage.empty": "没有已保存的搜索结果",
+			"notify.storage.deleted": "已删除 {id}",
+			"result.noQuery": "错误: 未提供查询。请使用 'query' 或 'queries' 参数。",
+			"result.noUrl": "错误: 未提供 URL。",
+			"result.fetching": "正在抓取 {count} 个 URL...",
+			"result.searching": "正在搜索 {index}/{total}: \"{query}\"...",
+			"result.searchesComplete": "所有搜索完成 — 正在浏览器中等待摘要审批...",
+			"result.curatorStreaming": "搜索结果正在流式传输到浏览器...",
+			"result.waitingApproval": "正在浏览器中等待摘要审批...",
+			"result.geminiUnavailable": "Gemini Web 不可用。请在受支持的 Chromium 浏览器中登录 gemini.google.com。",
+		},
+	},
+	{
+		locale: "es",
+		namespace: "pi-web-access",
+		messages: {
+			"cmd.curator.review": "Revisar resultados de búsqueda",
+			"cmd.activity.toggle": "Alternar actividad de búsqueda web",
+			"cmd.curator.open": "Abrir el curador de búsqueda web",
+			"cmd.curator.config": "Alternar o configurar el flujo del curador de búsqueda",
+			"cmd.gemini.account": "Mostrar la cuenta de Google activa para Gemini Web",
+			"cmd.storage.browse": "Explorar resultados de búsqueda web guardados",
+			"notify.curator.opening": "Abriendo curador — las búsquedas restantes se transmitirán allí",
+			"notify.curator.openingSearch": "Abriendo curador de búsqueda web...",
+			"notify.curator.failedConfig": "No se pudo cargar la configuración de búsqueda web: {message}",
+			"notify.curator.failedOpen": "No se pudo abrir el curador: {message}",
+			"notify.config.unknownOption": "Opción desconocida: {option}. Usa on, off o summary-review.",
+			"notify.config.failedSave": "No se pudo guardar la configuración: {message}",
+			"notify.storage.empty": "No hay resultados de búsqueda guardados",
+			"notify.storage.deleted": "Eliminado {id}",
+			"result.noQuery": "Error: no se indicó una consulta. Usa el parámetro 'query' o 'queries'.",
+			"result.noUrl": "Error: no se indicó una URL.",
+			"result.fetching": "Obteniendo {count} URL(s)...",
+			"result.searching": "Buscando {index}/{total}: \"{query}\"...",
+			"result.searchesComplete": "Todas las búsquedas terminaron — esperando aprobación del resumen en el navegador...",
+			"result.curatorStreaming": "Transmitiendo búsquedas al navegador...",
+			"result.waitingApproval": "Esperando aprobación del resumen en el navegador...",
+			"result.geminiUnavailable": "Gemini Web no está disponible. Inicia sesión en gemini.google.com en un navegador Chromium compatible.",
+		},
+	},
+];
+
+export function initI18n(pi: ExtensionAPI): void {
+	const events = pi.events;
+	if (!events) return;
+	for (const bundle of bundles) events.emit("pi-core/i18n/registerBundle", bundle);
+	events.emit("pi-core/i18n/requestApi", {
+		namespace: "pi-web-access",
+		callback(api: { t?: Translate } | undefined) {
+			if (typeof api?.t === "function") translate = api.t;
+		},
+	});
+}

--- a/index.ts
+++ b/index.ts
@@ -37,6 +37,7 @@ import { isPerplexityAvailable } from "./perplexity.js";
 import { isExaAvailable } from "./exa.js";
 import { isGeminiApiAvailable } from "./gemini-api.js";
 import { getActiveGoogleEmail, isGeminiWebAvailable } from "./gemini-web.js";
+import { initI18n, t } from "./i18n.js";
 
 const WEB_SEARCH_CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
 
@@ -464,6 +465,7 @@ function handleSessionChange(ctx: ExtensionContext): void {
 }
 
 export default function (pi: ExtensionAPI) {
+	initI18n(pi);
 	const initConfig = loadConfigForExtensionInit();
 	const curateKey = initConfig.shortcuts?.curate || DEFAULT_SHORTCUTS.curate;
 	const activityKey = initConfig.shortcuts?.activity || DEFAULT_SHORTCUTS.activity;
@@ -999,7 +1001,7 @@ export default function (pi: ExtensionAPI) {
 			if (searchesComplete) handle.searchesDone();
 
 			pc.onUpdate?.({
-				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],
+				content: [{ type: "text", text: searchesComplete ? t("result.waitingApproval", "Waiting for summary approval in browser...") : t("result.curatorStreaming", "Searches streaming to browser...") }],
 				details: { phase: "curating", progress: searchesComplete ? 1 : 0.5 },
 			});
 
@@ -1032,20 +1034,20 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	pi.registerShortcut(curateKey, {
-		description: "Review search results",
+		description: t("cmd.curator.review", "Review search results"),
 		handler: async (ctx) => {
 			if (!pendingCurate) return;
 
 			if (pendingCurate.phase === "searching") {
 				pendingCurate.browserPromise = openCuratorBrowser(pendingCurate, false);
-				ctx.ui.notify("Opening curator — remaining searches will stream in", "info");
+				ctx.ui.notify(t("notify.curator.opening", "Opening curator — remaining searches will stream in"), "info");
 				return;
 			}
 		},
 	});
 
 	pi.registerShortcut(activityKey, {
-		description: "Toggle web search activity",
+		description: t("cmd.activity.toggle", "Toggle web search activity"),
 		handler: async (ctx) => {
 			widgetVisible = !widgetVisible;
 			if (widgetVisible) {
@@ -1112,7 +1114,7 @@ export default function (pi: ExtensionAPI) {
 
 			if (queryList.length === 0) {
 				return {
-					content: [{ type: "text", text: "Error: No query provided. Use 'query' or 'queries' parameter." }],
+					content: [{ type: "text", text: t("result.noQuery", "Error: No query provided. Use 'query' or 'queries' parameter.") }],
 					details: { error: "No query provided" },
 				};
 			}
@@ -1202,7 +1204,7 @@ export default function (pi: ExtensionAPI) {
 				for (let qi = 0; qi < queryList.length; qi++) {
 					if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
 					onUpdate?.({
-						content: [{ type: "text", text: `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...` }],
+						content: [{ type: "text", text: t("result.searching", `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...`, { index: qi + 1, total: queryList.length, query: queryList[qi] }) }],
 						details: { phase: "searching", progress: qi / queryList.length, currentQuery: queryList[qi] },
 					});
 					const requestedProvider = pc.defaultProvider;
@@ -1244,7 +1246,7 @@ export default function (pi: ExtensionAPI) {
 				if (activeCurator && !cancelled) {
 					activeCurator.searchesDone();
 					pc.onUpdate?.({
-						content: [{ type: "text", text: "All searches complete — waiting for summary approval in browser..." }],
+						content: [{ type: "text", text: t("result.searchesComplete", "All searches complete — waiting for summary approval in browser...") }],
 						details: { phase: "curating", progress: 1 },
 					});
 				}
@@ -1261,7 +1263,7 @@ export default function (pi: ExtensionAPI) {
 				const query = queryList[i];
 
 				onUpdate?.({
-					content: [{ type: "text", text: `Searching ${i + 1}/${queryList.length}: "${query}"...` }],
+					content: [{ type: "text", text: t("result.searching", `Searching ${i + 1}/${queryList.length}: "${query}"...`, { index: i + 1, total: queryList.length, query }) }],
 					details: { phase: "search", progress: i / queryList.length, currentQuery: query },
 				});
 
@@ -1593,13 +1595,13 @@ export default function (pi: ExtensionAPI) {
 			const urlList = params.urls ?? (params.url ? [params.url] : []);
 			if (urlList.length === 0) {
 				return {
-					content: [{ type: "text", text: "Error: No URL provided." }],
+					content: [{ type: "text", text: t("result.noUrl", "Error: No URL provided.") }],
 					details: { error: "No URL provided" },
 				};
 			}
 
 			onUpdate?.({
-				content: [{ type: "text", text: `Fetching ${urlList.length} URL(s)...` }],
+				content: [{ type: "text", text: t("result.fetching", `Fetching ${urlList.length} URL(s)...`, { count: urlList.length }) }],
 				details: { phase: "fetch", progress: 0 },
 			});
 
@@ -1965,7 +1967,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("websearch", {
-		description: "Open web search curator",
+		description: t("cmd.curator.open", "Open web search curator"),
 		handler: async (args, ctx) => {
 			closeCurator();
 			const sessionToken = randomUUID();
@@ -1980,7 +1982,7 @@ export default function (pi: ExtensionAPI) {
 				bootstrap = await loadCuratorBootstrap(undefined);
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
-				ctx.ui.notify(`Failed to load web search config: ${message}`, "error");
+				ctx.ui.notify(t("notify.curator.failedConfig", `Failed to load web search config: ${message}`, { message }), "error");
 				return;
 			}
 			const availableProviders = bootstrap.availableProviders;
@@ -1993,7 +1995,7 @@ export default function (pi: ExtensionAPI) {
 			};
 			const summaryModelChoices = await loadSummaryModelChoices(summaryContext);
 
-			ctx.ui.notify("Opening web search curator...", "info");
+			ctx.ui.notify(t("notify.curator.openingSearch", "Opening web search curator..."), "info");
 
 			const collected = new Map<number, QueryResultData>();
 			const searchAbort = new AbortController();
@@ -2185,13 +2187,13 @@ export default function (pi: ExtensionAPI) {
 			} catch (err) {
 				closeCurator();
 				const message = err instanceof Error ? err.message : String(err);
-				ctx.ui.notify(`Failed to open curator: ${message}`, "error");
+				ctx.ui.notify(t("notify.curator.failedOpen", `Failed to open curator: ${message}`, { message }), "error");
 			}
 		},
 	});
 
 	pi.registerCommand("curator", {
-		description: "Toggle or configure the search curator workflow",
+		description: t("cmd.curator.config", "Toggle or configure the search curator workflow"),
 		handler: async (args, ctx) => {
 			const arg = args.trim().toLowerCase();
 
@@ -2206,7 +2208,7 @@ export default function (pi: ExtensionAPI) {
 			} else if (arg === "none" || arg === "summary-review") {
 				newWorkflow = arg;
 			} else {
-				ctx.ui.notify(`Unknown option: ${arg}. Use on, off, or summary-review.`, "error");
+				ctx.ui.notify(t("notify.config.unknownOption", `Unknown option: ${arg}. Use on, off, or summary-review.`, { option: arg }), "error");
 				return;
 			}
 
@@ -2214,7 +2216,7 @@ export default function (pi: ExtensionAPI) {
 				saveConfig({ workflow: newWorkflow });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
-				ctx.ui.notify(`Failed to save config: ${message}`, "error");
+				ctx.ui.notify(t("notify.config.failedSave", `Failed to save config: ${message}`, { message }), "error");
 				return;
 			}
 
@@ -2231,13 +2233,13 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("google-account", {
-		description: "Show the active Google account for Gemini Web",
+		description: t("cmd.gemini.account", "Show the active Google account for Gemini Web"),
 		handler: async () => {
 			const cookies = await isGeminiWebAvailable();
 			if (!cookies) {
 				pi.sendMessage({
 					customType: "google-account",
-					content: [{ type: "text", text: "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser." }],
+					content: [{ type: "text", text: t("result.geminiUnavailable", "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser.") }],
 					display: "tool",
 					details: { available: false },
 				}, { triggerTurn: true, deliverAs: "followUp" });
@@ -2259,12 +2261,12 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("search", {
-		description: "Browse stored web search results",
+		description: t("cmd.storage.browse", "Browse stored web search results"),
 		handler: async (_args, ctx) => {
 			const results = getAllResults();
 
 			if (results.length === 0) {
-				ctx.ui.notify("No stored search results", "info");
+				ctx.ui.notify(t("notify.storage.empty", "No stored search results"), "info");
 				return;
 			}
 
@@ -2295,7 +2297,7 @@ export default function (pi: ExtensionAPI) {
 
 			if (action === "Delete") {
 				deleteResult(selected.id);
-				ctx.ui.notify(`Deleted ${selected.id.slice(0, 6)}`, "info");
+				ctx.ui.notify(t("notify.storage.deleted", `Deleted ${selected.id.slice(0, 6)}`, { id: selected.id.slice(0, 6) }), "info");
 			} else if (action === "View details") {
 				let info = `ID: ${selected.id}\nType: ${selected.type}\nAge: ${Math.floor((Date.now() - selected.timestamp) / 60000)}m\n\n`;
 				if (selected.type === "search" && selected.queries) {


### PR DESCRIPTION
I found one focused UX issue: web access has dense status/error text at the moment users choose search curation, wait for browser approval, fetch URLs, or troubleshoot Gemini/browser setup. If those messages are misread, users can think search is stuck, miss the approval step, or fail provider setup.

This PR makes that path optionally localizable while preserving the current English strings as fallbacks.

- No new dependency
- No behavior change without an i18n provider
- English remains the default/fallback
- Locales: ja, zh-CN, es — broad web/research workflow locales
- Covers curator commands, open/failure notifications, search/fetch progress, and Gemini Web availability

Validation:
- npm install --ignore-scripts
- npm pack --dry-run