### PR TITLE
Add localized README quickstarts

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,58 @@
+# Pi Web Access: inicio rápido
+
+[English](./README.md) | [日本語](./README.ja.md) | [简体中文](./README.zh-CN.md)
+
+Pi Web Access añade al agente Pi búsqueda web, extracción de URLs, clonación de repositorios GitHub, extracción de PDF y comprensión de videos de YouTube o archivos locales.
+
+## Qué hace
+
+- Busca en la web con Exa, Perplexity y Gemini
+- Convierte páginas en Markdown legible
+- Clona URLs de GitHub localmente en vez de raspar HTML renderizado
+- Permite hacer preguntas sobre videos de YouTube o grabaciones locales
+- Extrae texto de PDFs
+- Con `ffmpeg` / `yt-dlp`, extrae frames de video en timestamps exactos
+
+## Instalación
+
+```bash
+pi install npm:pi-web-access
+```
+
+Funciona sin API keys mediante Exa MCP. Para más providers o acceso directo por API, agrega claves en `~/.pi/web-search.json`.
+
+```json
+{
+  "exaApiKey": "exa-...",
+  "perplexityApiKey": "pplx-...",
+  "geminiApiKey": "AIza..."
+}
+```
+
+## Uso rápido
+
+```typescript
+web_search({ query: "TypeScript best practices 2025" })
+fetch_content({ url: "https://docs.example.com/guide" })
+fetch_content({ url: "https://github.com/owner/repo" })
+fetch_content({ url: "https://youtube.com/watch?v=abc", prompt: "What libraries are shown?" })
+fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on screen?" })
+```
+
+## Extracción de frames de video (opcional)
+
+```bash
+brew install ffmpeg
+brew install yt-dlp
+```
+
+Sin estas herramientas, el análisis de contenido de video, transcripciones y descripciones visuales con Gemini siguen funcionando. Solo son necesarias para extraer frames individuales como imágenes.
+
+## Notas importantes
+
+- La búsqueda `auto` prueba Exa → Perplexity → Gemini API → Gemini Web.
+- Los repositorios GitHub se tratan como archivos reales, para que el agente pueda explorarlos con `read` y `bash`.
+- Los repositorios GitHub privados requieren `gh` CLI.
+- Requiere Pi v0.37.3 o superior.
+
+Consulta los detalles completos en el [README en inglés](./README.md).

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,58 @@
+# Pi Web Access クイックスタート
+
+[English](./README.md) | [简体中文](./README.zh-CN.md) | [Español](./README.es.md)
+
+Pi Web Access は Pi agent に Web 検索、URL 取得、GitHub リポジトリ取得、PDF 抽出、YouTube / ローカル動画理解を追加します。
+
+## できること
+
+- Exa、Perplexity、Gemini による Web 検索
+- ページを読みやすい Markdown として取得
+- GitHub URL をスクレイピングせずローカル clone として扱う
+- YouTube 動画やローカル録画について質問する
+- PDF からテキストを抽出する
+- `ffmpeg` / `yt-dlp` がある場合、指定時刻の動画フレームを画像として抽出する
+
+## インストール
+
+```bash
+pi install npm:pi-web-access
+```
+
+API キーなしでも Exa MCP により検索できます。追加プロバイダーや直接 API を使う場合は `~/.pi/web-search.json` にキーを追加します。
+
+```json
+{
+  "exaApiKey": "exa-...",
+  "perplexityApiKey": "pplx-...",
+  "geminiApiKey": "AIza..."
+}
+```
+
+## すぐ使う
+
+```typescript
+web_search({ query: "TypeScript best practices 2025" })
+fetch_content({ url: "https://docs.example.com/guide" })
+fetch_content({ url: "https://github.com/owner/repo" })
+fetch_content({ url: "https://youtube.com/watch?v=abc", prompt: "What libraries are shown?" })
+fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on screen?" })
+```
+
+## 動画フレーム抽出（任意）
+
+```bash
+brew install ffmpeg
+brew install yt-dlp
+```
+
+これらがなくても、Gemini による動画内容分析、文字起こし、視覚説明は利用できます。個別フレーム抽出にのみ必要です。
+
+## 主な注意点
+
+- デフォルトの `auto` 検索は Exa → Perplexity → Gemini API → Gemini Web の順に試します。
+- GitHub リポジトリは実ファイルとして扱うため、agent が `read` や `bash` で探索できます。
+- プライベート GitHub リポジトリには `gh` CLI が必要です。
+- Pi v0.37.3 以上が必要です。
+
+完全な詳細は [English README](./README.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 https://github.com/user-attachments/assets/cac6a17a-1eeb-4dde-9818-cdf85d8ea98f
 
+**Localized quickstarts:** [日本語](./README.ja.md) · [简体中文](./README.zh-CN.md) · [Español](./README.es.md)
+
 ## Why Pi Web Access
 
 **Zero Config** — Works out of the box with Exa MCP (no API key needed). Or sign into Google in Chrome, Arc, Helium, or Chromium for Gemini Web. Add API keys for Exa, Perplexity, or Gemini API for more control.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,58 @@
+# Pi Web Access 快速开始
+
+[English](./README.md) | [日本語](./README.ja.md) | [Español](./README.es.md)
+
+Pi Web Access 为 Pi agent 添加网页搜索、URL 抓取、GitHub 仓库获取、PDF 提取、YouTube / 本地视频理解能力。
+
+## 能做什么
+
+- 使用 Exa、Perplexity、Gemini 搜索网页
+- 将网页提取为易读 Markdown
+- 对 GitHub URL 进行本地 clone，而不是抓取渲染后的 HTML
+- 对 YouTube 视频或本地录屏提问
+- 从 PDF 提取文本
+- 安装 `ffmpeg` / `yt-dlp` 后，可按时间戳提取视频帧图片
+
+## 安装
+
+```bash
+pi install npm:pi-web-access
+```
+
+没有 API key 也可以通过 Exa MCP 进行搜索。若需要更多 provider 或直接 API 访问，请在 `~/.pi/web-search.json` 中添加 key。
+
+```json
+{
+  "exaApiKey": "exa-...",
+  "perplexityApiKey": "pplx-...",
+  "geminiApiKey": "AIza..."
+}
+```
+
+## 立即使用
+
+```typescript
+web_search({ query: "TypeScript best practices 2025" })
+fetch_content({ url: "https://docs.example.com/guide" })
+fetch_content({ url: "https://github.com/owner/repo" })
+fetch_content({ url: "https://youtube.com/watch?v=abc", prompt: "What libraries are shown?" })
+fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on screen?" })
+```
+
+## 视频帧提取（可选）
+
+```bash
+brew install ffmpeg
+brew install yt-dlp
+```
+
+即使不安装这些工具，仍可使用 Gemini 进行视频内容分析、转录和视觉描述。它们只用于提取单独的视频帧图片。
+
+## 主要注意事项
+
+- 默认 `auto` 搜索顺序为 Exa → Perplexity → Gemini API → Gemini Web。
+- GitHub 仓库会作为真实文件处理，agent 可以用 `read` 和 `bash` 探索。
+- 私有 GitHub 仓库需要 `gh` CLI。
+- 需要 Pi v0.37.3 或更高版本。
+
+完整细节见 [English README](./README.md)。

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,114 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Params = Record<string, string | number>;
+type Translate = (key: string, fallback: string, params?: Params) => string;
+
+let translate: Translate = (_key, fallback, params) => format(fallback, params);
+
+function format(text: string, params?: Params): string {
+	if (!params) return text;
+	return text.replace(/\{(\w+)\}/g, (_match, key: string) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+	return translate(key, fallback, params);
+}
+
+const bundles = [
+	{
+		locale: "ja",
+		namespace: "pi-web-access",
+		messages: {
+			"cmd.curator.review": "検索結果を確認",
+			"cmd.activity.toggle": "Web 検索アクティビティを切り替え",
+			"cmd.curator.open": "Web 検索キュレーターを開く",
+			"cmd.curator.config": "検索キュレーターワークフローを切り替えまたは設定",
+			"cmd.gemini.account": "Gemini Web のアクティブな Google アカウントを表示",
+			"cmd.storage.browse": "保存済み Web 検索結果を閲覧",
+			"notify.curator.opening": "キュレーターを開いています — 残りの検索はストリーミングされます",
+			"notify.curator.openingSearch": "Web 検索キュレーターを開いています...",
+			"notify.curator.failedConfig": "Web 検索設定の読み込みに失敗しました: {message}",
+			"notify.curator.failedOpen": "キュレーターを開けませんでした: {message}",
+			"notify.config.unknownOption": "不明なオプション: {option}。on、off、summary-review のいずれかを使用してください。",
+			"notify.config.failedSave": "設定の保存に失敗しました: {message}",
+			"notify.storage.empty": "保存済み検索結果はありません",
+			"notify.storage.deleted": "{id} を削除しました",
+			"result.noQuery": "エラー: クエリがありません。'query' または 'queries' パラメーターを使用してください。",
+			"result.noUrl": "エラー: URL がありません。",
+			"result.fetching": "{count} 件の URL を取得中...",
+			"result.searching": "検索中 {index}/{total}: \"{query}\"...",
+			"result.searchesComplete": "すべての検索が完了しました — ブラウザーで要約の承認を待っています...",
+			"result.curatorStreaming": "検索結果をブラウザーにストリーミング中...",
+			"result.waitingApproval": "ブラウザーで要約の承認を待っています...",
+			"result.geminiUnavailable": "Gemini Web は利用できません。対応する Chromium 系ブラウザーで gemini.google.com にログインしてください。",
+		},
+	},
+	{
+		locale: "zh-CN",
+		namespace: "pi-web-access",
+		messages: {
+			"cmd.curator.review": "审查搜索结果",
+			"cmd.activity.toggle": "切换 Web 搜索活动",
+			"cmd.curator.open": "打开 Web 搜索 curator",
+			"cmd.curator.config": "切换或配置搜索 curator 工作流",
+			"cmd.gemini.account": "显示 Gemini Web 当前 Google 账号",
+			"cmd.storage.browse": "浏览已保存的 Web 搜索结果",
+			"notify.curator.opening": "正在打开 curator — 剩余搜索会继续流式传入",
+			"notify.curator.openingSearch": "正在打开 Web 搜索 curator...",
+			"notify.curator.failedConfig": "加载 Web 搜索配置失败: {message}",
+			"notify.curator.failedOpen": "打开 curator 失败: {message}",
+			"notify.config.unknownOption": "未知选项: {option}。请使用 on、off 或 summary-review。",
+			"notify.config.failedSave": "保存配置失败: {message}",
+			"notify.storage.empty": "没有已保存的搜索结果",
+			"notify.storage.deleted": "已删除 {id}",
+			"result.noQuery": "错误: 未提供查询。请使用 'query' 或 'queries' 参数。",
+			"result.noUrl": "错误: 未提供 URL。",
+			"result.fetching": "正在抓取 {count} 个 URL...",
+			"result.searching": "正在搜索 {index}/{total}: \"{query}\"...",
+			"result.searchesComplete": "所有搜索完成 — 正在浏览器中等待摘要审批...",
+			"result.curatorStreaming": "搜索结果正在流式传输到浏览器...",
+			"result.waitingApproval": "正在浏览器中等待摘要审批...",
+			"result.geminiUnavailable": "Gemini Web 不可用。请在受支持的 Chromium 浏览器中登录 gemini.google.com。",
+		},
+	},
+	{
+		locale: "es",
+		namespace: "pi-web-access",
+		messages: {
+			"cmd.curator.review": "Revisar resultados de búsqueda",
+			"cmd.activity.toggle": "Alternar actividad de búsqueda web",
+			"cmd.curator.open": "Abrir el curador de búsqueda web",
+			"cmd.curator.config": "Alternar o configurar el flujo del curador de búsqueda",
+			"cmd.gemini.account": "Mostrar la cuenta de Google activa para Gemini Web",
+			"cmd.storage.browse": "Explorar resultados de búsqueda web guardados",
+			"notify.curator.opening": "Abriendo curador — las búsquedas restantes se transmitirán allí",
+			"notify.curator.openingSearch": "Abriendo curador de búsqueda web...",
+			"notify.curator.failedConfig": "No se pudo cargar la configuración de búsqueda web: {message}",
+			"notify.curator.failedOpen": "No se pudo abrir el curador: {message}",
+			"notify.config.unknownOption": "Opción desconocida: {option}. Usa on, off o summary-review.",
+			"notify.config.failedSave": "No se pudo guardar la configuración: {message}",
+			"notify.storage.empty": "No hay resultados de búsqueda guardados",
+			"notify.storage.deleted": "Eliminado {id}",
+			"result.noQuery": "Error: no se indicó una consulta. Usa el parámetro 'query' o 'queries'.",
+			"result.noUrl": "Error: no se indicó una URL.",
+			"result.fetching": "Obteniendo {count} URL(s)...",
+			"result.searching": "Buscando {index}/{total}: \"{query}\"...",
+			"result.searchesComplete": "Todas las búsquedas terminaron — esperando aprobación del resumen en el navegador...",
+			"result.curatorStreaming": "Transmitiendo búsquedas al navegador...",
+			"result.waitingApproval": "Esperando aprobación del resumen en el navegador...",
+			"result.geminiUnavailable": "Gemini Web no está disponible. Inicia sesión en gemini.google.com en un navegador Chromium compatible.",
+		},
+	},
+];
+
+export function initI18n(pi: ExtensionAPI): void {
+	const events = pi.events;
+	if (!events) return;
+	for (const bundle of bundles) events.emit("pi-core/i18n/registerBundle", bundle);
+	events.emit("pi-core/i18n/requestApi", {
+		namespace: "pi-web-access",
+		callback(api: { t?: Translate } | undefined) {
+			if (typeof api?.t === "function") translate = api.t;
+		},
+	});
+}

--- a/index.ts
+++ b/index.ts
@@ -37,6 +37,7 @@ import { isPerplexityAvailable } from "./perplexity.js";
 import { isExaAvailable } from "./exa.js";
 import { isGeminiApiAvailable } from "./gemini-api.js";
 import { getActiveGoogleEmail, isGeminiWebAvailable } from "./gemini-web.js";
+import { initI18n, t } from "./i18n.js";
 
 const WEB_SEARCH_CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
 
@@ -464,6 +465,7 @@ function handleSessionChange(ctx: ExtensionContext): void {
 }
 
 export default function (pi: ExtensionAPI) {
+	initI18n(pi);
 	const initConfig = loadConfigForExtensionInit();
 	const curateKey = initConfig.shortcuts?.curate || DEFAULT_SHORTCUTS.curate;
 	const activityKey = initConfig.shortcuts?.activity || DEFAULT_SHORTCUTS.activity;
@@ -999,7 +1001,7 @@ export default function (pi: ExtensionAPI) {
 			if (searchesComplete) handle.searchesDone();
 
 			pc.onUpdate?.({
-				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],
+				content: [{ type: "text", text: searchesComplete ? t("result.waitingApproval", "Waiting for summary approval in browser...") : t("result.curatorStreaming", "Searches streaming to browser...") }],
 				details: { phase: "curating", progress: searchesComplete ? 1 : 0.5 },
 			});
 
@@ -1032,20 +1034,20 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	pi.registerShortcut(curateKey, {
-		description: "Review search results",
+		description: t("cmd.curator.review", "Review search results"),
 		handler: async (ctx) => {
 			if (!pendingCurate) return;
 
 			if (pendingCurate.phase === "searching") {
 				pendingCurate.browserPromise = openCuratorBrowser(pendingCurate, false);
-				ctx.ui.notify("Opening curator — remaining searches will stream in", "info");
+				ctx.ui.notify(t("notify.curator.opening", "Opening curator — remaining searches will stream in"), "info");
 				return;
 			}
 		},
 	});
 
 	pi.registerShortcut(activityKey, {
-		description: "Toggle web search activity",
+		description: t("cmd.activity.toggle", "Toggle web search activity"),
 		handler: async (ctx) => {
 			widgetVisible = !widgetVisible;
 			if (widgetVisible) {
@@ -1112,7 +1114,7 @@ export default function (pi: ExtensionAPI) {
 
 			if (queryList.length === 0) {
 				return {
-					content: [{ type: "text", text: "Error: No query provided. Use 'query' or 'queries' parameter." }],
+					content: [{ type: "text", text: t("result.noQuery", "Error: No query provided. Use 'query' or 'queries' parameter.") }],
 					details: { error: "No query provided" },
 				};
 			}
@@ -1202,7 +1204,7 @@ export default function (pi: ExtensionAPI) {
 				for (let qi = 0; qi < queryList.length; qi++) {
 					if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
 					onUpdate?.({
-						content: [{ type: "text", text: `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...` }],
+						content: [{ type: "text", text: t("result.searching", `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...`, { index: qi + 1, total: queryList.length, query: queryList[qi] }) }],
 						details: { phase: "searching", progress: qi / queryList.length, currentQuery: queryList[qi] },
 					});
 					const requestedProvider = pc.defaultProvider;
@@ -1244,7 +1246,7 @@ export default function (pi: ExtensionAPI) {
 				if (activeCurator && !cancelled) {
 					activeCurator.searchesDone();
 					pc.onUpdate?.({
-						content: [{ type: "text", text: "All searches complete — waiting for summary approval in browser..." }],
+						content: [{ type: "text", text: t("result.searchesComplete", "All searches complete — waiting for summary approval in browser...") }],
 						details: { phase: "curating", progress: 1 },
 					});
 				}
@@ -1261,7 +1263,7 @@ export default function (pi: ExtensionAPI) {
 				const query = queryList[i];
 
 				onUpdate?.({
-					content: [{ type: "text", text: `Searching ${i + 1}/${queryList.length}: "${query}"...` }],
+					content: [{ type: "text", text: t("result.searching", `Searching ${i + 1}/${queryList.length}: "${query}"...`, { index: i + 1, total: queryList.length, query }) }],
 					details: { phase: "search", progress: i / queryList.length, currentQuery: query },
 				});
 
@@ -1593,13 +1595,13 @@ export default function (pi: ExtensionAPI) {
 			const urlList = params.urls ?? (params.url ? [params.url] : []);
 			if (urlList.length === 0) {
 				return {
-					content: [{ type: "text", text: "Error: No URL provided." }],
+					content: [{ type: "text", text: t("result.noUrl", "Error: No URL provided.") }],
 					details: { error: "No URL provided" },
 				};
 			}
 
 			onUpdate?.({
-				content: [{ type: "text", text: `Fetching ${urlList.length} URL(s)...` }],
+				content: [{ type: "text", text: t("result.fetching", `Fetching ${urlList.length} URL(s)...`, { count: urlList.length }) }],
 				details: { phase: "fetch", progress: 0 },
 			});
 
@@ -1965,7 +1967,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("websearch", {
-		description: "Open web search curator",
+		description: t("cmd.curator.open", "Open web search curator"),
 		handler: async (args, ctx) => {
 			closeCurator();
 			const sessionToken = randomUUID();
@@ -1980,7 +1982,7 @@ export default function (pi: ExtensionAPI) {
 				bootstrap = await loadCuratorBootstrap(undefined);
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
-				ctx.ui.notify(`Failed to load web search config: ${message}`, "error");
+				ctx.ui.notify(t("notify.curator.failedConfig", `Failed to load web search config: ${message}`, { message }), "error");
 				return;
 			}
 			const availableProviders = bootstrap.availableProviders;
@@ -1993,7 +1995,7 @@ export default function (pi: ExtensionAPI) {
 			};
 			const summaryModelChoices = await loadSummaryModelChoices(summaryContext);
 
-			ctx.ui.notify("Opening web search curator...", "info");
+			ctx.ui.notify(t("notify.curator.openingSearch", "Opening web search curator..."), "info");
 
 			const collected = new Map<number, QueryResultData>();
 			const searchAbort = new AbortController();
@@ -2185,13 +2187,13 @@ export default function (pi: ExtensionAPI) {
 			} catch (err) {
 				closeCurator();
 				const message = err instanceof Error ? err.message : String(err);
-				ctx.ui.notify(`Failed to open curator: ${message}`, "error");
+				ctx.ui.notify(t("notify.curator.failedOpen", `Failed to open curator: ${message}`, { message }), "error");
 			}
 		},
 	});
 
 	pi.registerCommand("curator", {
-		description: "Toggle or configure the search curator workflow",
+		description: t("cmd.curator.config", "Toggle or configure the search curator workflow"),
 		handler: async (args, ctx) => {
 			const arg = args.trim().toLowerCase();
 
@@ -2206,7 +2208,7 @@ export default function (pi: ExtensionAPI) {
 			} else if (arg === "none" || arg === "summary-review") {
 				newWorkflow = arg;
 			} else {
-				ctx.ui.notify(`Unknown option: ${arg}. Use on, off, or summary-review.`, "error");
+				ctx.ui.notify(t("notify.config.unknownOption", `Unknown option: ${arg}. Use on, off, or summary-review.`, { option: arg }), "error");
 				return;
 			}
 
@@ -2214,7 +2216,7 @@ export default function (pi: ExtensionAPI) {
 				saveConfig({ workflow: newWorkflow });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
-				ctx.ui.notify(`Failed to save config: ${message}`, "error");
+				ctx.ui.notify(t("notify.config.failedSave", `Failed to save config: ${message}`, { message }), "error");
 				return;
 			}
 
@@ -2231,13 +2233,13 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("google-account", {
-		description: "Show the active Google account for Gemini Web",
+		description: t("cmd.gemini.account", "Show the active Google account for Gemini Web"),
 		handler: async () => {
 			const cookies = await isGeminiWebAvailable();
 			if (!cookies) {
 				pi.sendMessage({
 					customType: "google-account",
-					content: [{ type: "text", text: "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser." }],
+					content: [{ type: "text", text: t("result.geminiUnavailable", "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser.") }],
 					display: "tool",
 					details: { available: false },
 				}, { triggerTurn: true, deliverAs: "followUp" });
@@ -2259,12 +2261,12 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("search", {
-		description: "Browse stored web search results",
+		description: t("cmd.storage.browse", "Browse stored web search results"),
 		handler: async (_args, ctx) => {
 			const results = getAllResults();
 
 			if (results.length === 0) {
-				ctx.ui.notify("No stored search results", "info");
+				ctx.ui.notify(t("notify.storage.empty", "No stored search results"), "info");
 				return;
 			}
 
@@ -2295,7 +2297,7 @@ export default function (pi: ExtensionAPI) {
 
 			if (action === "Delete") {
 				deleteResult(selected.id);
-				ctx.ui.notify(`Deleted ${selected.id.slice(0, 6)}`, "info");
+				ctx.ui.notify(t("notify.storage.deleted", `Deleted ${selected.id.slice(0, 6)}`, { id: selected.id.slice(0, 6) }), "info");
 			} else if (action === "View details") {
 				let info = `ID: ${selected.id}\nType: ${selected.type}\nAge: ${Math.floor((Date.now() - selected.timestamp) / 60000)}m\n\n`;
 				if (selected.type === "search" && selected.queries) {


### PR DESCRIPTION
This follows the web-access localization direction with docs only.

The package page is where users decide whether web/video/GitHub fetching is safe and worth installing. I translated only the quickstart/decision path, not the full README, so the PR stays reviewable.

- No code changes
- English README unchanged except small language links
- Adds concise ja/zh-CN/es quickstarts
- Focuses on install, provider fallback, GitHub behavior, video support, and optional ffmpeg/yt-dlp setup

I kept commands, config keys, tool names, and code examples unchanged.