### PR TITLE
Migrate package imports from @mariozechner/pi-* to @earendil-works/pi-*

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { Box, Text, truncateToWidth } from "@mariozechner/pi-tui";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Box, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { StringEnum, complete, getModel, type Model } from "@mariozechner/pi-ai";
+import { StringEnum, complete, getModel, type Model } from "@earendil-works/pi-ai";
 import { fetchAllContent, type ExtractedContent } from "./extract.js";
 import { clearCloneCache } from "./github-extract.js";
 import { search, type SearchProvider, type ResolvedSearchProvider } from "./gemini-search.js";

--- a/storage.ts
+++ b/storage.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ExtractedContent } from "./extract.js";
 import type { SearchResult } from "./perplexity.js";
 

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -1,5 +1,5 @@
-import { complete, getModel, type Message, type Model } from "@mariozechner/pi-ai";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { complete, getModel, type Message, type Model } from "@earendil-works/pi-ai";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { QueryResultData } from "./storage.js";
 
 const PREFERRED_SUMMARY_MODELS = [


### PR DESCRIPTION
## Summary

Pi has been migrated from the `@mariozechner/pi-*` npm scope to `@earendil-works/pi-*`. This PR updates the import paths in three source files to match.

## Changes

```diff
- import { ... } from "@mariozechner/pi-ai";
- import { ... } from "@mariozechner/pi-tui";
- import { ... } from "@mariozechner/pi-coding-agent";
+ import { ... } from "@earendil-works/pi-ai";
+ import { ... } from "@earendil-works/pi-tui";
+ import { ... } from "@earendil-works/pi-coding-agent";
```

Files changed:
- `index.ts` (3 import lines)
- `summary-review.ts` (2 import lines)
- `storage.ts` (1 import line)

No logic changes — pure import path rename.

## Compatibility

Pi's extension loader currently provides backward-compatible aliases for `@mariozechner/pi-*`, so this is not a breaking fix. But those aliases may be removed in a future version, so this migration keeps things working going forward.