### PR TITLE
chore: add prettier formatting config and apply to codebase

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "useTabs": true,
+  "tabWidth": 4,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "endOfLine": "lf"
+}

--- a/activity.ts
+++ b/activity.ts
@@ -27,7 +27,12 @@ export class ActivityMonitor {
 	private entries: ActivityEntry[] = [];
 	private readonly maxEntries = 10;
 	private listeners = new Set<() => void>();
-	private rateLimitInfo: RateLimitInfo = { used: 0, max: 10, oldestTimestamp: null, windowMs: 60000 };
+	private rateLimitInfo: RateLimitInfo = {
+		used: 0,
+		max: 10,
+		oldestTimestamp: null,
+		windowMs: 60000,
+	};
 	private nextId = 1;
 
 	logStart(partial: Omit<ActivityEntry, "id" | "startTime" | "status">): string {
@@ -92,8 +97,7 @@ export class ActivityMonitor {
 		for (const cb of this.listeners) {
 			try {
 				cb();
-			} catch {
-			}
+			} catch {}
 		}
 	}
 }

--- a/chrome-cookies.ts
+++ b/chrome-cookies.ts
@@ -67,15 +67,17 @@ const LINUX_BROWSER_CONFIGS: BrowserConfig[] = [
 	{ name: "Chrome", baseDir: ".config/google-chrome", secretToolApp: "chrome" },
 ];
 
-export async function getGoogleCookies(
-	options?: { profile?: string; requiredCookies?: string[] },
-): Promise<{ cookies: CookieMap; warnings: string[] } | null> {
+export async function getGoogleCookies(options?: {
+	profile?: string;
+	requiredCookies?: string[];
+}): Promise<{ cookies: CookieMap; warnings: string[] } | null> {
 	const currentPlatform = platform();
-	const configs = currentPlatform === "darwin"
-		? MACOS_BROWSER_CONFIGS
-		: currentPlatform === "linux"
-			? LINUX_BROWSER_CONFIGS
-			: [];
+	const configs =
+		currentPlatform === "darwin"
+			? MACOS_BROWSER_CONFIGS
+			: currentPlatform === "linux"
+				? LINUX_BROWSER_CONFIGS
+				: [];
 	if (configs.length === 0) return null;
 
 	const warnings: string[] = [];
@@ -92,7 +94,13 @@ export async function getGoogleCookies(
 			continue;
 		}
 
-		const key = pbkdf2Sync(password, "saltysalt", currentPlatform === "darwin" ? 1003 : 1, 16, "sha1");
+		const key = pbkdf2Sync(
+			password,
+			"saltysalt",
+			currentPlatform === "darwin" ? 1003 : 1,
+			16,
+			"sha1"
+		);
 		const tempDir = mkdtempSync(join(tmpdir(), "pi-chrome-cookies-"));
 
 		try {
@@ -115,7 +123,8 @@ export async function getGoogleCookies(
 				if (!ALL_COOKIE_NAMES.has(name)) continue;
 				if (cookies[name]) continue;
 
-				let value = typeof row.value === "string" && row.value.length > 0 ? row.value : null;
+				let value =
+					typeof row.value === "string" && row.value.length > 0 ? row.value : null;
 				if (!value) {
 					const encrypted = row.encrypted_value;
 					if (encrypted instanceof Uint8Array) {
@@ -125,7 +134,10 @@ export async function getGoogleCookies(
 				if (value) cookies[name] = value;
 			}
 
-			if (options?.requiredCookies?.length && !options.requiredCookies.every((name) => Boolean(cookies[name]))) {
+			if (
+				options?.requiredCookies?.length &&
+				!options.requiredCookies.every((name) => Boolean(cookies[name]))
+			) {
 				continue;
 			}
 
@@ -173,7 +185,7 @@ function removePkcs7Padding(buf: Buffer): Buffer {
 
 function readBrowserPassword(
 	config: BrowserConfig,
-	currentPlatform: ReturnType<typeof platform>,
+	currentPlatform: ReturnType<typeof platform>
 ): Promise<string | null> {
 	if (currentPlatform === "darwin") {
 		if (!config.keychainAccount || !config.keychainService) return Promise.resolve(null);
@@ -192,9 +204,12 @@ function readKeychainPassword(account: string, service: string): Promise<string 
 			["find-generic-password", "-w", "-a", account, "-s", service],
 			{ timeout: 5000 },
 			(err, stdout) => {
-				if (err) { resolve(null); return; }
+				if (err) {
+					resolve(null);
+					return;
+				}
 				resolve(stdout.trim() || null);
-			},
+			}
 		);
 	});
 }
@@ -214,7 +229,7 @@ function readLinuxPassword(secretToolApp: string | undefined): Promise<string> {
 					return;
 				}
 				resolve(stdout.trim() || "peanuts");
-			},
+			}
 		);
 	});
 }
@@ -225,7 +240,7 @@ async function importSqlite(): Promise<typeof import("node:sqlite") | null> {
 	if (sqliteModule) return sqliteModule;
 	const orig = process.emitWarning.bind(process);
 	process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
-		const msg = typeof warning === "string" ? warning : warning?.message ?? "";
+		const msg = typeof warning === "string" ? warning : (warning?.message ?? "");
 		if (msg.includes("SQLite is an experimental feature")) return;
 		return (orig as Function)(warning, ...args);
 	}) as typeof process.emitWarning;
@@ -253,7 +268,9 @@ async function readMetaVersion(dbPath: string): Promise<number> {
 	if (supportsReadBigInts()) opts.readBigInts = true;
 	const db = new sqlite.DatabaseSync(dbPath, opts);
 	try {
-		const rows = db.prepare("SELECT value FROM meta WHERE key = 'version'").all() as Array<Record<string, unknown>>;
+		const rows = db.prepare("SELECT value FROM meta WHERE key = 'version'").all() as Array<
+			Record<string, unknown>
+		>;
 		const val = rows[0]?.value;
 		if (typeof val === "number") return Math.floor(val);
 		if (typeof val === "bigint") return Number(val);
@@ -268,7 +285,7 @@ async function readMetaVersion(dbPath: string): Promise<number> {
 
 async function queryCookieRows(
 	dbPath: string,
-	hosts: string[],
+	hosts: string[]
 ): Promise<Array<Record<string, unknown>> | null> {
 	const sqlite = await importSqlite();
 	if (!sqlite) return null;
@@ -290,7 +307,7 @@ async function queryCookieRows(
 	try {
 		return db
 			.prepare(
-				`SELECT name, value, host_key, encrypted_value FROM cookies WHERE (${where}) ORDER BY expires_utc DESC`,
+				`SELECT name, value, host_key, encrypted_value FROM cookies WHERE (${where}) ORDER BY expires_utc DESC`
 			)
 			.all() as Array<Record<string, unknown>>;
 	} catch {
@@ -317,6 +334,5 @@ function copySidecar(srcDb: string, targetDb: string, suffix: string): void {
 	if (!existsSync(sidecar)) return;
 	try {
 		copyFileSync(sidecar, `${targetDb}${suffix}`);
-	} catch {
-	}
+	} catch {}
 }

--- a/code-search.ts
+++ b/code-search.ts
@@ -14,8 +14,13 @@ function isMissingMcpToolError(message: string): boolean {
 
 function buildFallbackQuery(query: string): string {
 	const normalized = query.toLowerCase();
-	const hasCodeTerms = /\b(api|code|docs?|documentation|example|github|implementation|library|source|stackoverflow|stack overflow)\b/.test(normalized);
-	return hasCodeTerms ? query : `${query} code examples documentation GitHub Stack Overflow official docs`;
+	const hasCodeTerms =
+		/\b(api|code|docs?|documentation|example|github|implementation|library|source|stackoverflow|stack overflow)\b/.test(
+			normalized
+		);
+	return hasCodeTerms
+		? query
+		: `${query} code examples documentation GitHub Stack Overflow official docs`;
 }
 
 function maxTokensToResultCount(maxTokens: number): number {
@@ -28,7 +33,11 @@ function trimApproxTokens(text: string, maxTokens: number): string {
 	return `${text.slice(0, maxCharacters).trimEnd()}\n\n[Truncated by code_search to approximately ${maxTokens} tokens.]`;
 }
 
-async function executeFallbackSearch(query: string, maxTokens: number, signal?: AbortSignal): Promise<string> {
+async function executeFallbackSearch(
+	query: string,
+	maxTokens: number,
+	signal?: AbortSignal
+): Promise<string> {
 	const text = await callExaMcp(
 		WEB_SEARCH_TOOL,
 		{
@@ -38,7 +47,7 @@ async function executeFallbackSearch(query: string, maxTokens: number, signal?: 
 			type: "auto",
 			contextMaxCharacters: Math.min(50000, Math.max(1000, maxTokens * 4)),
 		},
-		signal,
+		signal
 	);
 	return trimApproxTokens(text, maxTokens);
 }
@@ -46,16 +55,25 @@ async function executeFallbackSearch(query: string, maxTokens: number, signal?: 
 export async function executeCodeSearch(
 	_toolCallId: string,
 	params: { query: string; maxTokens?: number },
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<{
 	content: Array<{ type: "text"; text: string }>;
-	details: { query: string; maxTokens: number; error?: string; mode?: "code-context" | "web-search-fallback" };
+	details: {
+		query: string;
+		maxTokens: number;
+		error?: string;
+		mode?: "code-context" | "web-search-fallback";
+	};
 }> {
 	const query = params.query.trim();
 	if (!query) {
 		return {
 			content: [{ type: "text", text: "Error: No query provided." }],
-			details: { query: "", maxTokens: params.maxTokens ?? DEFAULT_MAX_TOKENS, error: "No query provided" },
+			details: {
+				query: "",
+				maxTokens: params.maxTokens ?? DEFAULT_MAX_TOKENS,
+				error: "No query provided",
+			},
 		};
 	}
 
@@ -76,7 +94,7 @@ export async function executeCodeSearch(
 						query,
 						tokensNum: maxTokens,
 					},
-					signal,
+					signal
 				);
 				mode = "code-context";
 			} catch (err) {

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -10,7 +10,7 @@ function safeInlineJSON(data: unknown): string {
 function buildProviderButtons(
 	available: { perplexity: boolean; exa: boolean; gemini: boolean },
 	selected: string,
-	hasInitialQueries: boolean,
+	hasInitialQueries: boolean
 ): string {
 	const providers = [
 		{ value: "perplexity", label: "Perplexity", available: available.perplexity },
@@ -19,11 +19,13 @@ function buildProviderButtons(
 	];
 
 	return providers
-		.filter(p => p.available)
+		.filter((p) => p.available)
 		.map((p) => {
 			const isDefault = p.value === selected;
 			const state = isDefault && hasInitialQueries ? "loading" : "idle";
-			const classes = ["provider-btn", state, isDefault ? "is-default" : ""].filter(Boolean).join(" ");
+			const classes = ["provider-btn", state, isDefault ? "is-default" : ""]
+				.filter(Boolean)
+				.join(" ");
 			const disabled = state === "loading" ? " disabled" : "";
 			return `<button type="button" class="${classes}" data-provider="${p.value}" data-state="${state}"${disabled}>${p.label}</button>`;
 		})
@@ -37,10 +39,22 @@ export function generateCuratorPage(
 	availableProviders: { perplexity: boolean; exa: boolean; gemini: boolean },
 	defaultProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
-	defaultSummaryModel: string | null,
+	defaultSummaryModel: string | null
 ): string {
-	const providerButtonsHtml = buildProviderButtons(availableProviders, defaultProvider, queries.length > 0);
-	const inlineData = safeInlineJSON({ queries, sessionToken, timeout, defaultProvider, summaryModels, defaultSummaryModel, availableProviders });
+	const providerButtonsHtml = buildProviderButtons(
+		availableProviders,
+		defaultProvider,
+		queries.length > 0
+	);
+	const inlineData = safeInlineJSON({
+		queries,
+		sessionToken,
+		timeout,
+		defaultProvider,
+		summaryModels,
+		defaultSummaryModel,
+		availableProviders,
+	});
 
 	return `<!DOCTYPE html>
 <html lang="en">

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -19,10 +19,19 @@ export interface CuratorServerOptions {
 }
 
 export interface CuratorServerCallbacks {
-	onSubmit: (payload: { selectedQueryIndices: number[]; summary?: string; summaryMeta?: SummaryMeta; rawResults?: boolean }) => void;
+	onSubmit: (payload: {
+		selectedQueryIndices: number[];
+		summary?: string;
+		summaryMeta?: SummaryMeta;
+		rawResults?: boolean;
+	}) => void;
 	onCancel: (reason: "user" | "timeout" | "stale") => void;
 	onProviderChange: (provider: string) => void;
-	onAddSearch: (query: string, queryIndex: number, provider?: string) => Promise<{
+	onAddSearch: (
+		query: string,
+		queryIndex: number,
+		provider?: string
+	) => Promise<{
 		answer: string;
 		results: Array<{ title: string; url: string; domain: string }>;
 		provider: string;
@@ -31,7 +40,7 @@ export interface CuratorServerCallbacks {
 		selectedQueryIndices: number[],
 		signal: AbortSignal,
 		model?: string,
-		feedback?: string,
+		feedback?: string
 	) => Promise<{ summary: string; meta: SummaryMeta }>;
 	onRewriteQuery: (query: string, signal: AbortSignal) => Promise<string>;
 }
@@ -40,7 +49,14 @@ export interface CuratorServerHandle {
 	server: http.Server;
 	url: string;
 	close: () => void;
-	pushResult: (queryIndex: number, data: { answer: string; results: Array<{ title: string; url: string; domain: string }>; provider: string }) => void;
+	pushResult: (
+		queryIndex: number,
+		data: {
+			answer: string;
+			results: Array<{ title: string; url: string; domain: string }>;
+			provider: string;
+		}
+	) => void;
 	pushError: (queryIndex: number, error: string, provider?: string) => void;
 	searchesDone: () => void;
 }
@@ -91,7 +107,7 @@ async function parseBodyOrSend(req: IncomingMessage, res: ServerResponse): Promi
 
 function normalizeSelectedIndices(
 	value: unknown,
-	options: { allowEmpty: boolean; maxExclusive: number },
+	options: { allowEmpty: boolean; maxExclusive: number }
 ): { ok: true; indices: number[] } | { ok: false; error: string } {
 	if (!Array.isArray(value)) {
 		return { ok: false, error: "Invalid selection" };
@@ -132,10 +148,12 @@ function normalizeSummaryMeta(value: unknown): SummaryMeta | null {
 	if (model !== null && typeof model !== "string") return null;
 
 	const durationMs = meta.durationMs;
-	if (typeof durationMs !== "number" || !Number.isFinite(durationMs) || durationMs < 0) return null;
+	if (typeof durationMs !== "number" || !Number.isFinite(durationMs) || durationMs < 0)
+		return null;
 
 	const tokenEstimate = meta.tokenEstimate;
-	if (typeof tokenEstimate !== "number" || !Number.isFinite(tokenEstimate) || tokenEstimate < 0) return null;
+	if (typeof tokenEstimate !== "number" || !Number.isFinite(tokenEstimate) || tokenEstimate < 0)
+		return null;
 
 	const fallbackUsed = meta.fallbackUsed;
 	if (typeof fallbackUsed !== "boolean") return null;
@@ -158,7 +176,7 @@ function normalizeSummaryMeta(value: unknown): SummaryMeta | null {
 
 export function startCuratorServer(
 	options: CuratorServerOptions,
-	callbacks: CuratorServerCallbacks,
+	callbacks: CuratorServerCallbacks
 ): Promise<CuratorServerHandle> {
 	const {
 		queries,
@@ -202,7 +220,9 @@ export function startCuratorServer(
 		}
 		abortInFlightSummarize();
 		if (sseResponse) {
-			try { sseResponse.end(); } catch {}
+			try {
+				sseResponse.end();
+			} catch {}
 			sseResponse = null;
 		}
 		return true;
@@ -236,7 +256,10 @@ export function startCuratorServer(
 		const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 		const res = sseResponse;
 		if (res && !res.writableEnded && res.socket && !res.socket.destroyed) {
-			try { res.write(payload); return; } catch {}
+			try {
+				res.write(payload);
+				return;
+			} catch {}
 		}
 		sseBuffer.push(payload);
 	}
@@ -248,7 +271,7 @@ export function startCuratorServer(
 		availableProviders,
 		defaultProvider,
 		summaryModels,
-		defaultSummaryModel,
+		defaultSummaryModel
 	);
 
 	const server = http.createServer(async (req, res) => {
@@ -284,7 +307,9 @@ export function startCuratorServer(
 					return;
 				}
 				if (sseResponse) {
-					try { sseResponse.end(); } catch {}
+					try {
+						sseResponse.end();
+					} catch {}
 				}
 				res.writeHead(200, {
 					"Content-Type": "text/event-stream",
@@ -310,7 +335,9 @@ export function startCuratorServer(
 				if (sseKeepalive) clearInterval(sseKeepalive);
 				sseKeepalive = setInterval(() => {
 					if (sseResponse) {
-						try { sseResponse.write(":keepalive\n\n"); } catch {}
+						try {
+							sseResponse.write(":keepalive\n\n");
+						} catch {}
 					}
 				}, 15000);
 				req.on("close", () => {
@@ -365,7 +392,10 @@ export function startCuratorServer(
 						return;
 					}
 					if (!isAvailableProvider(provider)) {
-						sendJson(res, 400, { ok: false, error: `Provider unavailable: ${provider}` });
+						sendJson(res, 400, {
+							ok: false,
+							error: `Provider unavailable: ${provider}`,
+						});
 						return;
 					}
 				}
@@ -386,7 +416,10 @@ export function startCuratorServer(
 						ok: true,
 						queryIndex: qi,
 						error: message,
-						provider: typeof provider === "string" && provider.length > 0 ? provider : undefined,
+						provider:
+							typeof provider === "string" && provider.length > 0
+								? provider
+								: undefined,
 					});
 				}
 				return;
@@ -422,9 +455,10 @@ export function startCuratorServer(
 				}
 
 				const bodyFeedback = (body as { feedback?: unknown }).feedback;
-				const feedback = typeof bodyFeedback === "string" && bodyFeedback.trim().length > 0
-					? bodyFeedback.trim()
-					: undefined;
+				const feedback =
+					typeof bodyFeedback === "string" && bodyFeedback.trim().length > 0
+						? bodyFeedback.trim()
+						: undefined;
 
 				abortInFlightSummarize();
 				const controller = new AbortController();
@@ -432,7 +466,12 @@ export function startCuratorServer(
 				const requestId = ++summarizeRequestSeq;
 
 				try {
-					const result = await callbacks.onSummarize(parsed.indices, controller.signal, model, feedback);
+					const result = await callbacks.onSummarize(
+						parsed.indices,
+						controller.signal,
+						model,
+						feedback
+					);
 					if (requestId !== summarizeRequestSeq || state === "COMPLETED") {
 						sendJson(res, 409, { ok: false, error: "Summarize request superseded" });
 						return;
@@ -443,7 +482,8 @@ export function startCuratorServer(
 						meta: result.meta,
 					});
 				} catch (err) {
-					const message = err instanceof Error ? err.message : "Summary generation failed";
+					const message =
+						err instanceof Error ? err.message : "Summary generation failed";
 					const status = controller.signal.aborted ? 409 : 500;
 					sendJson(res, status, { ok: false, error: message });
 				} finally {
@@ -471,7 +511,10 @@ export function startCuratorServer(
 				req.on("close", () => controller.abort());
 				touchHeartbeat();
 				try {
-					const rewritten = await callbacks.onRewriteQuery(query.trim(), controller.signal);
+					const rewritten = await callbacks.onRewriteQuery(
+						query.trim(),
+						controller.signal
+					);
 					sendJson(res, 200, { ok: true, query: rewritten });
 				} catch (err) {
 					const message = err instanceof Error ? err.message : "Rewrite failed";
@@ -527,7 +570,14 @@ export function startCuratorServer(
 				}
 				const rawResults = (body as { rawResults?: unknown }).rawResults === true;
 				sendJson(res, 200, { ok: true });
-				setImmediate(() => callbacks.onSubmit({ selectedQueryIndices: parsed.indices, summary, summaryMeta, rawResults }));
+				setImmediate(() =>
+					callbacks.onSubmit({
+						selectedQueryIndices: parsed.indices,
+						summary,
+						summaryMeta,
+						rawResults,
+					})
+				);
 				return;
 			}
 
@@ -581,7 +631,9 @@ export function startCuratorServer(
 				url,
 				close: () => {
 					const wasOpen = markCompleted();
-					try { server.close(); } catch {}
+					try {
+						server.close();
+					} catch {}
 					if (wasOpen) {
 						setImmediate(() => callbacks.onCancel("stale"));
 					}
@@ -592,7 +644,12 @@ export function startCuratorServer(
 				},
 				pushError: (queryIndex, error, provider) => {
 					if (completed) return;
-					sendSSE("search-error", { queryIndex, query: queries[queryIndex] ?? "", error, provider });
+					sendSSE("search-error", {
+						queryIndex,
+						query: queries[queryIndex] ?? "",
+						error,
+						provider,
+					});
 				},
 				searchesDone: () => {
 					if (completed) return;

--- a/exa.ts
+++ b/exa.ts
@@ -98,7 +98,8 @@ function normalizeUsage(raw: unknown): ExaUsage {
 	if (!raw || typeof raw !== "object") return { month, count: 0 };
 	const data = raw as { month?: unknown; count?: unknown };
 	const parsedMonth = typeof data.month === "string" ? data.month : month;
-	const parsedCount = typeof data.count === "number" && Number.isFinite(data.count) ? data.count : 0;
+	const parsedCount =
+		typeof data.count === "number" && Number.isFinite(data.count) ? data.count : 0;
 	if (parsedMonth !== month) return { month, count: 0 };
 	return { month: parsedMonth, count: Math.max(0, Math.floor(parsedCount)) };
 }
@@ -154,14 +155,17 @@ function recencyToStartDate(filter: string): string {
 	return new Date(now.getTime() - days * 86400000).toISOString();
 }
 
-function mapDomainFilter(domainFilter: string[] | undefined): { includeDomains?: string[]; excludeDomains?: string[] } {
+function mapDomainFilter(domainFilter: string[] | undefined): {
+	includeDomains?: string[];
+	excludeDomains?: string[];
+} {
 	if (!domainFilter?.length) return {};
 	const includeDomains = domainFilter
-		.filter(d => !d.startsWith("-") && d.trim().length > 0)
-		.map(d => d.trim());
+		.filter((d) => !d.startsWith("-") && d.trim().length > 0)
+		.map((d) => d.trim());
 	const excludeDomains = domainFilter
-		.filter(d => d.startsWith("-"))
-		.map(d => d.slice(1).trim())
+		.filter((d) => d.startsWith("-"))
+		.map((d) => d.slice(1).trim())
 		.filter(Boolean);
 	return {
 		...(includeDomains.length ? { includeDomains } : {}),
@@ -171,7 +175,9 @@ function mapDomainFilter(domainFilter: string[] | undefined): { includeDomains?:
 
 function normalizeHighlights(value: unknown): string[] {
 	if (!Array.isArray(value)) return [];
-	return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+	return value.filter(
+		(item): item is string => typeof item === "string" && item.trim().length > 0
+	);
 }
 
 function buildAnswerFromSearchResults(results: ExaSearchResponse["results"]): string {
@@ -181,9 +187,12 @@ function buildAnswerFromSearchResults(results: ExaSearchResponse["results"]): st
 		const item = results[i];
 		if (!item?.url) continue;
 		const highlights = normalizeHighlights(item.highlights);
-		const content = highlights.length > 0
-			? highlights.join(" ")
-			: typeof item.text === "string" ? item.text.trim().slice(0, 1000) : "";
+		const content =
+			highlights.length > 0
+				? highlights.join(" ")
+				: typeof item.text === "string"
+					? item.text.trim().slice(0, 1000)
+					: "";
 		if (!content) continue;
 		const sourceTitle = item.title || `Source ${i + 1}`;
 		parts.push(`${content}\nSource: ${sourceTitle} (${item.url})`);
@@ -191,7 +200,9 @@ function buildAnswerFromSearchResults(results: ExaSearchResponse["results"]): st
 	return parts.join("\n\n");
 }
 
-function mapResults(results: ExaSearchResponse["results"] | ExaAnswerResponse["citations"]): SearchResponse["results"] {
+function mapResults(
+	results: ExaSearchResponse["results"] | ExaAnswerResponse["citations"]
+): SearchResponse["results"] {
 	if (!Array.isArray(results)) return [];
 	const mapped: SearchResponse["results"] = [];
 	for (let i = 0; i < results.length; i++) {
@@ -209,9 +220,15 @@ function mapResults(results: ExaSearchResponse["results"] | ExaAnswerResponse["c
 function mapInlineContent(results: ExaSearchResponse["results"]): ExtractedContent[] {
 	if (!results?.length) return [];
 	return results
-		.filter((r): r is NonNullable<ExaSearchResponse["results"]>[number] & { url: string; text: string } =>
-			!!r?.url && typeof r.text === "string" && r.text.length > 0)
-		.map(r => ({
+		.filter(
+			(
+				r
+			): r is NonNullable<ExaSearchResponse["results"]>[number] & {
+				url: string;
+				text: string;
+			} => !!r?.url && typeof r.text === "string" && r.text.length > 0
+		)
+		.map((r) => ({
 			url: r.url,
 			title: r.title || "",
 			content: r.text,
@@ -222,13 +239,13 @@ function mapInlineContent(results: ExaSearchResponse["results"]): ExtractedConte
 export async function callExaMcp(
 	toolName: string,
 	args: Record<string, unknown>,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<string> {
 	const response = await fetch(EXA_MCP_URL, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
-			"Accept": "application/json, text/event-stream",
+			Accept: "application/json, text/event-stream",
 		},
 		body: JSON.stringify({
 			jsonrpc: "2.0",
@@ -248,7 +265,7 @@ export async function callExaMcp(
 	}
 
 	const body = await response.text();
-	const dataLines = body.split("\n").filter(line => line.startsWith("data:"));
+	const dataLines = body.split("\n").filter((line) => line.startsWith("data:"));
 
 	let parsed: ExaMcpRpcResponse | null = null;
 	for (const line of dataLines) {
@@ -260,8 +277,7 @@ export async function callExaMcp(
 				parsed = candidate;
 				break;
 			}
-		} catch {
-		}
+		} catch {}
 	}
 
 	if (!parsed) {
@@ -270,8 +286,7 @@ export async function callExaMcp(
 			if (candidate?.result || candidate?.error) {
 				parsed = candidate;
 			}
-		} catch {
-		}
+		} catch {}
 	}
 
 	if (!parsed) {
@@ -286,14 +301,15 @@ export async function callExaMcp(
 
 	if (parsed.result?.isError) {
 		const message = parsed.result.content
-			?.find(item => item.type === "text" && typeof item.text === "string")
+			?.find((item) => item.type === "text" && typeof item.text === "string")
 			?.text?.trim();
 		throw new Error(message || "Exa MCP returned an error");
 	}
 
-	const text = parsed.result?.content
-		?.find(item => item.type === "text" && typeof item.text === "string" && item.text.trim().length > 0)
-		?.text;
+	const text = parsed.result?.content?.find(
+		(item) =>
+			item.type === "text" && typeof item.text === "string" && item.text.trim().length > 0
+	)?.text;
 
 	if (!text) {
 		throw new Error("Exa MCP returned empty content");
@@ -303,23 +319,25 @@ export async function callExaMcp(
 }
 
 function parseMcpResults(text: string): McpParsedResult[] | null {
-	const blocks = text.split(/(?=^Title: )/m).filter(block => block.trim().length > 0);
-	const parsed = blocks.map(block => {
-		const title = block.match(/^Title: (.+)/m)?.[1]?.trim() ?? "";
-		const url = block.match(/^URL: (.+)/m)?.[1]?.trim() ?? "";
-		let content = "";
-		const textStart = block.indexOf("\nText: ");
-		if (textStart >= 0) {
-			content = block.slice(textStart + 7).trim();
-		} else {
-			const hlMatch = block.match(/\nHighlights:\s*\n/);
-			if (hlMatch?.index != null) {
-				content = block.slice(hlMatch.index + hlMatch[0].length).trim();
+	const blocks = text.split(/(?=^Title: )/m).filter((block) => block.trim().length > 0);
+	const parsed = blocks
+		.map((block) => {
+			const title = block.match(/^Title: (.+)/m)?.[1]?.trim() ?? "";
+			const url = block.match(/^URL: (.+)/m)?.[1]?.trim() ?? "";
+			let content = "";
+			const textStart = block.indexOf("\nText: ");
+			if (textStart >= 0) {
+				content = block.slice(textStart + 7).trim();
+			} else {
+				const hlMatch = block.match(/\nHighlights:\s*\n/);
+				if (hlMatch?.index != null) {
+					content = block.slice(hlMatch.index + hlMatch[0].length).trim();
+				}
 			}
-		}
-		content = content.replace(/\n---\s*$/, "").trim();
-		return { title, url, content };
-	}).filter(result => result.url.length > 0);
+			content = content.replace(/\n---\s*$/, "").trim();
+			return { title, url, content };
+		})
+		.filter((result) => result.url.length > 0);
 	return parsed.length > 0 ? parsed : null;
 }
 
@@ -338,8 +356,8 @@ function buildAnswerFromMcpResults(results: McpParsedResult[]): string {
 
 function mapMcpInlineContent(results: McpParsedResult[]): ExtractedContent[] {
 	return results
-		.filter(result => result.content.length > 0)
-		.map(result => ({
+		.filter((result) => result.content.length > 0)
+		.map((result) => ({
 			url: result.url,
 			title: result.title,
 			content: result.content,
@@ -357,16 +375,27 @@ function buildMcpQuery(query: string, options: ExaSearchOptions): string {
 	if (options.recencyFilter) {
 		const now = new Date();
 		switch (options.recencyFilter) {
-			case "day": parts.push("past 24 hours"); break;
-			case "week": parts.push("past week"); break;
-			case "month": parts.push(`${now.toLocaleString("en", { month: "long" })} ${now.getFullYear()}`); break;
-			case "year": parts.push(String(now.getFullYear())); break;
+			case "day":
+				parts.push("past 24 hours");
+				break;
+			case "week":
+				parts.push("past week");
+				break;
+			case "month":
+				parts.push(`${now.toLocaleString("en", { month: "long" })} ${now.getFullYear()}`);
+				break;
+			case "year":
+				parts.push(String(now.getFullYear()));
+				break;
 		}
 	}
 	return parts.join(" ");
 }
 
-async function searchWithExaMcp(query: string, options: ExaSearchOptions = {}): Promise<SearchResponse | null> {
+async function searchWithExaMcp(
+	query: string,
+	options: ExaSearchOptions = {}
+): Promise<SearchResponse | null> {
 	const enrichedQuery = buildMcpQuery(query, options);
 	const activityId = activityMonitor.logStart({ type: "api", query: enrichedQuery });
 
@@ -380,7 +409,7 @@ async function searchWithExaMcp(query: string, options: ExaSearchOptions = {}): 
 				type: "auto",
 				contextMaxCharacters: options.includeContent ? 50000 : 3000,
 			},
-			options.signal,
+			options.signal
 		);
 		const parsedResults = parseMcpResults(text);
 		activityMonitor.logComplete(activityId, 200);
@@ -425,7 +454,10 @@ export function hasExaApiKey(): boolean {
 	return !!getApiKey();
 }
 
-export async function searchWithExa(query: string, options: ExaSearchOptions = {}): Promise<ExaSearchResult> {
+export async function searchWithExa(
+	query: string,
+	options: ExaSearchOptions = {}
+): Promise<ExaSearchResult> {
 	const apiKey = getApiKey();
 	if (!apiKey) {
 		return searchWithExaMcp(query, options);
@@ -434,10 +466,11 @@ export async function searchWithExa(query: string, options: ExaSearchOptions = {
 	const budget = reserveRequestBudget();
 	if (budget) return budget;
 
-	const useSearch = options.includeContent
-		|| !!options.recencyFilter
-		|| !!options.domainFilter?.length
-		|| !!(options.numResults && options.numResults !== 5);
+	const useSearch =
+		options.includeContent ||
+		!!options.recencyFilter ||
+		!!options.domainFilter?.length ||
+		!!(options.numResults && options.numResults !== 5);
 
 	const activityId = activityMonitor.logStart({ type: "api", query });
 
@@ -461,7 +494,7 @@ export async function searchWithExa(query: string, options: ExaSearchOptions = {
 				throw new Error(`Exa API error ${response.status}: ${errorText.slice(0, 300)}`);
 			}
 
-			const data = await response.json() as ExaAnswerResponse;
+			const data = (await response.json()) as ExaAnswerResponse;
 			activityMonitor.logComplete(activityId, response.status);
 			return {
 				answer: data.answer || "",
@@ -496,7 +529,7 @@ export async function searchWithExa(query: string, options: ExaSearchOptions = {
 			throw new Error(`Exa API error ${response.status}: ${errorText.slice(0, 300)}`);
 		}
 
-		const data = await response.json() as ExaSearchResponse;
+		const data = (await response.json()) as ExaSearchResponse;
 		activityMonitor.logComplete(activityId, response.status);
 
 		const mapped: SearchResponse = {

--- a/extract.ts
+++ b/extract.ts
@@ -6,9 +6,21 @@ import { activityMonitor } from "./activity.js";
 import { extractRSCContent } from "./rsc-extract.js";
 import { extractPDFToMarkdown, isPDF } from "./pdf-extract.js";
 import { extractGitHub } from "./github-extract.js";
-import { isYouTubeURL, isYouTubeEnabled, extractYouTube, extractYouTubeFrame, extractYouTubeFrames, getYouTubeStreamInfo } from "./youtube-extract.js";
+import {
+	isYouTubeURL,
+	isYouTubeEnabled,
+	extractYouTube,
+	extractYouTubeFrame,
+	extractYouTubeFrames,
+	getYouTubeStreamInfo,
+} from "./youtube-extract.js";
 import { extractWithUrlContext, extractWithGeminiWeb } from "./gemini-url-context.js";
-import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } from "./video-extract.js";
+import {
+	isVideoFile,
+	extractVideo,
+	extractVideoFrame,
+	getLocalVideoDuration,
+} from "./video-extract.js";
 import { formatSeconds } from "./utils.js";
 
 const DEFAULT_TIMEOUT_MS = 30000;
@@ -88,7 +100,7 @@ const JINA_TIMEOUT_MS = 30000;
 
 async function extractWithJinaReader(
 	url: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	const jinaUrl = JINA_READER_BASE + url;
 
@@ -97,7 +109,7 @@ async function extractWithJinaReader(
 	try {
 		const res = await fetch(jinaUrl, {
 			headers: {
-				"Accept": "text/markdown",
+				Accept: "text/markdown",
 				"X-No-Cache": "true",
 			},
 			signal: AbortSignal.any([
@@ -122,13 +134,16 @@ async function extractWithJinaReader(
 		const markdownPart = content.slice(contentStart + 17).trim(); // 17 = "Markdown Content:".length
 
 		// Check for failed JS rendering or minimal content
-		if (markdownPart.length < 100 ||
+		if (
+			markdownPart.length < 100 ||
 			markdownPart.startsWith("Loading...") ||
-			markdownPart.startsWith("Please enable JavaScript")) {
+			markdownPart.startsWith("Please enable JavaScript")
+		) {
 			return null;
 		}
 
-		const title = extractHeadingTitle(markdownPart) ?? (new URL(url).pathname.split("/").pop() || url);
+		const title =
+			extractHeadingTitle(markdownPart) ?? (new URL(url).pathname.split("/").pop() || url);
 		return { url, title, content: markdownPart, error: null };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -145,13 +160,15 @@ function parseTimestamp(ts: string): number | null {
 	const num = Number(ts);
 	if (!isNaN(num) && num >= 0) return Math.floor(num);
 	const parts = ts.split(":").map(Number);
-	if (parts.some(p => isNaN(p) || p < 0)) return null;
+	if (parts.some((p) => isNaN(p) || p < 0)) return null;
 	if (parts.length === 3) return Math.floor(parts[0] * 3600 + parts[1] * 60 + parts[2]);
 	if (parts.length === 2) return Math.floor(parts[0] * 60 + parts[1]);
 	return null;
 }
 
-type TimestampSpec = { type: "single"; seconds: number } | { type: "range"; start: number; end: number };
+type TimestampSpec =
+	| { type: "single"; seconds: number }
+	| { type: "range"; start: number; end: number };
 
 function parseTimestampSpec(ts: string): TimestampSpec | null {
 	const dashIdx = ts.indexOf("-", 1);
@@ -167,7 +184,11 @@ function parseTimestampSpec(ts: string): TimestampSpec | null {
 const DEFAULT_RANGE_FRAMES = 6;
 const MIN_FRAME_INTERVAL = 5;
 
-function computeRangeTimestamps(start: number, end: number, maxFrames: number = DEFAULT_RANGE_FRAMES): number[] {
+function computeRangeTimestamps(
+	start: number,
+	end: number,
+	maxFrames: number = DEFAULT_RANGE_FRAMES
+): number[] {
 	if (maxFrames <= 1) return [start];
 	const duration = end - start;
 	const idealInterval = duration / (maxFrames - 1);
@@ -182,8 +203,12 @@ function computeRangeTimestamps(start: number, end: number, maxFrames: number = 
 }
 
 function buildFrameResult(
-	url: string, label: string, requestedCount: number,
-	frames: VideoFrame[], error: string | null, duration?: number,
+	url: string,
+	label: string,
+	requestedCount: number,
+	frames: VideoFrame[],
+	error: string | null,
+	duration?: number
 ): ExtractedContent {
 	if (frames.length === 0) {
 		const msg = error ?? "Frame extraction failed";
@@ -200,13 +225,16 @@ function buildFrameResult(
 }
 
 async function extractLocalFrames(
-	filePath: string, timestamps: number[],
+	filePath: string,
+	timestamps: number[]
 ): Promise<{ frames: VideoFrame[]; error: string | null }> {
-	const results = await Promise.all(timestamps.map(async (t) => {
-		const frame = await extractVideoFrame(filePath, t);
-		if ("error" in frame) return { error: frame.error };
-		return { ...frame, timestamp: formatSeconds(t) };
-	}));
+	const results = await Promise.all(
+		timestamps.map(async (t) => {
+			const frame = await extractVideoFrame(filePath, t);
+			if ("error" in frame) return { error: frame.error };
+			return { ...frame, timestamp: formatSeconds(t) };
+		})
+	);
 	const frames = results.filter((f): f is VideoFrame => "data" in f);
 	const firstError = results.find((f): f is { error: string } => "error" in f);
 	return { frames, error: frames.length === 0 && firstError ? firstError.error : null };
@@ -223,7 +251,7 @@ function safeVideoInfo(url: string): { info: ReturnType<typeof isVideoFile>; err
 export async function extractContent(
 	url: string,
 	signal?: AbortSignal,
-	options?: ExtractOptions,
+	options?: ExtractOptions
 ): Promise<ExtractedContent> {
 	if (signal?.aborted) {
 		return { url, title: "", content: "", error: "Aborted" };
@@ -235,7 +263,13 @@ export async function extractContent(
 		if (ytInfo.isYouTube && ytInfo.videoId) {
 			const streamInfo = await getYouTubeStreamInfo(ytInfo.videoId);
 			if ("error" in streamInfo) {
-				return { url, title: "Frames", content: streamInfo.error, error: streamInfo.error, extractionMethod: "frames" };
+				return {
+					url,
+					title: "Frames",
+					content: streamInfo.error,
+					error: streamInfo.error,
+					extractionMethod: "frames",
+				};
 			}
 			if (streamInfo.duration === null) {
 				const error = "Cannot determine video duration. Use a timestamp range instead.";
@@ -245,26 +279,63 @@ export async function extractContent(
 			const timestamps = computeRangeTimestamps(0, dur, frameCount);
 			const result = await extractYouTubeFrames(ytInfo.videoId, timestamps, streamInfo);
 			const label = `${formatSeconds(0)}-${formatSeconds(dur)}`;
-			return { ...buildFrameResult(url, label, timestamps.length, result.frames, result.error, streamInfo.duration), extractionMethod: "frames" };
+			return {
+				...buildFrameResult(
+					url,
+					label,
+					timestamps.length,
+					result.frames,
+					result.error,
+					streamInfo.duration
+				),
+				extractionMethod: "frames",
+			};
 		}
 
 		const localVideo = safeVideoInfo(url);
 		if (localVideo.error) {
-			return { url, title: "", content: "", error: localVideo.error, extractionMethod: "frames" };
+			return {
+				url,
+				title: "",
+				content: "",
+				error: localVideo.error,
+				extractionMethod: "frames",
+			};
 		}
 		if (localVideo.info) {
 			const durationResult = await getLocalVideoDuration(localVideo.info.absolutePath);
 			if (typeof durationResult !== "number") {
-				return { url, title: "Frames", content: durationResult.error, error: durationResult.error, extractionMethod: "frames" };
+				return {
+					url,
+					title: "Frames",
+					content: durationResult.error,
+					error: durationResult.error,
+					extractionMethod: "frames",
+				};
 			}
 			const dur = Math.floor(durationResult);
 			const timestamps = computeRangeTimestamps(0, dur, frameCount);
 			const result = await extractLocalFrames(localVideo.info.absolutePath, timestamps);
 			const label = `${formatSeconds(0)}-${formatSeconds(dur)}`;
-			return { ...buildFrameResult(url, label, timestamps.length, result.frames, result.error, durationResult), extractionMethod: "frames" };
+			return {
+				...buildFrameResult(
+					url,
+					label,
+					timestamps.length,
+					result.frames,
+					result.error,
+					durationResult
+				),
+				extractionMethod: "frames",
+			};
 		}
 
-		return { url, title: "", content: "", error: "Frame extraction only works with YouTube and local video files" };
+		return {
+			url,
+			title: "",
+			content: "",
+			error: "Frame extraction only works with YouTube and local video files",
+		};
 	}
 
 	if (options?.timestamp) {
@@ -285,14 +356,29 @@ export async function extractContent(
 			if ("error" in streamInfo) {
 				if (spec.type === "range") {
 					const label = `${formatSeconds(spec.start)}-${formatSeconds(spec.end)}`;
-					return { url, title: `Frames ${label}`, content: streamInfo.error, error: streamInfo.error };
+					return {
+						url,
+						title: `Frames ${label}`,
+						content: streamInfo.error,
+						error: streamInfo.error,
+					};
 				}
 				if (frameCount) {
 					const end = spec.seconds + (frameCount - 1) * MIN_FRAME_INTERVAL;
 					const label = `${formatSeconds(spec.seconds)}-${formatSeconds(end)}`;
-					return { url, title: `Frames ${label}`, content: streamInfo.error, error: streamInfo.error };
+					return {
+						url,
+						title: `Frames ${label}`,
+						content: streamInfo.error,
+						error: streamInfo.error,
+					};
 				}
-				return { url, title: `Frame at ${options.timestamp}`, content: streamInfo.error, error: streamInfo.error };
+				return {
+					url,
+					title: `Frame at ${options.timestamp}`,
+					content: streamInfo.error,
+					error: streamInfo.error,
+				};
 			}
 
 			if (spec.type === "range") {
@@ -305,7 +391,14 @@ export async function extractContent(
 					? computeRangeTimestamps(spec.start, spec.end, frameCount)
 					: computeRangeTimestamps(spec.start, spec.end);
 				const result = await extractYouTubeFrames(ytInfo.videoId, timestamps, streamInfo);
-				return buildFrameResult(url, label, timestamps.length, result.frames, result.error, result.duration ?? undefined);
+				return buildFrameResult(
+					url,
+					label,
+					timestamps.length,
+					result.frames,
+					result.error,
+					result.duration ?? undefined
+				);
 			}
 
 			if (frameCount) {
@@ -317,7 +410,14 @@ export async function extractContent(
 				}
 				const timestamps = computeRangeTimestamps(spec.seconds, end, frameCount);
 				const result = await extractYouTubeFrames(ytInfo.videoId, timestamps, streamInfo);
-				return buildFrameResult(url, label, timestamps.length, result.frames, result.error, result.duration ?? undefined);
+				return buildFrameResult(
+					url,
+					label,
+					timestamps.length,
+					result.frames,
+					result.error,
+					result.duration ?? undefined
+				);
 			}
 
 			if (streamInfo.duration !== null && spec.seconds > streamInfo.duration) {
@@ -326,9 +426,20 @@ export async function extractContent(
 			}
 			const frame = await extractYouTubeFrame(ytInfo.videoId, spec.seconds, streamInfo);
 			if ("error" in frame) {
-				return { url, title: `Frame at ${options.timestamp}`, content: frame.error, error: frame.error };
+				return {
+					url,
+					title: `Frame at ${options.timestamp}`,
+					content: frame.error,
+					error: frame.error,
+				};
 			}
-			return { url, title: `Frame at ${options.timestamp}`, content: `Video frame at ${options.timestamp}`, error: null, thumbnail: frame };
+			return {
+				url,
+				title: `Frame at ${options.timestamp}`,
+				content: `Video frame at ${options.timestamp}`,
+				error: null,
+				thumbnail: frame,
+			};
 		}
 
 		const localVideo = safeVideoInfo(url);
@@ -355,12 +466,28 @@ export async function extractContent(
 
 			const frame = await extractVideoFrame(localVideo.info.absolutePath, spec.seconds);
 			if ("error" in frame) {
-				return { url, title: `Frame at ${options.timestamp}`, content: frame.error, error: frame.error };
+				return {
+					url,
+					title: `Frame at ${options.timestamp}`,
+					content: frame.error,
+					error: frame.error,
+				};
 			}
-			return { url, title: `Frame at ${options.timestamp}`, content: `Video frame at ${options.timestamp}`, error: null, thumbnail: frame };
+			return {
+				url,
+				title: `Frame at ${options.timestamp}`,
+				content: `Video frame at ${options.timestamp}`,
+				error: null,
+				thumbnail: frame,
+			};
 		}
 
-		return { url, title: "", content: "", error: "Timestamp extraction only works with YouTube and local video files" };
+		return {
+			url,
+			title: "",
+			content: "",
+			error: "Timestamp extraction only works with YouTube and local video files",
+		};
 	}
 
 	const localVideo = safeVideoInfo(url);
@@ -380,7 +507,13 @@ export async function extractContent(
 			return { ...output, extractionMethod: "gemini-video" };
 		} catch (err) {
 			if (isAbortError(err)) return abortedResult(url);
-			return { url, title: "", content: "", error: errorMessage(err), extractionMethod: "gemini-video" };
+			return {
+				url,
+				title: "",
+				content: "",
+				error: errorMessage(err),
+				extractionMethod: "gemini-video",
+			};
 		}
 	}
 
@@ -392,13 +525,20 @@ export async function extractContent(
 
 	try {
 		const ghResult = await extractGitHub(url, signal, options?.forceClone);
-		if (ghResult) return { ...ghResult, extractionMethod: ghResult.extractionMethod ?? "github-clone" };
+		if (ghResult)
+			return { ...ghResult, extractionMethod: ghResult.extractionMethod ?? "github-clone" };
 		if (signal?.aborted) return abortedResult(url);
 	} catch (err) {
 		const message = errorMessage(err);
 		if (isAbortError(err)) return abortedResult(url);
 		if (isConfigParseError(err)) {
-			return { url, title: "", content: "", error: message, extractionMethod: "github-clone" };
+			return {
+				url,
+				title: "",
+				content: "",
+				error: message,
+				extractionMethod: "github-clone",
+			};
 		}
 	}
 
@@ -407,18 +547,34 @@ export async function extractContent(
 	try {
 		youtubeEnabled = isYouTubeEnabled();
 	} catch (err) {
-		return { url, title: "", content: "", error: errorMessage(err), extractionMethod: "gemini-youtube" };
+		return {
+			url,
+			title: "",
+			content: "",
+			error: errorMessage(err),
+			extractionMethod: "gemini-youtube",
+		};
 	}
 	if (ytInfo.isYouTube && youtubeEnabled) {
 		try {
 			const ytResult = await extractYouTube(url, signal, options?.prompt, options?.model);
-			if (ytResult) return { ...ytResult, extractionMethod: ytResult.extractionMethod ?? "gemini-youtube" };
+			if (ytResult)
+				return {
+					...ytResult,
+					extractionMethod: ytResult.extractionMethod ?? "gemini-youtube",
+				};
 			if (signal?.aborted) return abortedResult(url);
 		} catch (err) {
 			const message = errorMessage(err);
 			if (isAbortError(err)) return abortedResult(url);
 			if (isConfigParseError(err)) {
-				return { url, title: "", content: "", error: message, extractionMethod: "gemini-youtube" };
+				return {
+					url,
+					title: "",
+					content: "",
+					error: message,
+					extractionMethod: "gemini-youtube",
+				};
 			}
 		}
 		return {
@@ -436,7 +592,8 @@ export async function extractContent(
 
 	if (signal?.aborted) return abortedResult(url);
 	if (!httpResult.error) return httpResult;
-	if (NON_RECOVERABLE_ERRORS.some(prefix => httpResult.error!.startsWith(prefix))) return httpResult;
+	if (NON_RECOVERABLE_ERRORS.some((prefix) => httpResult.error!.startsWith(prefix)))
+		return httpResult;
 
 	const jinaResult = await extractWithJinaReader(url, signal);
 	if (jinaResult) return { ...jinaResult, extractionMethod: "jina" };
@@ -459,7 +616,8 @@ export async function extractContent(
 		}
 	}
 
-	if (geminiResult) return { ...geminiResult, extractionMethod: geminiResult.extractionMethod ?? geminiMethod };
+	if (geminiResult)
+		return { ...geminiResult, extractionMethod: geminiResult.extractionMethod ?? geminiMethod };
 	if (signal?.aborted) return abortedResult(url);
 
 	const guidance = [
@@ -498,7 +656,7 @@ function isLikelyJSRendered(html: string): boolean {
 async function extractViaHttp(
 	url: string,
 	signal?: AbortSignal,
-	options?: ExtractOptions,
+	options?: ExtractOptions
 ): Promise<ExtractedContent> {
 	const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	const activityId = activityMonitor.logStart({ type: "fetch", url });
@@ -513,8 +671,9 @@ async function extractViaHttp(
 		const response = await fetch(url, {
 			signal: controller.signal,
 			headers: {
-				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
-				"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+				"User-Agent":
+					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+				Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
 				"Accept-Language": "en-US,en;q=0.9",
 				"Cache-Control": "no-cache",
 				"Sec-Fetch-Dest": "document",
@@ -567,15 +726,23 @@ async function extractViaHttp(
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				activityMonitor.logError(activityId, message);
-				return { url, title: "", content: "", error: `PDF extraction failed: ${message}`, extractionMethod: "pdf" };
+				return {
+					url,
+					title: "",
+					content: "",
+					error: `PDF extraction failed: ${message}`,
+					extractionMethod: "pdf",
+				};
 			}
 		}
 
-		if (contentType.includes("application/octet-stream") ||
+		if (
+			contentType.includes("application/octet-stream") ||
 			contentType.includes("image/") ||
 			contentType.includes("audio/") ||
 			contentType.includes("video/") ||
-			contentType.includes("application/zip")) {
+			contentType.includes("application/zip")
+		) {
 			activityMonitor.logComplete(activityId, response.status);
 			return {
 				url,
@@ -586,7 +753,8 @@ async function extractViaHttp(
 		}
 
 		const text = await response.text();
-		const isHTML = contentType.includes("text/html") || contentType.includes("application/xhtml+xml");
+		const isHTML =
+			contentType.includes("text/html") || contentType.includes("application/xhtml+xml");
 
 		if (!isHTML) {
 			activityMonitor.logComplete(activityId, response.status);
@@ -602,7 +770,13 @@ async function extractViaHttp(
 			const rscResult = extractRSCContent(text);
 			if (rscResult) {
 				activityMonitor.logComplete(activityId, response.status);
-				return { url, title: rscResult.title, content: rscResult.content, error: null, extractionMethod: "rsc" };
+				return {
+					url,
+					title: rscResult.title,
+					content: rscResult.content,
+					error: null,
+					extractionMethod: "rsc",
+				};
 			}
 
 			activityMonitor.logComplete(activityId, response.status);
@@ -636,7 +810,13 @@ async function extractViaHttp(
 			};
 		}
 
-		return { url, title: article.title || "", content: markdown, error: null, extractionMethod: "readability" };
+		return {
+			url,
+			title: article.title || "",
+			content: markdown,
+			error: null,
+			extractionMethod: "readability",
+		};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		if (message.toLowerCase().includes("abort")) {
@@ -665,7 +845,7 @@ function extractTextTitle(text: string, url: string): string {
 export async function fetchAllContent(
 	urls: string[],
 	signal?: AbortSignal,
-	options?: ExtractOptions,
+	options?: ExtractOptions
 ): Promise<ExtractedContent[]> {
 	return Promise.all(urls.map((url) => fetchLimit(() => extractContent(url, signal, options))));
 }

--- a/extract.ts
+++ b/extract.ts
@@ -49,11 +49,26 @@ export interface VideoFrame {
 export type FrameData = { data: string; mimeType: string };
 export type FrameResult = FrameData | { error: string };
 
+export type ExtractionMethod =
+	| "readability"
+	| "text"
+	| "rsc"
+	| "pdf"
+	| "jina"
+	| "gemini-url-context"
+	| "gemini-web"
+	| "github-clone"
+	| "github-api"
+	| "gemini-video"
+	| "gemini-youtube"
+	| "frames";
+
 export interface ExtractedContent {
 	url: string;
 	title: string;
 	content: string;
 	error: string | null;
+	extractionMethod?: ExtractionMethod;
 	thumbnail?: { data: string; mimeType: string };
 	frames?: VideoFrame[];
 	duration?: number;
@@ -220,33 +235,33 @@ export async function extractContent(
 		if (ytInfo.isYouTube && ytInfo.videoId) {
 			const streamInfo = await getYouTubeStreamInfo(ytInfo.videoId);
 			if ("error" in streamInfo) {
-				return { url, title: "Frames", content: streamInfo.error, error: streamInfo.error };
+				return { url, title: "Frames", content: streamInfo.error, error: streamInfo.error, extractionMethod: "frames" };
 			}
 			if (streamInfo.duration === null) {
 				const error = "Cannot determine video duration. Use a timestamp range instead.";
-				return { url, title: "Frames", content: error, error };
+				return { url, title: "Frames", content: error, error, extractionMethod: "frames" };
 			}
 			const dur = Math.floor(streamInfo.duration);
 			const timestamps = computeRangeTimestamps(0, dur, frameCount);
 			const result = await extractYouTubeFrames(ytInfo.videoId, timestamps, streamInfo);
 			const label = `${formatSeconds(0)}-${formatSeconds(dur)}`;
-			return buildFrameResult(url, label, timestamps.length, result.frames, result.error, streamInfo.duration);
+			return { ...buildFrameResult(url, label, timestamps.length, result.frames, result.error, streamInfo.duration), extractionMethod: "frames" };
 		}
 
 		const localVideo = safeVideoInfo(url);
 		if (localVideo.error) {
-			return { url, title: "", content: "", error: localVideo.error };
+			return { url, title: "", content: "", error: localVideo.error, extractionMethod: "frames" };
 		}
 		if (localVideo.info) {
 			const durationResult = await getLocalVideoDuration(localVideo.info.absolutePath);
 			if (typeof durationResult !== "number") {
-				return { url, title: "Frames", content: durationResult.error, error: durationResult.error };
+				return { url, title: "Frames", content: durationResult.error, error: durationResult.error, extractionMethod: "frames" };
 			}
 			const dur = Math.floor(durationResult);
 			const timestamps = computeRangeTimestamps(0, dur, frameCount);
 			const result = await extractLocalFrames(localVideo.info.absolutePath, timestamps);
 			const label = `${formatSeconds(0)}-${formatSeconds(dur)}`;
-			return buildFrameResult(url, label, timestamps.length, result.frames, result.error, durationResult);
+			return { ...buildFrameResult(url, label, timestamps.length, result.frames, result.error, durationResult), extractionMethod: "frames" };
 		}
 
 		return { url, title: "", content: "", error: "Frame extraction only works with YouTube and local video files" };
@@ -356,10 +371,16 @@ export async function extractContent(
 		try {
 			const result = await extractVideo(localVideo.info, signal, options);
 			if (signal?.aborted) return abortedResult(url);
-			return result ?? { url, title: "", content: "", error: "Video analysis requires Gemini access. Either:\n  1. Sign into gemini.google.com in Chrome (free, uses cookies)\n  2. Set GEMINI_API_KEY in ~/.pi/web-search.json" };
+			const output = result ?? {
+				url,
+				title: "",
+				content: "",
+				error: "Video analysis requires Gemini access. Either:\n  1. Sign into gemini.google.com in Chrome (free, uses cookies)\n  2. Set GEMINI_API_KEY in ~/.pi/web-search.json",
+			};
+			return { ...output, extractionMethod: "gemini-video" };
 		} catch (err) {
 			if (isAbortError(err)) return abortedResult(url);
-			return { url, title: "", content: "", error: errorMessage(err) };
+			return { url, title: "", content: "", error: errorMessage(err), extractionMethod: "gemini-video" };
 		}
 	}
 
@@ -371,13 +392,13 @@ export async function extractContent(
 
 	try {
 		const ghResult = await extractGitHub(url, signal, options?.forceClone);
-		if (ghResult) return ghResult;
+		if (ghResult) return { ...ghResult, extractionMethod: ghResult.extractionMethod ?? "github-clone" };
 		if (signal?.aborted) return abortedResult(url);
 	} catch (err) {
 		const message = errorMessage(err);
 		if (isAbortError(err)) return abortedResult(url);
 		if (isConfigParseError(err)) {
-			return { url, title: "", content: "", error: message };
+			return { url, title: "", content: "", error: message, extractionMethod: "github-clone" };
 		}
 	}
 
@@ -386,18 +407,18 @@ export async function extractContent(
 	try {
 		youtubeEnabled = isYouTubeEnabled();
 	} catch (err) {
-		return { url, title: "", content: "", error: errorMessage(err) };
+		return { url, title: "", content: "", error: errorMessage(err), extractionMethod: "gemini-youtube" };
 	}
 	if (ytInfo.isYouTube && youtubeEnabled) {
 		try {
 			const ytResult = await extractYouTube(url, signal, options?.prompt, options?.model);
-			if (ytResult) return ytResult;
+			if (ytResult) return { ...ytResult, extractionMethod: ytResult.extractionMethod ?? "gemini-youtube" };
 			if (signal?.aborted) return abortedResult(url);
 		} catch (err) {
 			const message = errorMessage(err);
 			if (isAbortError(err)) return abortedResult(url);
 			if (isConfigParseError(err)) {
-				return { url, title: "", content: "", error: message };
+				return { url, title: "", content: "", error: message, extractionMethod: "gemini-youtube" };
 			}
 		}
 		return {
@@ -405,6 +426,7 @@ export async function extractContent(
 			title: "",
 			content: "",
 			error: "Could not extract YouTube video content. Sign into Google in Chrome for automatic access, or set GEMINI_API_KEY.",
+			extractionMethod: "gemini-youtube",
 		};
 	}
 
@@ -417,13 +439,19 @@ export async function extractContent(
 	if (NON_RECOVERABLE_ERRORS.some(prefix => httpResult.error!.startsWith(prefix))) return httpResult;
 
 	const jinaResult = await extractWithJinaReader(url, signal);
-	if (jinaResult) return jinaResult;
+	if (jinaResult) return { ...jinaResult, extractionMethod: "jina" };
 	if (signal?.aborted) return abortedResult(url);
 
 	let geminiResult: ExtractedContent | null = null;
+	let geminiMethod: ExtractionMethod = "gemini-web";
 	try {
-		geminiResult = await extractWithUrlContext(url, signal)
-			?? await extractWithGeminiWeb(url, signal);
+		const urlContext = await extractWithUrlContext(url, signal);
+		if (urlContext) {
+			geminiResult = urlContext;
+			geminiMethod = "gemini-url-context";
+		} else {
+			geminiResult = await extractWithGeminiWeb(url, signal);
+		}
 	} catch (err) {
 		if (isAbortError(err)) return abortedResult(url);
 		if (isConfigParseError(err)) {
@@ -431,7 +459,7 @@ export async function extractContent(
 		}
 	}
 
-	if (geminiResult) return geminiResult;
+	if (geminiResult) return { ...geminiResult, extractionMethod: geminiResult.extractionMethod ?? geminiMethod };
 	if (signal?.aborted) return abortedResult(url);
 
 	const guidance = [
@@ -534,11 +562,12 @@ async function extractViaHttp(
 					title: result.title,
 					content: `PDF extracted and saved to: ${result.outputPath}\n\nPages: ${result.pages}\nCharacters: ${result.chars}`,
 					error: null,
+					extractionMethod: "pdf",
 				};
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				activityMonitor.logError(activityId, message);
-				return { url, title: "", content: "", error: `PDF extraction failed: ${message}` };
+				return { url, title: "", content: "", error: `PDF extraction failed: ${message}`, extractionMethod: "pdf" };
 			}
 		}
 
@@ -562,7 +591,7 @@ async function extractViaHttp(
 		if (!isHTML) {
 			activityMonitor.logComplete(activityId, response.status);
 			const title = extractTextTitle(text, url);
-			return { url, title, content: text, error: null };
+			return { url, title, content: text, error: null, extractionMethod: "text" };
 		}
 
 		const { document } = parseHTML(text);
@@ -573,7 +602,7 @@ async function extractViaHttp(
 			const rscResult = extractRSCContent(text);
 			if (rscResult) {
 				activityMonitor.logComplete(activityId, response.status);
-				return { url, title: rscResult.title, content: rscResult.content, error: null };
+				return { url, title: rscResult.title, content: rscResult.content, error: null, extractionMethod: "rsc" };
 			}
 
 			activityMonitor.logComplete(activityId, response.status);
@@ -603,10 +632,11 @@ async function extractViaHttp(
 				error: isLikelyJSRendered(text)
 					? "Page appears to be JavaScript-rendered (content loads dynamically)"
 					: "Extracted content appears incomplete",
+				extractionMethod: "readability",
 			};
 		}
 
-		return { url, title: article.title || "", content: markdown, error: null };
+		return { url, title: article.title || "", content: markdown, error: null, extractionMethod: "readability" };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		if (message.toLowerCase().includes("abort")) {

--- a/gemini-api.ts
+++ b/gemini-api.ts
@@ -41,7 +41,9 @@ function normalizeApiKey(value: unknown): string | null {
 }
 
 export function getApiKey(): string | null {
-	return normalizeApiKey(process.env.GEMINI_API_KEY) ?? normalizeApiKey(loadConfig().geminiApiKey);
+	return (
+		normalizeApiKey(process.env.GEMINI_API_KEY) ?? normalizeApiKey(loadConfig().geminiApiKey)
+	);
 }
 
 export function isGeminiApiAvailable(): boolean {
@@ -58,7 +60,7 @@ export interface GeminiApiOptions {
 export async function queryGeminiApiWithVideo(
 	prompt: string,
 	videoUri: string,
-	options: GeminiApiOptions = {},
+	options: GeminiApiOptions = {}
 ): Promise<string> {
 	const apiKey = getApiKey();
 	if (!apiKey) throw new Error("GEMINI_API_KEY not configured");
@@ -73,10 +75,7 @@ export async function queryGeminiApiWithVideo(
 	const body = {
 		contents: [
 			{
-				parts: [
-					{ fileData },
-					{ text: prompt },
-				],
+				parts: [{ fileData }, { text: prompt }],
 			},
 		],
 	};

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -4,7 +4,13 @@ import { join } from "node:path";
 import { activityMonitor } from "./activity.js";
 import { getApiKey, isGeminiApiAvailable, API_BASE, DEFAULT_MODEL } from "./gemini-api.js";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.js";
-import { isPerplexityAvailable, searchWithPerplexity, type SearchResult, type SearchResponse, type SearchOptions } from "./perplexity.js";
+import {
+	isPerplexityAvailable,
+	searchWithPerplexity,
+	type SearchResult,
+	type SearchResponse,
+	type SearchOptions,
+} from "./perplexity.js";
 import { hasExaApiKey, isExaAvailable, searchWithExa } from "./exa.js";
 
 export type SearchProvider = "auto" | "perplexity" | "gemini" | "exa";
@@ -57,7 +63,10 @@ function normalizeSearchModel(value: unknown): string | undefined {
 
 function normalizeSearchProvider(value: unknown): SearchProvider {
 	const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-	return normalized === "auto" || normalized === "perplexity" || normalized === "gemini" || normalized === "exa"
+	return normalized === "auto" ||
+		normalized === "perplexity" ||
+		normalized === "gemini" ||
+		normalized === "exa"
 		? normalized
 		: "auto";
 }
@@ -78,7 +87,7 @@ function isAbortError(err: unknown): boolean {
 async function searchWithGemini(
 	query: string,
 	options: SearchOptions,
-	strictErrors: boolean,
+	strictErrors: boolean
 ): Promise<SearchResponse | null> {
 	const errors: string[] = [];
 
@@ -105,7 +114,10 @@ async function searchWithGemini(
 	return null;
 }
 
-export async function search(query: string, options: FullSearchOptions = {}): Promise<AttributedSearchResponse> {
+export async function search(
+	query: string,
+	options: FullSearchOptions = {}
+): Promise<AttributedSearchResponse> {
 	const config = getSearchConfig();
 	const provider = options.provider ?? config.searchProvider;
 
@@ -119,8 +131,8 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		if (result) return { ...result, provider: "gemini" };
 		throw new Error(
 			"Gemini search unavailable. Either:\n" +
-			"  1. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
-			"  2. Sign into gemini.google.com in a supported Chromium-based browser"
+				"  1. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
+				"  2. Sign into gemini.google.com in a supported Chromium-based browser"
 		);
 	}
 
@@ -131,7 +143,7 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 			if (result && "exhausted" in result) {
 				throw new Error(
 					"Exa monthly free tier exhausted (1,000 requests). Resets next month.\n" +
-					"  Use provider: 'perplexity' or 'gemini', or upgrade at exa.ai/pricing"
+						"  Use provider: 'perplexity' or 'gemini', or upgrade at exa.ai/pricing"
 				);
 			}
 			if (result && "answer" in result) return { ...result, provider: "exa" };
@@ -207,14 +219,17 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 
 	throw new Error(
 		"No search provider available. Either:\n" +
-		"  1. Set perplexityApiKey in ~/.pi/web-search.json\n" +
-		"  2. Set EXA_API_KEY (or exaApiKey) in ~/.pi/web-search.json\n" +
-		"  3. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
-		"  4. Sign into gemini.google.com in a supported Chromium-based browser"
+			"  1. Set perplexityApiKey in ~/.pi/web-search.json\n" +
+			"  2. Set EXA_API_KEY (or exaApiKey) in ~/.pi/web-search.json\n" +
+			"  3. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
+			"  4. Sign into gemini.google.com in a supported Chromium-based browser"
 	);
 }
 
-async function searchWithGeminiApi(query: string, options: SearchOptions = {}): Promise<SearchResponse | null> {
+async function searchWithGeminiApi(
+	query: string,
+	options: SearchOptions = {}
+): Promise<SearchResponse | null> {
 	const apiKey = getApiKey();
 	if (!apiKey) return null;
 
@@ -242,11 +257,14 @@ async function searchWithGeminiApi(query: string, options: SearchOptions = {}): 
 			throw new Error(`Gemini API error ${res.status}: ${errorText.slice(0, 300)}`);
 		}
 
-		const data = await res.json() as GeminiSearchResponse;
+		const data = (await res.json()) as GeminiSearchResponse;
 		activityMonitor.logComplete(activityId, res.status);
 
-		const answer = data.candidates?.[0]?.content?.parts
-			?.map(p => p.text).filter(Boolean).join("\n") ?? "";
+		const answer =
+			data.candidates?.[0]?.content?.parts
+				?.map((p) => p.text)
+				.filter(Boolean)
+				.join("\n") ?? "";
 
 		const metadata = data.candidates?.[0]?.groundingMetadata;
 		const chunks = metadata?.groundingChunks ?? [];
@@ -270,7 +288,10 @@ async function searchWithGeminiApi(query: string, options: SearchOptions = {}): 
 	}
 }
 
-async function searchWithGeminiWeb(query: string, options: SearchOptions = {}): Promise<SearchResponse | null> {
+async function searchWithGeminiWeb(
+	query: string,
+	options: SearchOptions = {}
+): Promise<SearchResponse | null> {
 	const cookies = await isGeminiWebAvailable();
 	if (!cookies) return null;
 
@@ -313,8 +334,10 @@ function buildSearchPrompt(query: string, options: SearchOptions): string {
 	}
 
 	if (options.domainFilter?.length) {
-		const includes = options.domainFilter.filter(d => !d.startsWith("-"));
-		const excludes = options.domainFilter.filter(d => d.startsWith("-")).map(d => d.slice(1));
+		const includes = options.domainFilter.filter((d) => !d.startsWith("-"));
+		const excludes = options.domainFilter
+			.filter((d) => d.startsWith("-"))
+			.map((d) => d.slice(1));
 		if (includes.length) prompt += `\n\nOnly cite sources from: ${includes.join(", ")}`;
 		if (excludes.length) prompt += `\n\nDo not cite sources from: ${excludes.join(", ")}`;
 	}
@@ -337,7 +360,7 @@ function extractSourceUrls(markdown: string): SearchResult[] {
 
 async function resolveGroundingChunks(
 	chunks: GroundingChunk[] | undefined,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<SearchResult[]> {
 	if (!chunks?.length) return [];
 
@@ -362,10 +385,7 @@ async function resolveRedirect(proxyUrl: string, signal?: AbortSignal): Promise<
 		const res = await fetch(proxyUrl, {
 			method: "HEAD",
 			redirect: "manual",
-			signal: AbortSignal.any([
-				AbortSignal.timeout(5000),
-				...(signal ? [signal] : []),
-			]),
+			signal: AbortSignal.any([AbortSignal.timeout(5000), ...(signal ? [signal] : [])]),
 		});
 		return res.headers.get("location") || null;
 	} catch {

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { activityMonitor } from "./activity.js";
-import { getApiKey, API_BASE, DEFAULT_MODEL } from "./gemini-api.js";
+import { getApiKey, isGeminiApiAvailable, API_BASE, DEFAULT_MODEL } from "./gemini-api.js";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.js";
 import { isPerplexityAvailable, searchWithPerplexity, type SearchResult, type SearchResponse, type SearchOptions } from "./perplexity.js";
 import { hasExaApiKey, isExaAvailable, searchWithExa } from "./exa.js";
@@ -146,9 +146,11 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	// Auto provider: prefer providers with API keys, then MCP/cookie fallbacks
 	const fallbackErrors: string[] = [];
 
-	if (provider !== "exa" && isExaAvailable()) {
+	// 1. Providers with API keys (budget-conscious)
+	if (hasExaApiKey()) {
 		try {
 			const result = await searchWithExa(query, options);
 			if (result && "answer" in result) return { ...result, provider: "exa" };
@@ -168,12 +170,35 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
-	try {
-		const geminiResult = await searchWithGemini(query, options, false);
-		if (geminiResult) return { ...geminiResult, provider: "gemini" };
-	} catch (err) {
-		if (isAbortError(err)) throw err;
-		fallbackErrors.push(`Gemini: ${errorMessage(err)}`);
+	if (isGeminiApiAvailable()) {
+		try {
+			const geminiResult = await searchWithGemini(query, options, false);
+			if (geminiResult) return { ...geminiResult, provider: "gemini" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Gemini: ${errorMessage(err)}`);
+		}
+	}
+
+	// 2. MCP/cookie fallbacks (no per-user budget)
+	if (!hasExaApiKey() && isExaAvailable()) {
+		try {
+			const result = await searchWithExa(query, options);
+			if (result && "answer" in result) return { ...result, provider: "exa" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Exa: ${errorMessage(err)}`);
+		}
+	}
+
+	if (!isGeminiApiAvailable()) {
+		try {
+			const geminiResult = await searchWithGemini(query, options, false);
+			if (geminiResult) return { ...geminiResult, provider: "gemini" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Gemini: ${errorMessage(err)}`);
+		}
 	}
 
 	if (fallbackErrors.length > 0) {
@@ -224,7 +249,13 @@ async function searchWithGeminiApi(query: string, options: SearchOptions = {}): 
 			?.map(p => p.text).filter(Boolean).join("\n") ?? "";
 
 		const metadata = data.candidates?.[0]?.groundingMetadata;
-		const results = await resolveGroundingChunks(metadata?.groundingChunks, options.signal);
+		const chunks = metadata?.groundingChunks ?? [];
+		let results = await resolveGroundingChunks(chunks, options.signal);
+
+		// Fallback: extract URLs from answer text if grounding chunks are empty
+		if (results.length === 0 && answer) {
+			results = extractSourceUrls(answer);
+		}
 
 		if (!answer && results.length === 0) return null;
 		return { answer, results };

--- a/gemini-url-context.ts
+++ b/gemini-url-context.ts
@@ -16,7 +16,7 @@ function shouldRethrow(err: unknown): boolean {
 
 export async function extractWithUrlContext(
 	url: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	const apiKey = getApiKey();
 	if (!apiKey) return null;
@@ -34,10 +34,7 @@ export async function extractWithUrlContext(
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(body),
-			signal: AbortSignal.any([
-				AbortSignal.timeout(60000),
-				...(signal ? [signal] : []),
-			]),
+			signal: AbortSignal.any([AbortSignal.timeout(60000), ...(signal ? [signal] : [])]),
 		});
 
 		if (!res.ok) {
@@ -45,19 +42,25 @@ export async function extractWithUrlContext(
 			return null;
 		}
 
-		const data = await res.json() as UrlContextResponse;
+		const data = (await res.json()) as UrlContextResponse;
 		activityMonitor.logComplete(activityId, res.status);
 
 		const metadata = data.candidates?.[0]?.url_context_metadata;
 		if (metadata?.url_metadata?.length) {
 			const status = metadata.url_metadata[0].url_retrieval_status;
-			if (status === "URL_RETRIEVAL_STATUS_UNSAFE" || status === "URL_RETRIEVAL_STATUS_ERROR") {
+			if (
+				status === "URL_RETRIEVAL_STATUS_UNSAFE" ||
+				status === "URL_RETRIEVAL_STATUS_ERROR"
+			) {
 				return null;
 			}
 		}
 
-		const content = data.candidates?.[0]?.content?.parts
-			?.map(p => p.text).filter(Boolean).join("\n") ?? "";
+		const content =
+			data.candidates?.[0]?.content?.parts
+				?.map((p) => p.text)
+				.filter(Boolean)
+				.join("\n") ?? "";
 
 		if (!content || content.length < 50) return null;
 
@@ -77,7 +80,7 @@ export async function extractWithUrlContext(
 
 export async function extractWithGeminiWeb(
 	url: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	const cookies = await isGeminiWebAvailable();
 	if (!cookies) return null;

--- a/gemini-web-config.ts
+++ b/gemini-web-config.ts
@@ -45,7 +45,10 @@ export function getChromeProfileFromConfig(): string | undefined {
 }
 
 export function isBrowserCookieAccessAllowed(): boolean {
-	if (process.env.PI_ALLOW_BROWSER_COOKIES === "1" || process.env.FEYNMAN_ALLOW_BROWSER_COOKIES === "1") {
+	if (
+		process.env.PI_ALLOW_BROWSER_COOKIES === "1" ||
+		process.env.FEYNMAN_ALLOW_BROWSER_COOKIES === "1"
+	) {
 		return true;
 	}
 	return loadConfig().allowBrowserCookies === true;

--- a/gemini-web.ts
+++ b/gemini-web.ts
@@ -1,6 +1,10 @@
 import { basename } from "node:path";
 import { type CookieMap, getGoogleCookies } from "./chrome-cookies.js";
-import { getChromeProfileFromConfig, isBrowserCookieAccessAllowed, normalizeChromeProfile } from "./gemini-web-config.ts";
+import {
+	getChromeProfileFromConfig,
+	isBrowserCookieAccessAllowed,
+	normalizeChromeProfile,
+} from "./gemini-web-config.ts";
 
 const GEMINI_APP_URL = "https://gemini.google.com/app";
 const GEMINI_STREAM_GENERATE_URL =
@@ -50,19 +54,18 @@ export async function getActiveGoogleEmail(cookies: CookieMap): Promise<string |
 			GEMINI_APP_URL,
 			cookieHeader,
 			10,
-			AbortSignal.timeout(10000),
+			AbortSignal.timeout(10000)
 		);
 		const email = extractEmailFromGeminiHtml(html);
 		if (email) return email;
-	} catch {
-	}
+	} catch {}
 
 	try {
 		const response = await fetchWithCookieRedirects(
 			GOOGLE_LIST_ACCOUNTS_URL,
 			cookieHeader,
 			10,
-			AbortSignal.timeout(10000),
+			AbortSignal.timeout(10000)
 		);
 		return extractEmailFromListAccounts(response);
 	} catch {
@@ -73,9 +76,10 @@ export async function getActiveGoogleEmail(cookies: CookieMap): Promise<string |
 export async function queryWithCookies(
 	prompt: string,
 	cookieMap: CookieMap,
-	options: GeminiWebOptions = {},
+	options: GeminiWebOptions = {}
 ): Promise<string> {
-	const model = options.model && MODEL_HEADERS[options.model] ? options.model : "gemini-2.5-flash";
+	const model =
+		options.model && MODEL_HEADERS[options.model] ? options.model : "gemini-2.5-flash";
 	const timeoutMs = options.timeoutMs ?? 120000;
 
 	let fullPrompt = prompt;
@@ -83,10 +87,24 @@ export async function queryWithCookies(
 		fullPrompt = `${fullPrompt}\n\nYouTube video: ${options.youtubeUrl}`;
 	}
 
-	const result = await runGeminiWebOnce(fullPrompt, cookieMap, model, options.files, timeoutMs, options.signal);
+	const result = await runGeminiWebOnce(
+		fullPrompt,
+		cookieMap,
+		model,
+		options.files,
+		timeoutMs,
+		options.signal
+	);
 
 	if (isModelUnavailable(result.errorCode) && model !== "gemini-2.5-flash") {
-		const fallback = await runGeminiWebOnce(fullPrompt, cookieMap, "gemini-2.5-flash", options.files, timeoutMs, options.signal);
+		const fallback = await runGeminiWebOnce(
+			fullPrompt,
+			cookieMap,
+			"gemini-2.5-flash",
+			options.files,
+			timeoutMs,
+			options.signal
+		);
 		if (fallback.errorMessage) throw new Error(fallback.errorMessage);
 		if (!fallback.text) throw new Error("Gemini Web returned empty response (fallback model)");
 		return fallback.text;
@@ -109,7 +127,7 @@ async function runGeminiWebOnce(
 	model: string,
 	files: string[] | undefined,
 	timeoutMs: number,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<GeminiWebResult> {
 	const effectiveSignal = withTimeout(signal, timeoutMs);
 	const cookieHeader = buildCookieHeader(cookieMap);
@@ -156,8 +174,7 @@ async function runGeminiWebOnce(
 		try {
 			const json = JSON.parse(trimJsonEnvelope(rawText));
 			errorCode = extractErrorCode(json);
-		} catch {
-		}
+		} catch {}
 		return {
 			text: "",
 			errorCode,
@@ -166,10 +183,7 @@ async function runGeminiWebOnce(
 	}
 }
 
-async function fetchAccessToken(
-	cookieHeader: string,
-	signal: AbortSignal,
-): Promise<string> {
+async function fetchAccessToken(cookieHeader: string, signal: AbortSignal): Promise<string> {
 	const html = await fetchWithCookieRedirects(GEMINI_APP_URL, cookieHeader, 10, signal);
 
 	for (const key of ["SNlM0e", "thykhd"]) {
@@ -177,14 +191,16 @@ async function fetchAccessToken(
 		if (match?.[1]) return match[1];
 	}
 
-	throw new Error("Unable to authenticate with Gemini. Make sure you're signed into gemini.google.com in a supported Chromium-based browser.");
+	throw new Error(
+		"Unable to authenticate with Gemini. Make sure you're signed into gemini.google.com in a supported Chromium-based browser."
+	);
 }
 
 async function fetchWithCookieRedirects(
 	url: string,
 	cookieHeader: string,
 	maxRedirects: number,
-	signal: AbortSignal,
+	signal: AbortSignal
 ): Promise<string> {
 	let current = url;
 	for (let i = 0; i <= maxRedirects; i++) {
@@ -268,14 +284,14 @@ function decodeEmailEscapes(value: string): string {
 		.replace(/\\x40/gi, "@")
 		.replace(/&#64;/gi, "@")
 		.replace(/&commat;/gi, "@")
-		.replace(/\\"/g, "\"")
+		.replace(/\\"/g, '"')
 		.replace(/\\\\/g, "\\");
 }
 
 async function uploadFile(
 	filePath: string,
 	cookieHeader: string,
-	signal: AbortSignal,
+	signal: AbortSignal
 ): Promise<{ id: string; name: string }> {
 	const data = readFileSync(filePath);
 	const fileName = basename(filePath);
@@ -283,11 +299,7 @@ async function uploadFile(
 	const header = `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${fileName}"\r\nContent-Type: application/octet-stream\r\n\r\n`;
 	const footer = `\r\n--${boundary}--\r\n`;
 
-	const body = Buffer.concat([
-		Buffer.from(header, "utf-8"),
-		data,
-		Buffer.from(footer, "utf-8"),
-	]);
+	const body = Buffer.concat([Buffer.from(header, "utf-8"), data, Buffer.from(footer, "utf-8")]);
 
 	const res = await fetch(GEMINI_UPLOAD_URL, {
 		method: "POST",
@@ -309,14 +321,9 @@ async function uploadFile(
 	return { id: await res.text(), name: fileName };
 }
 
-function buildFReqPayload(
-	prompt: string,
-	uploaded: Array<{ id: string; name: string }>,
-): string {
+function buildFReqPayload(prompt: string, uploaded: Array<{ id: string; name: string }>): string {
 	const promptPayload =
-		uploaded.length > 0
-			? [prompt, 0, null, uploaded.map((file) => [[file.id, 1]])]
-			: [prompt];
+		uploaded.length > 0 ? [prompt, 0, null, uploaded.map((file) => [[file.id, 1]])] : [prompt];
 	const innerList = [promptPayload, null, null];
 	return JSON.stringify([null, JSON.stringify(innerList)]);
 }
@@ -378,12 +385,13 @@ function parseStreamGenerateResponse(rawText: string): GeminiWebResult {
 				body = parsed;
 				break;
 			}
-		} catch {
-		}
+		} catch {}
 	}
 
 	const candidateList = getNestedValue(body, [4]);
-	const firstCandidate = Array.isArray(candidateList) ? (candidateList as unknown[])[0] : undefined;
+	const firstCandidate = Array.isArray(candidateList)
+		? (candidateList as unknown[])[0]
+		: undefined;
 	const textRaw = getNestedValue(firstCandidate, [1, 0]) as string | undefined;
 
 	let text = textRaw ?? "";

--- a/github-api.ts
+++ b/github-api.ts
@@ -22,7 +22,9 @@ export async function checkGhAvailable(): Promise<boolean> {
 export function showGhHint(): void {
 	if (!ghHintShown) {
 		ghHintShown = true;
-		console.error("[pi-web-access] Install `gh` CLI for better GitHub repo access including private repos.");
+		console.error(
+			"[pi-web-access] Install `gh` CLI for better GitHub repo access including private repos."
+		);
 	}
 }
 
@@ -30,14 +32,19 @@ export async function checkRepoSize(owner: string, repo: string): Promise<number
 	if (!(await checkGhAvailable())) return null;
 
 	return new Promise((resolve) => {
-		execFile("gh", ["api", `repos/${owner}/${repo}`, "--jq", ".size"], { timeout: 10000 }, (err, stdout) => {
-			if (err) {
-				resolve(null);
-				return;
+		execFile(
+			"gh",
+			["api", `repos/${owner}/${repo}`, "--jq", ".size"],
+			{ timeout: 10000 },
+			(err, stdout) => {
+				if (err) {
+					resolve(null);
+					return;
+				}
+				const kb = parseInt(stdout.trim(), 10);
+				resolve(Number.isNaN(kb) ? null : kb);
 			}
-			const kb = parseInt(stdout.trim(), 10);
-			resolve(Number.isNaN(kb) ? null : kb);
-		});
+		);
 	});
 }
 
@@ -45,14 +52,19 @@ async function getDefaultBranch(owner: string, repo: string): Promise<string | n
 	if (!(await checkGhAvailable())) return null;
 
 	return new Promise((resolve) => {
-		execFile("gh", ["api", `repos/${owner}/${repo}`, "--jq", ".default_branch"], { timeout: 10000 }, (err, stdout) => {
-			if (err) {
-				resolve(null);
-				return;
+		execFile(
+			"gh",
+			["api", `repos/${owner}/${repo}`, "--jq", ".default_branch"],
+			{ timeout: 10000 },
+			(err, stdout) => {
+				if (err) {
+					resolve(null);
+					return;
+				}
+				const branch = stdout.trim();
+				resolve(branch || null);
 			}
-			const branch = stdout.trim();
-			resolve(branch || null);
-		});
+		);
 	});
 }
 
@@ -77,7 +89,7 @@ async function fetchTreeViaApi(owner: string, repo: string, ref: string): Promis
 				const truncated = paths.length > MAX_TREE_ENTRIES;
 				const display = paths.slice(0, MAX_TREE_ENTRIES).join("\n");
 				resolve(truncated ? display + `\n... (${paths.length} total entries)` : display);
-			},
+			}
 		);
 	});
 }
@@ -97,16 +109,25 @@ async function fetchReadmeViaApi(owner: string, repo: string, ref: string): Prom
 				}
 				try {
 					const decoded = Buffer.from(stdout.trim(), "base64").toString("utf-8");
-					resolve(decoded.length > 8192 ? decoded.slice(0, 8192) + "\n\n[README truncated at 8K chars]" : decoded);
+					resolve(
+						decoded.length > 8192
+							? decoded.slice(0, 8192) + "\n\n[README truncated at 8K chars]"
+							: decoded
+					);
 				} catch {
 					resolve(null);
 				}
-			},
+			}
 		);
 	});
 }
 
-async function fetchFileViaApi(owner: string, repo: string, path: string, ref: string): Promise<string | null> {
+async function fetchFileViaApi(
+	owner: string,
+	repo: string,
+	path: string,
+	ref: string
+): Promise<string | null> {
 	if (!(await checkGhAvailable())) return null;
 
 	return new Promise((resolve) => {
@@ -124,7 +145,7 @@ async function fetchFileViaApi(owner: string, repo: string, path: string, ref: s
 				} catch {
 					resolve(null);
 				}
-			},
+			}
 		);
 	});
 }
@@ -134,7 +155,7 @@ export async function fetchViaApi(
 	owner: string,
 	repo: string,
 	info: GitHubUrlInfo,
-	sizeNote?: string,
+	sizeNote?: string
 ): Promise<ExtractedContent | null> {
 	const ref = info.ref || (await getDefaultBranch(owner, repo));
 	if (!ref) return null;
@@ -184,7 +205,9 @@ export async function fetchViaApi(
 		lines.push("");
 	}
 
-	lines.push("This is an API-only view. Clone the repo or use `read`/`bash` for deeper exploration.");
+	lines.push(
+		"This is an API-only view. Clone the repo or use `read`/`bash` for deeper exploration."
+	);
 
 	const title = info.path ? `${owner}/${repo} - ${info.path}` : `${owner}/${repo}`;
 	return {

--- a/github-extract.ts
+++ b/github-extract.ts
@@ -1,4 +1,14 @@
-import { existsSync, readFileSync, rmSync, statSync, readdirSync, openSync, readSync, closeSync, realpathSync } from "node:fs";
+import {
+	existsSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	readdirSync,
+	openSync,
+	readSync,
+	closeSync,
+	realpathSync,
+} from "node:fs";
 import { execFile } from "node:child_process";
 import { homedir } from "node:os";
 import { extname, join, resolve as resolvePath, sep as pathSep } from "node:path";
@@ -9,21 +19,85 @@ import { checkGhAvailable, checkRepoSize, fetchViaApi, showGhHint } from "./gith
 const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
 
 const BINARY_EXTENSIONS = new Set([
-	".png", ".jpg", ".jpeg", ".gif", ".bmp", ".ico", ".webp", ".svg", ".tiff", ".tif",
-	".mp3", ".mp4", ".avi", ".mov", ".mkv", ".flv", ".wmv", ".wav", ".ogg", ".webm", ".flac", ".aac",
-	".zip", ".tar", ".gz", ".bz2", ".xz", ".7z", ".rar", ".zst",
-	".exe", ".dll", ".so", ".dylib", ".bin", ".o", ".a", ".lib",
-	".woff", ".woff2", ".ttf", ".otf", ".eot",
-	".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
-	".sqlite", ".db", ".sqlite3",
-	".pyc", ".pyo", ".class", ".jar", ".war",
-	".iso", ".img", ".dmg",
+	".png",
+	".jpg",
+	".jpeg",
+	".gif",
+	".bmp",
+	".ico",
+	".webp",
+	".svg",
+	".tiff",
+	".tif",
+	".mp3",
+	".mp4",
+	".avi",
+	".mov",
+	".mkv",
+	".flv",
+	".wmv",
+	".wav",
+	".ogg",
+	".webm",
+	".flac",
+	".aac",
+	".zip",
+	".tar",
+	".gz",
+	".bz2",
+	".xz",
+	".7z",
+	".rar",
+	".zst",
+	".exe",
+	".dll",
+	".so",
+	".dylib",
+	".bin",
+	".o",
+	".a",
+	".lib",
+	".woff",
+	".woff2",
+	".ttf",
+	".otf",
+	".eot",
+	".pdf",
+	".doc",
+	".docx",
+	".xls",
+	".xlsx",
+	".ppt",
+	".pptx",
+	".sqlite",
+	".db",
+	".sqlite3",
+	".pyc",
+	".pyo",
+	".class",
+	".jar",
+	".war",
+	".iso",
+	".img",
+	".dmg",
 ]);
 
 const NOISE_DIRS = new Set([
-	"node_modules", "vendor", ".next", "dist", "build", "__pycache__",
-	".venv", "venv", ".tox", ".mypy_cache", ".pytest_cache",
-	"target", ".gradle", ".idea", ".vscode",
+	"node_modules",
+	"vendor",
+	".next",
+	"dist",
+	"build",
+	"__pycache__",
+	".venv",
+	"venv",
+	".tox",
+	".mypy_cache",
+	".pytest_cache",
+	"target",
+	".gradle",
+	".idea",
+	".vscode",
 ]);
 
 const MAX_INLINE_FILE_CHARS = 100_000;
@@ -85,9 +159,23 @@ function loadGitHubConfig(): GitHubCloneConfig {
 	}
 
 	const rawText = readFileSync(CONFIG_PATH, "utf-8");
-	let raw: { githubClone?: { enabled?: unknown; maxRepoSizeMB?: unknown; cloneTimeoutSeconds?: unknown; clonePath?: unknown } };
+	let raw: {
+		githubClone?: {
+			enabled?: unknown;
+			maxRepoSizeMB?: unknown;
+			cloneTimeoutSeconds?: unknown;
+			clonePath?: unknown;
+		};
+	};
 	try {
-		raw = JSON.parse(rawText) as { githubClone?: { enabled?: unknown; maxRepoSizeMB?: unknown; cloneTimeoutSeconds?: unknown; clonePath?: unknown } };
+		raw = JSON.parse(rawText) as {
+			githubClone?: {
+				enabled?: unknown;
+				maxRepoSizeMB?: unknown;
+				cloneTimeoutSeconds?: unknown;
+				clonePath?: unknown;
+			};
+		};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
@@ -97,19 +185,45 @@ function loadGitHubConfig(): GitHubCloneConfig {
 	cachedConfig = {
 		enabled: normalizeEnabled(gc.enabled, defaults.enabled),
 		maxRepoSizeMB: normalizePositiveNumber(gc.maxRepoSizeMB, defaults.maxRepoSizeMB),
-		cloneTimeoutSeconds: normalizePositiveNumber(gc.cloneTimeoutSeconds, defaults.cloneTimeoutSeconds),
+		cloneTimeoutSeconds: normalizePositiveNumber(
+			gc.cloneTimeoutSeconds,
+			defaults.cloneTimeoutSeconds
+		),
 		clonePath: normalizeClonePath(gc.clonePath, defaults.clonePath),
 	};
 	return cachedConfig;
 }
 
 const NON_CODE_SEGMENTS = new Set([
-	"issues", "pull", "pulls", "discussions", "releases", "wiki",
-	"actions", "settings", "security", "projects", "graphs",
-	"compare", "commits", "tags", "branches", "stargazers",
-	"watchers", "network", "forks", "milestone", "labels",
-	"packages", "codespaces", "contribute", "community",
-	"sponsors", "invitations", "notifications", "insights",
+	"issues",
+	"pull",
+	"pulls",
+	"discussions",
+	"releases",
+	"wiki",
+	"actions",
+	"settings",
+	"security",
+	"projects",
+	"graphs",
+	"compare",
+	"commits",
+	"tags",
+	"branches",
+	"stargazers",
+	"watchers",
+	"network",
+	"forks",
+	"milestone",
+	"labels",
+	"packages",
+	"codespaces",
+	"contribute",
+	"community",
+	"sponsors",
+	"invitations",
+	"notifications",
+	"insights",
 ]);
 
 export function parseGitHubUrl(url: string): GitHubUrlInfo | null {
@@ -172,14 +286,18 @@ function cloneDir(config: GitHubCloneConfig, owner: string, repo: string, ref?: 
 	return join(config.clonePath, owner, dirName);
 }
 
-function execClone(args: string[], localPath: string, timeoutMs: number, signal?: AbortSignal): Promise<string | null> {
+function execClone(
+	args: string[],
+	localPath: string,
+	timeoutMs: number,
+	signal?: AbortSignal
+): Promise<string | null> {
 	return new Promise((resolve) => {
 		const child = execFile(args[0], args.slice(1), { timeout: timeoutMs }, (err) => {
 			if (err) {
 				try {
 					rmSync(localPath, { recursive: true, force: true });
-				} catch {
-				}
+				} catch {}
 				resolve(null);
 				return;
 			}
@@ -199,20 +317,29 @@ async function cloneRepo(
 	repo: string,
 	ref: string | undefined,
 	config: GitHubCloneConfig,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<string | null> {
 	const localPath = cloneDir(config, owner, repo, ref);
 
 	try {
 		rmSync(localPath, { recursive: true, force: true });
-	} catch {
-	}
+	} catch {}
 
 	const timeoutMs = config.cloneTimeoutSeconds * 1000;
 	const hasGh = await checkGhAvailable();
 
 	if (hasGh) {
-		const args = ["gh", "repo", "clone", `${owner}/${repo}`, localPath, "--", "--depth", "1", "--single-branch"];
+		const args = [
+			"gh",
+			"repo",
+			"clone",
+			`${owner}/${repo}`,
+			localPath,
+			"--",
+			"--depth",
+			"1",
+			"--single-branch",
+		];
 		if (ref) args.push("--branch", ref);
 		return execClone(args, localPath, timeoutMs, signal);
 	}
@@ -261,7 +388,9 @@ function resolveWithinRepo(rootPath: string, relativePath: string): string | nul
 	const normalizedRoot = resolvePath(rootPath);
 	const candidate = resolvePath(normalizedRoot, relativePath);
 	if (candidate !== normalizedRoot) {
-		const rootPrefix = normalizedRoot.endsWith(pathSep) ? normalizedRoot : normalizedRoot + pathSep;
+		const rootPrefix = normalizedRoot.endsWith(pathSep)
+			? normalizedRoot
+			: normalizedRoot + pathSep;
 		if (!candidate.startsWith(rootPrefix)) return null;
 	}
 
@@ -381,7 +510,9 @@ function readReadme(localPath: string): string | null {
 		if (existsSync(readmePath)) {
 			try {
 				const content = readFileSync(readmePath, "utf-8");
-				return content.length > 8192 ? content.slice(0, 8192) + "\n\n[README truncated at 8K chars]" : content;
+				return content.length > 8192
+					? content.slice(0, 8192) + "\n\n[README truncated at 8K chars]"
+					: content;
 			} catch {
 				continue;
 			}
@@ -466,7 +597,9 @@ function generateContent(localPath: string, info: GitHubUrlInfo): string {
 		if (isBinaryFile(fullFilePath)) {
 			const ext = extname(filePath).replace(".", "");
 			lines.push(`## ${filePath}`);
-			lines.push(`Binary file (${ext}, ${formatFileSize(stat.size)}). Use \`read\` or \`bash\` tools at the path above to inspect.`);
+			lines.push(
+				`Binary file (${ext}, ${formatFileSize(stat.size)}). Use \`read\` or \`bash\` tools at the path above to inspect.`
+			);
 			return lines.join("\n");
 		}
 
@@ -501,7 +634,7 @@ async function awaitCachedClone(
 	owner: string,
 	repo: string,
 	info: GitHubUrlInfo,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	if (signal?.aborted) return null;
 	const result = await cached.clonePromise;
@@ -517,7 +650,7 @@ async function awaitCachedClone(
 export async function extractGitHub(
 	url: string,
 	signal?: AbortSignal,
-	forceClone?: boolean,
+	forceClone?: boolean
 ): Promise<ExtractedContent | null> {
 	const info = parseGitHubUrl(url);
 	if (!info) return null;
@@ -539,7 +672,10 @@ export async function extractGitHub(
 		return fetchViaApi(url, owner, repo, info, sizeNote);
 	}
 
-	const activityId = activityMonitor.logStart({ type: "fetch", url: `github.com/${owner}/${repo}` });
+	const activityId = activityMonitor.logStart({
+		type: "fetch",
+		url: `github.com/${owner}/${repo}`,
+	});
 
 	if (!forceClone) {
 		const sizeKB = await checkRepoSize(owner, repo);
@@ -563,7 +699,10 @@ export async function extractGitHub(
 					activityMonitor.logComplete(activityId, 200);
 					return apiView;
 				}
-				activityMonitor.logError(activityId, "api fallback unavailable for oversized repository");
+				activityMonitor.logError(
+					activityId,
+					"api fallback unavailable for oversized repository"
+				);
 				return null;
 			}
 		}
@@ -577,7 +716,14 @@ export async function extractGitHub(
 	// Re-check: another concurrent caller may have started a clone while we awaited the size check
 	const cachedAfterSizeCheck = cloneCache.get(key);
 	if (cachedAfterSizeCheck) {
-		const cachedResult = await awaitCachedClone(cachedAfterSizeCheck, url, owner, repo, info, signal);
+		const cachedResult = await awaitCachedClone(
+			cachedAfterSizeCheck,
+			url,
+			owner,
+			repo,
+			info,
+			signal
+		);
 		if (signal?.aborted) {
 			activityMonitor.logComplete(activityId, 0);
 		} else if (cachedResult) {
@@ -626,8 +772,7 @@ export function clearCloneCache(): void {
 	for (const entry of cloneCache.values()) {
 		try {
 			rmSync(entry.localPath, { recursive: true, force: true });
-		} catch {
-		}
+		} catch {}
 	}
 	cloneCache.clear();
 	cachedConfig = null;

--- a/index.ts
+++ b/index.ts
@@ -114,7 +114,12 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	if (normalized === "auto" || normalized === "exa" || normalized === "perplexity" || normalized === "gemini") {
+	if (
+		normalized === "auto" ||
+		normalized === "exa" ||
+		normalized === "perplexity" ||
+		normalized === "gemini"
+	) {
 		return normalized;
 	}
 	return "auto";
@@ -129,7 +134,8 @@ function normalizeCuratorTimeoutSeconds(value: unknown): number | undefined {
 
 function resolveWorkflow(input: unknown, hasUI: boolean): WebSearchWorkflow {
 	if (!hasUI) return "none";
-	if (typeof input === "string" && input.trim().toLowerCase() === "summary-review") return "summary-review";
+	if (typeof input === "string" && input.trim().toLowerCase() === "summary-review")
+		return "summary-review";
 	return "none";
 }
 
@@ -145,7 +151,10 @@ function normalizeQueryList(queryList: unknown[]): string[] {
 
 function getCuratorTimeoutSeconds(): number {
 	const source = loadConfig();
-	return normalizeCuratorTimeoutSeconds(source.curatorTimeoutSeconds) ?? DEFAULT_CURATOR_TIMEOUT_SECONDS;
+	return (
+		normalizeCuratorTimeoutSeconds(source.curatorTimeoutSeconds) ??
+		DEFAULT_CURATOR_TIMEOUT_SECONDS
+	);
 }
 
 async function getProviderAvailability(): Promise<ProviderAvailability> {
@@ -168,7 +177,7 @@ async function loadCuratorBootstrap(requestedProvider: unknown): Promise<Curator
 
 function resolveProvider(
 	requested: unknown,
-	available: ProviderAvailability,
+	available: ProviderAvailability
 ): ResolvedSearchProvider {
 	const provider = normalizeProviderInput(requested ?? loadConfig().provider ?? "auto") ?? "auto";
 
@@ -216,7 +225,12 @@ interface PendingCurate {
 	summaryModels: Array<{ value: string; label: string }>;
 	defaultSummaryModel: string | null;
 	timeoutSeconds: number;
-	onUpdate: ((update: { content: Array<{ type: string; text: string }>; details?: Record<string, unknown> }) => void) | undefined;
+	onUpdate:
+		| ((update: {
+				content: Array<{ type: string; text: string }>;
+				details?: Record<string, unknown>;
+		  }) => void)
+		| undefined;
 	signal: AbortSignal | undefined;
 	abortSearches: () => void;
 	finish: (value: unknown) => void;
@@ -254,15 +268,22 @@ function duplicateQuerySet(results: QueryResultData[]): Set<string> {
 	return duplicates;
 }
 
-function formatQueryHeader(query: string, provider: string | undefined, duplicateQueries: Set<string>): string {
+function formatQueryHeader(
+	query: string,
+	provider: string | undefined,
+	duplicateQueries: Set<string>
+): string {
 	const suffix = duplicateQueries.has(query) && provider ? ` (${provider})` : "";
 	return `## Query: "${query}"${suffix}\n\n`;
 }
 
-function hasFullInlineCoverage(urls: string[], inlineContent: ExtractedContent[] | undefined): boolean {
+function hasFullInlineCoverage(
+	urls: string[],
+	inlineContent: ExtractedContent[] | undefined
+): boolean {
 	if (!inlineContent || inlineContent.length === 0) return false;
-	const coveredUrls = new Set(inlineContent.map(c => c.url));
-	return urls.every(url => coveredUrls.has(url));
+	const coveredUrls = new Set(inlineContent.map((c) => c.url));
+	return urls.every((url) => coveredUrls.has(url));
 }
 
 function formatFullResults(queryData: QueryResultData): string {
@@ -286,7 +307,9 @@ function abortPendingFetches(): void {
 function closeCurator(): void {
 	const win = glimpseWin;
 	glimpseWin = null;
-	try { win?.close(); } catch {}
+	try {
+		win?.close();
+	} catch {}
 	cancelPendingCurate();
 	if (activeCurator) {
 		activeCurator.close();
@@ -296,11 +319,12 @@ function closeCurator(): void {
 
 async function openInBrowser(pi: ExtensionAPI, url: string): Promise<void> {
 	const plat = platform();
-	const result = plat === "darwin"
-		? await pi.exec("open", [url])
-		: plat === "win32"
-			? await pi.exec("cmd", ["/c", "start", "", url])
-			: await pi.exec("xdg-open", [url]);
+	const result =
+		plat === "darwin"
+			? await pi.exec("open", [url])
+			: plat === "win32"
+				? await pi.exec("cmd", ["/c", "start", "", url])
+				: await pi.exec("xdg-open", [url]);
 	if (result.code !== 0) {
 		throw new Error(result.stderr || `Failed to open browser (exit code ${result.code})`);
 	}
@@ -314,7 +338,10 @@ interface GlimpseWindow {
 	_write(obj: Record<string, unknown>): void;
 }
 
-let glimpseOpen: ((html: string, opts: Record<string, unknown>) => GlimpseWindow) | null | undefined;
+let glimpseOpen:
+	| ((html: string, opts: Record<string, unknown>) => GlimpseWindow)
+	| null
+	| undefined;
 
 function findGlimpseMjs(): string | null {
 	try {
@@ -349,7 +376,7 @@ async function getGlimpseOpen() {
 function openInGlimpse(
 	open: (html: string, opts: Record<string, unknown>) => GlimpseWindow,
 	url: string,
-	title: string,
+	title: string
 ): GlimpseWindow {
 	const shellHTML = `<!DOCTYPE html>
 <html>
@@ -383,8 +410,11 @@ function openInGlimpse(
 }
 
 function extractDomain(url: string): string {
-	try { return new URL(url).hostname; }
-	catch { return url; }
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return url;
+	}
 }
 
 function updateWidget(ctx: ExtensionContext): void {
@@ -405,11 +435,13 @@ function updateWidget(ctx: ExtensionContext): void {
 	lines.push(theme.fg("accent", "─".repeat(60)));
 
 	const rateInfo = activityMonitor.getRateLimitInfo();
-	const resetMs = rateInfo.oldestTimestamp ? Math.max(0, rateInfo.oldestTimestamp + rateInfo.windowMs - Date.now()) : 0;
+	const resetMs = rateInfo.oldestTimestamp
+		? Math.max(0, rateInfo.oldestTimestamp + rateInfo.windowMs - Date.now())
+		: 0;
 	const resetSec = Math.ceil(resetMs / 1000);
 	lines.push(
 		theme.fg("muted", `Rate: ${rateInfo.used}/${rateInfo.max}`) +
-			(resetMs > 0 ? theme.fg("dim", ` (resets in ${resetSec}s)`) : ""),
+			(resetMs > 0 ? theme.fg("dim", ` (resets in ${resetSec}s)`) : "")
 	);
 
 	ctx.ui.setWidget("web-activity", new Text(lines.join("\n"), 0, 0));
@@ -417,7 +449,7 @@ function updateWidget(ctx: ExtensionContext): void {
 
 function formatEntryLine(
 	entry: ActivityEntry,
-	theme: { fg: (color: string, text: string) => string },
+	theme: { fg: (color: string, text: string) => string }
 ): string {
 	const typeStr = entry.type === "api" ? "API" : "GET";
 	const target =
@@ -442,7 +474,10 @@ function formatEntryLine(
 		indicator = theme.fg("muted", "○");
 	} else {
 		statusStr = String(entry.status);
-		indicator = entry.status >= 200 && entry.status < 300 ? theme.fg("success", "✓") : theme.fg("error", "✗");
+		indicator =
+			entry.status >= 200 && entry.status < 300
+				? theme.fg("success", "✓")
+				: theme.fg("error", "✗");
 	}
 
 	return `${typeStr.padEnd(4)} ${target.padEnd(32)} ${statusStr.padStart(5)} ${duration.padStart(5)} ${indicator}`;
@@ -486,20 +521,22 @@ export default function (pi: ExtensionAPI) {
 				};
 				storeResult(fetchId, data);
 				pi.appendEntry("web-search-results", data);
-				const ok = fetched.filter(f => !f.error).length;
+				const ok = fetched.filter((f) => !f.error).length;
 				pi.sendMessage(
 					{
 						customType: "web-search-content-ready",
 						content: `Content fetched for ${ok}/${fetched.length} URLs [${fetchId}]. Full page content now available.`,
 						display: true,
 					},
-					{ triggerTurn: true },
+					{ triggerTurn: true }
 				);
 			})
 			.catch((err) => {
 				if (!sessionActive || !pendingFetches.has(fetchId)) return;
 				const message = err instanceof Error ? err.message : String(err);
-				const isAbort = (err instanceof Error && err.name === "AbortError") || message.toLowerCase().includes("abort");
+				const isAbort =
+					(err instanceof Error && err.name === "AbortError") ||
+					message.toLowerCase().includes("abort");
 				if (!isAbort) {
 					pi.sendMessage(
 						{
@@ -507,18 +544,23 @@ export default function (pi: ExtensionAPI) {
 							content: `Content fetch failed [${fetchId}]: ${message}`,
 							display: true,
 						},
-						{ triggerTurn: false },
+						{ triggerTurn: false }
 					);
 				}
 			})
-			.finally(() => { pendingFetches.delete(fetchId); });
+			.finally(() => {
+				pendingFetches.delete(fetchId);
+			});
 		return fetchId;
 	}
 
 	function storeAndPublishSearch(results: QueryResultData[]): string {
 		const id = generateId();
 		const data: StoredSearchData = {
-			id, type: "search", timestamp: Date.now(), queries: results,
+			id,
+			type: "search",
+			timestamp: Date.now(),
+			queries: results,
 		};
 		storeResult(id, data);
 		pi.appendEntry("web-search-results", data);
@@ -544,7 +586,10 @@ export default function (pi: ExtensionAPI) {
 			return {
 				model: null,
 				durationMs: 0,
-				tokenEstimate: normalizedText.length > 0 ? Math.max(1, Math.ceil(normalizedText.length / 4)) : 0,
+				tokenEstimate:
+					normalizedText.length > 0
+						? Math.max(1, Math.ceil(normalizedText.length / 4))
+						: 0,
 				fallbackUsed: false,
 				edited: false,
 			};
@@ -552,10 +597,14 @@ export default function (pi: ExtensionAPI) {
 
 		return {
 			model: meta.model,
-			durationMs: Number.isFinite(meta.durationMs) && meta.durationMs >= 0 ? meta.durationMs : 0,
-			tokenEstimate: Number.isFinite(meta.tokenEstimate) && meta.tokenEstimate >= 0
-				? meta.tokenEstimate
-				: (normalizedText.length > 0 ? Math.max(1, Math.ceil(normalizedText.length / 4)) : 0),
+			durationMs:
+				Number.isFinite(meta.durationMs) && meta.durationMs >= 0 ? meta.durationMs : 0,
+			tokenEstimate:
+				Number.isFinite(meta.tokenEstimate) && meta.tokenEstimate >= 0
+					? meta.tokenEstimate
+					: normalizedText.length > 0
+						? Math.max(1, Math.ceil(normalizedText.length / 4))
+						: 0,
 			fallbackUsed: meta.fallbackUsed === true,
 			fallbackReason: meta.fallbackReason,
 			edited: meta.edited === true,
@@ -576,18 +625,25 @@ export default function (pi: ExtensionAPI) {
 
 	async function resolveFirstAvailableModel(
 		ctx: SummaryGenerationContext,
-		candidates: Array<{ provider: string; id: string }>,
+		candidates: Array<{ provider: string; id: string }>
 	): Promise<{ model: Model; apiKey: string; headers?: Record<string, string> }> {
 		for (const { provider, id } of candidates) {
 			const model = getModel(provider, id);
 			if (!model) continue;
 			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-			if (auth.ok && auth.apiKey) return { model, apiKey: auth.apiKey, headers: auth.headers };
+			if (auth.ok && auth.apiKey)
+				return { model, apiKey: auth.apiKey, headers: auth.headers };
 		}
-		throw new Error(`No model available: ${candidates.map(c => `${c.provider}/${c.id}`).join(", ")}`);
+		throw new Error(
+			`No model available: ${candidates.map((c) => `${c.provider}/${c.id}`).join(", ")}`
+		);
 	}
 
-	async function rewriteSearchQuery(query: string, ctx: SummaryGenerationContext, signal: AbortSignal): Promise<string> {
+	async function rewriteSearchQuery(
+		query: string,
+		ctx: SummaryGenerationContext,
+		signal: AbortSignal
+	): Promise<string> {
 		const { model, apiKey, headers } = await resolveFirstAvailableModel(ctx, [
 			{ provider: "anthropic", id: "claude-haiku-4-5" },
 			{ provider: "google", id: "gemini-2.5-flash" },
@@ -596,18 +652,25 @@ export default function (pi: ExtensionAPI) {
 		const response = await complete(
 			model,
 			{
-				messages: [{
-					role: "user",
-					content: [{ type: "text", text: `Rewrite this web search query to get better, more specific results. Add relevant year qualifiers, precise technical terms, and specificity. Return ONLY the improved query text, nothing else.\n\nQuery: ${query}` }],
-					timestamp: Date.now(),
-				}],
+				messages: [
+					{
+						role: "user",
+						content: [
+							{
+								type: "text",
+								text: `Rewrite this web search query to get better, more specific results. Add relevant year qualifiers, precise technical terms, and specificity. Return ONLY the improved query text, nothing else.\n\nQuery: ${query}`,
+							},
+						],
+						timestamp: Date.now(),
+					},
+				],
 			},
-			{ apiKey, headers, signal },
+			{ apiKey, headers, signal }
 		);
 		if (response.stopReason === "aborted") throw new Error("Aborted");
 		const contentParts = Array.isArray(response.content) ? response.content : [];
 		const text = contentParts
-			.map(p => {
+			.map((p) => {
 				if (!p || typeof p !== "object") return "";
 				const part = p as Record<string, unknown>;
 				return typeof part.text === "string" ? part.text : "";
@@ -624,7 +687,7 @@ export default function (pi: ExtensionAPI) {
 		summaryContext: SummaryGenerationContext,
 		signal?: AbortSignal,
 		modelOverride?: string,
-		feedback?: string,
+		feedback?: string
 	): Promise<{ summary: string; meta: SummaryMeta }> {
 		const selectedResults: QueryResultData[] = [];
 		for (const qi of selectedQueryIndices) {
@@ -635,9 +698,17 @@ export default function (pi: ExtensionAPI) {
 			throw new Error("No selected results available for summary generation");
 		}
 		try {
-			return await generateSummaryDraft(selectedResults, summaryContext, signal, modelOverride, feedback);
+			return await generateSummaryDraft(
+				selectedResults,
+				summaryContext,
+				signal,
+				modelOverride,
+				feedback
+			);
 		} catch (err) {
-			const isEmptyResponse = err instanceof Error && err.message.includes("Summary model returned empty response");
+			const isEmptyResponse =
+				err instanceof Error &&
+				err.message.includes("Summary model returned empty response");
 			if (!isEmptyResponse) throw err;
 			const deterministic = buildDeterministicSummary(selectedResults);
 			return {
@@ -650,9 +721,10 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
-	async function loadSummaryModelChoices(
-		summaryContext: SummaryGenerationContext,
-	): Promise<{ summaryModels: Array<{ value: string; label: string }>; defaultSummaryModel: string | null }> {
+	async function loadSummaryModelChoices(summaryContext: SummaryGenerationContext): Promise<{
+		summaryModels: Array<{ value: string; label: string }>;
+		defaultSummaryModel: string | null;
+	}> {
 		const summaryModels: Array<{ value: string; label: string }> = [];
 		const seen = new Set<string>();
 		const availableValues = new Set<string>();
@@ -684,7 +756,8 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		const config = loadConfig();
-		const configuredSummaryModel = typeof config.summaryModel === "string" ? config.summaryModel.trim() : "";
+		const configuredSummaryModel =
+			typeof config.summaryModel === "string" ? config.summaryModel.trim() : "";
 		const preferredDefaults = [
 			"anthropic/claude-haiku-4-5",
 			"openai-codex/gpt-5.3-codex-spark",
@@ -711,7 +784,7 @@ export default function (pi: ExtensionAPI) {
 
 	function resolveSummaryForSubmit(
 		payload: { selectedQueryIndices: number[]; summary?: string; summaryMeta?: SummaryMeta },
-		resultsByIndex: Map<number, QueryResultData>,
+		resultsByIndex: Map<number, QueryResultData>
 	): { approvedSummary: string; summaryMeta: SummaryMeta } {
 		const submittedSummary = typeof payload.summary === "string" ? payload.summary.trim() : "";
 		if (submittedSummary.length > 0) {
@@ -731,18 +804,22 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	function buildSearchReturn(opts: SearchReturnOptions) {
-		const sc = opts.results.filter(r => !r.error).length;
+		const sc = opts.results.filter((r) => !r.error).length;
 		const tr = opts.results.reduce((sum, r) => sum + r.results.length, 0);
 
-		const hasApprovedSummary = typeof opts.approvedSummary === "string" && opts.approvedSummary.trim().length > 0;
+		const hasApprovedSummary =
+			typeof opts.approvedSummary === "string" && opts.approvedSummary.trim().length > 0;
 		let output = "";
 		if (hasApprovedSummary) {
 			output = opts.approvedSummary!.trim();
 		} else {
 			if (opts.curated) {
-				output += "[These results were manually curated by the user in the browser. Use them as-is — do not re-search or discard.]\n\n";
+				output +=
+					"[These results were manually curated by the user in the browser. Use them as-is — do not re-search or discard.]\n\n";
 			}
-			const duplicateQueries = opts.curated ? duplicateQuerySet(opts.results) : new Set<string>();
+			const duplicateQueries = opts.curated
+				? duplicateQuerySet(opts.results)
+				: new Set<string>();
 			for (const { query, answer, results, error, provider } of opts.results) {
 				if (opts.queryList.length > 1) {
 					output += opts.curated
@@ -750,8 +827,11 @@ export default function (pi: ExtensionAPI) {
 						: `## Query: "${query}"\n\n`;
 				}
 				if (error) output += `Error: ${error}\n\n`;
-				else if (results.length === 0) output += answer ? `${answer}\n\n---\n
-**Sources:** None found.\n` : "No results found.\n\n";
+				else if (results.length === 0)
+					output += answer
+						? `${answer}\n\n---\n
+**Sources:** None found.\n`
+						: "No results found.\n\n";
 				else output += formatSearchSummary(results, answer) + "\n\n";
 			}
 		}
@@ -785,7 +865,7 @@ export default function (pi: ExtensionAPI) {
 			content: [{ type: "text", text: output.trim() }],
 			details: {
 				queries: opts.queryList,
-				providers: opts.results.map(r => r.provider || null),
+				providers: opts.results.map((r) => r.provider || null),
 				queryCount: opts.queryList.length,
 				successfulQueries: sc,
 				totalResults: tr,
@@ -793,36 +873,41 @@ export default function (pi: ExtensionAPI) {
 				fetchId,
 				fetchUrls: isBackgroundFetch ? opts.urls : undefined,
 				searchId,
-				...(opts.curated ? {
-					curated: true,
-					curatedFrom: opts.curatedFrom,
-					curatedQueries: opts.results.map(r => ({
-						query: r.query,
-						provider: r.provider || null,
-						answer: r.answer || null,
-						sources: r.results.map(s => ({ title: s.title, url: s.url })),
-						error: r.error,
-					})),
-				} : {}),
-				...((opts.workflow && hasApprovedSummary)
+				...(opts.curated
 					? {
-						summary: {
-							text: opts.approvedSummary!.trim(),
-							workflow: opts.workflow,
-							model: opts.summaryMeta?.model ?? null,
-							durationMs: opts.summaryMeta?.durationMs ?? 0,
-							tokenEstimate: opts.summaryMeta?.tokenEstimate ?? 0,
-							fallbackUsed: opts.summaryMeta?.fallbackUsed === true,
-							fallbackReason: opts.summaryMeta?.fallbackReason,
-							edited: opts.summaryMeta?.edited === true,
-						},
-					}
+							curated: true,
+							curatedFrom: opts.curatedFrom,
+							curatedQueries: opts.results.map((r) => ({
+								query: r.query,
+								provider: r.provider || null,
+								answer: r.answer || null,
+								sources: r.results.map((s) => ({ title: s.title, url: s.url })),
+								error: r.error,
+							})),
+						}
+					: {}),
+				...(opts.workflow && hasApprovedSummary
+					? {
+							summary: {
+								text: opts.approvedSummary!.trim(),
+								workflow: opts.workflow,
+								model: opts.summaryMeta?.model ?? null,
+								durationMs: opts.summaryMeta?.durationMs ?? 0,
+								tokenEstimate: opts.summaryMeta?.tokenEstimate ?? 0,
+								fallbackUsed: opts.summaryMeta?.fallbackUsed === true,
+								fallbackReason: opts.summaryMeta?.fallbackReason,
+								edited: opts.summaryMeta?.edited === true,
+							},
+						}
 					: {}),
 			},
 		};
 	}
 
-	function filterByQueryIndices(selectedQueryIndices: number[], results: Map<number, QueryResultData>) {
+	function filterByQueryIndices(
+		selectedQueryIndices: number[],
+		results: Map<number, QueryResultData>
+	) {
 		const filteredResults: QueryResultData[] = [];
 		const filteredUrls: string[] = [];
 		for (const qi of selectedQueryIndices) {
@@ -871,7 +956,8 @@ export default function (pi: ExtensionAPI) {
 				},
 				{
 					async onSummarize(selectedQueryIndices, summarizeSignal, model, feedback) {
-						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
+						if (pendingCurate !== pc)
+							throw new Error("Curator session is no longer active.");
 						pc.onUpdate?.({
 							content: [{ type: "text", text: "Generating summary draft..." }],
 							details: { phase: "generating-summary", progress: 0.9 },
@@ -882,11 +968,17 @@ export default function (pi: ExtensionAPI) {
 							pc.summaryContext,
 							summarizeSignal,
 							model,
-							feedback,
+							feedback
 						);
-						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
+						if (pendingCurate !== pc)
+							throw new Error("Curator session is no longer active.");
 						pc.onUpdate?.({
-							content: [{ type: "text", text: "Summary draft ready — waiting for approval..." }],
+							content: [
+								{
+									type: "text",
+									text: "Summary draft ready — waiting for approval...",
+								},
+							],
 							details: { phase: "waiting-for-approval", progress: 1 },
 						});
 						return draft;
@@ -894,12 +986,18 @@ export default function (pi: ExtensionAPI) {
 					onSubmit(payload) {
 						if (pendingCurate !== pc) return;
 						searchAbort.abort();
-						const filtered = payload.selectedQueryIndices.length > 0
-							? filterByQueryIndices(payload.selectedQueryIndices, pc.searchResults)
-							: collectAllResultsAndUrls(pc.searchResults);
-						const filteredInline = pc.allInlineContent.filter(c => filtered.urls.includes(c.url));
+						const filtered =
+							payload.selectedQueryIndices.length > 0
+								? filterByQueryIndices(
+										payload.selectedQueryIndices,
+										pc.searchResults
+									)
+								: collectAllResultsAndUrls(pc.searchResults);
+						const filteredInline = pc.allInlineContent.filter((c) =>
+							filtered.urls.includes(c.url)
+						);
 						const base: SearchReturnOptions = {
-							queryList: filtered.results.map(r => r.query),
+							queryList: filtered.results.map((r) => r.query),
 							results: filtered.results,
 							urls: filtered.urls,
 							includeContent: pc.includeContent,
@@ -908,7 +1006,10 @@ export default function (pi: ExtensionAPI) {
 							curatedFrom: pc.searchResults.size,
 						};
 						if (!payload.rawResults) {
-							const resolvedSummary = resolveSummaryForSubmit(payload, pc.searchResults);
+							const resolvedSummary = resolveSummaryForSubmit(
+								payload,
+								pc.searchResults
+							);
 							base.workflow = pc.workflow;
 							base.approvedSummary = resolvedSummary.approvedSummary;
 							base.summaryMeta = resolvedSummary.summaryMeta;
@@ -920,21 +1021,33 @@ export default function (pi: ExtensionAPI) {
 						if (pendingCurate !== pc) return;
 						searchAbort.abort();
 						if (reason === "timeout") {
-							const resolvedSummary = resolveSummaryForSubmit({ selectedQueryIndices: [], summary: undefined, summaryMeta: undefined }, pc.searchResults);
+							const resolvedSummary = resolveSummaryForSubmit(
+								{
+									selectedQueryIndices: [],
+									summary: undefined,
+									summaryMeta: undefined,
+								},
+								pc.searchResults
+							);
 							const all = collectAllResultsAndUrls(pc.searchResults);
-							const filteredInline = pc.allInlineContent.filter(c => all.urls.includes(c.url));
-							pc.finish(buildSearchReturn({
-								queryList: all.results.map(r => r.query),
-								results: all.results,
-								urls: all.urls,
-								includeContent: pc.includeContent,
-								inlineContent: filteredInline.length > 0 ? filteredInline : undefined,
-								curated: true,
-								curatedFrom: pc.searchResults.size,
-								workflow: pc.workflow,
-								approvedSummary: resolvedSummary.approvedSummary,
-								summaryMeta: resolvedSummary.summaryMeta,
-							}));
+							const filteredInline = pc.allInlineContent.filter((c) =>
+								all.urls.includes(c.url)
+							);
+							pc.finish(
+								buildSearchReturn({
+									queryList: all.results.map((r) => r.query),
+									results: all.results,
+									urls: all.urls,
+									includeContent: pc.includeContent,
+									inlineContent:
+										filteredInline.length > 0 ? filteredInline : undefined,
+									curated: true,
+									curatedFrom: pc.searchResults.size,
+									workflow: pc.workflow,
+									approvedSummary: resolvedSummary.approvedSummary,
+									summaryMeta: resolvedSummary.summaryMeta,
+								})
+							);
 						} else {
 							pc.finish(buildCurationCancelledReturn(reason));
 						}
@@ -953,13 +1066,20 @@ export default function (pi: ExtensionAPI) {
 						}
 					},
 					async onAddSearch(query, queryIndex, provider) {
-						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
+						if (pendingCurate !== pc)
+							throw new Error("Curator session is no longer active.");
 						const normalizedProvider = normalizeProviderInput(provider);
-						const requestedProvider = !normalizedProvider || normalizedProvider === "auto"
-							? pc.defaultProvider
-							: normalizedProvider;
+						const requestedProvider =
+							!normalizedProvider || normalizedProvider === "auto"
+								? pc.defaultProvider
+								: normalizedProvider;
 						try {
-							const { answer, results, inlineContent, provider: actualProvider } = await search(query, {
+							const {
+								answer,
+								results,
+								inlineContent,
+								provider: actualProvider,
+							} = await search(query, {
 								provider: requestedProvider,
 								numResults: pc.numResults,
 								recencyFilter: pc.recencyFilter,
@@ -967,27 +1087,45 @@ export default function (pi: ExtensionAPI) {
 								includeContent: pc.includeContent,
 								signal: addSearchSignal,
 							});
-							if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
-							pc.searchResults.set(queryIndex, { query, answer, results, error: null, provider: actualProvider });
+							if (pendingCurate !== pc)
+								throw new Error("Curator session is no longer active.");
+							pc.searchResults.set(queryIndex, {
+								query,
+								answer,
+								results,
+								error: null,
+								provider: actualProvider,
+							});
 							if (inlineContent) pc.allInlineContent.push(...inlineContent);
 							return {
 								answer,
-								results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+								results: results.map((r) => ({
+									title: r.title,
+									url: r.url,
+									domain: extractDomain(r.url),
+								})),
 								provider: actualProvider,
 							};
 						} catch (err) {
 							const message = err instanceof Error ? err.message : String(err);
 							if (pendingCurate === pc) {
-								pc.searchResults.set(queryIndex, { query, answer: "", results: [], error: message, provider: requestedProvider });
+								pc.searchResults.set(queryIndex, {
+									query,
+									answer: "",
+									results: [],
+									error: message,
+									provider: requestedProvider,
+								});
 							}
 							throw err;
 						}
 					},
 					async onRewriteQuery(query, rewriteSignal) {
-						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
+						if (pendingCurate !== pc)
+							throw new Error("Curator session is no longer active.");
 						return rewriteSearchQuery(query, pc.summaryContext, rewriteSignal);
 					},
-				},
+				}
 			);
 
 			if (pendingCurate !== pc) {
@@ -1003,7 +1141,11 @@ export default function (pi: ExtensionAPI) {
 				} else {
 					handle.pushResult(qi, {
 						answer: data.answer,
-						results: data.results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+						results: data.results.map((r) => ({
+							title: r.title,
+							url: r.url,
+							domain: extractDomain(r.url),
+						})),
 						provider: data.provider || pc.defaultProvider,
 					});
 				}
@@ -1011,7 +1153,14 @@ export default function (pi: ExtensionAPI) {
 			if (searchesComplete) handle.searchesDone();
 
 			pc.onUpdate?.({
-				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],
+				content: [
+					{
+						type: "text",
+						text: searchesComplete
+							? "Waiting for summary approval in browser..."
+							: "Searches streaming to browser...",
+					},
+				],
 				details: { phase: "curating", progress: searchesComplete ? 1 : 0.5 },
 			});
 
@@ -1090,48 +1239,80 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "web_search",
 		label: "Web Search",
-		description:
-			`Search the web. Returns an AI-synthesized answer with source citations. Use queries (plural) with 2-4 varied angles for comprehensive research.`,
+		description: `Search the web. Returns an AI-synthesized answer with source citations. Use queries (plural) with 2-4 varied angles for comprehensive research.`,
 		promptSnippet:
 			"Use for web research. Prefer {queries:[...]} with 2-4 varied angles for broader coverage.",
 		parameters: Type.Object({
 			query: Type.Optional(Type.String({ description: "Single search query." })),
-			queries: Type.Optional(Type.Array(Type.String(), { description: "Multiple queries, each returning its own answer. Use 2-4 varied angles for research." })),
-			numResults: Type.Optional(Type.Number({ description: "Results per query (default: 5, max: 20)." })),
-			includeContent: Type.Optional(Type.Boolean({ description: "Fetch full page content from results (async)." })),
-			recencyFilter: Type.Optional(
-				StringEnum(["day", "week", "month", "year"], { description: "Filter results by recency." }),
+			queries: Type.Optional(
+				Type.Array(Type.String(), {
+					description:
+						"Multiple queries, each returning its own answer. Use 2-4 varied angles for research.",
+				})
 			),
-			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit or exclude domains (prefix with - to exclude)." })),
+			numResults: Type.Optional(
+				Type.Number({ description: "Results per query (default: 5, max: 20)." })
+			),
+			includeContent: Type.Optional(
+				Type.Boolean({ description: "Fetch full page content from results (async)." })
+			),
+			recencyFilter: Type.Optional(
+				StringEnum(["day", "week", "month", "year"], {
+					description: "Filter results by recency.",
+				})
+			),
+			domainFilter: Type.Optional(
+				Type.Array(Type.String(), {
+					description: "Limit or exclude domains (prefix with - to exclude).",
+				})
+			),
 			provider: Type.Optional(
-				StringEnum(["auto", "perplexity", "gemini", "exa"], { description: "Search provider (default: auto)." }),
+				StringEnum(["auto", "perplexity", "gemini", "exa"], {
+					description: "Search provider (default: auto).",
+				})
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review"], {
-					description: "Workflow: none = return results directly; summary-review = open browser curator for curation (default: none).",
-				}),
+					description:
+						"Workflow: none = return results directly; summary-review = open browser curator for curation (default: none).",
+				})
 			),
 		}),
 
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
 			const rawQueryList: unknown[] = Array.isArray(params.queries)
 				? params.queries
-				: (params.query !== undefined ? [params.query] : []);
+				: params.query !== undefined
+					? [params.query]
+					: [];
 			const queryList = normalizeQueryList(rawQueryList);
 			const configWorkflow = loadConfigForExtensionInit().workflow;
-			const workflow = resolveWorkflow(params.workflow ?? configWorkflow, ctx?.hasUI !== false);
+			const workflow = resolveWorkflow(
+				params.workflow ?? configWorkflow,
+				ctx?.hasUI !== false
+			);
 			const shouldCurate = workflow !== "none";
 
 			if (queryList.length === 0) {
 				return {
-					content: [{ type: "text", text: "Error: No query provided. Use 'query' or 'queries' parameter." }],
+					content: [
+						{
+							type: "text",
+							text: "Error: No query provided. Use 'query' or 'queries' parameter.",
+						},
+					],
 					details: { error: "No query provided" },
 				};
 			}
 
 			if (shouldCurate && !ctx) {
 				return {
-					content: [{ type: "text", text: "Error: Curation requires an active extension context." }],
+					content: [
+						{
+							type: "text",
+							text: "Error: Curation requires an active extension context.",
+						},
+					],
 					details: { error: "Missing extension context" },
 				};
 			}
@@ -1214,33 +1395,61 @@ export default function (pi: ExtensionAPI) {
 				for (let qi = 0; qi < queryList.length; qi++) {
 					if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
 					onUpdate?.({
-						content: [{ type: "text", text: `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...` }],
-						details: { phase: "searching", progress: qi / queryList.length, currentQuery: queryList[qi] },
+						content: [
+							{
+								type: "text",
+								text: `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...`,
+							},
+						],
+						details: {
+							phase: "searching",
+							progress: qi / queryList.length,
+							currentQuery: queryList[qi],
+						},
 					});
 					const requestedProvider = pc.defaultProvider;
 					try {
-						const { answer, results, inlineContent, provider } = await search(queryList[qi], {
-							provider: requestedProvider,
-							numResults: params.numResults,
-							recencyFilter: params.recencyFilter,
-							domainFilter: params.domainFilter,
-							includeContent: params.includeContent,
-							signal: searchSignal,
-						});
+						const { answer, results, inlineContent, provider } = await search(
+							queryList[qi],
+							{
+								provider: requestedProvider,
+								numResults: params.numResults,
+								recencyFilter: params.recencyFilter,
+								domainFilter: params.domainFilter,
+								includeContent: params.includeContent,
+								signal: searchSignal,
+							}
+						);
 						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
-						searchResults.set(qi, { query: queryList[qi], answer, results, error: null, provider });
+						searchResults.set(qi, {
+							query: queryList[qi],
+							answer,
+							results,
+							error: null,
+							provider,
+						});
 						if (inlineContent) allInlineContent.push(...inlineContent);
 						if (activeCurator) {
 							activeCurator.pushResult(qi, {
 								answer,
-								results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+								results: results.map((r) => ({
+									title: r.title,
+									url: r.url,
+									domain: extractDomain(r.url),
+								})),
 								provider,
 							});
 						}
 					} catch (err) {
 						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
 						const message = err instanceof Error ? err.message : String(err);
-						searchResults.set(qi, { query: queryList[qi], answer: "", results: [], error: message, provider: requestedProvider });
+						searchResults.set(qi, {
+							query: queryList[qi],
+							answer: "",
+							results: [],
+							error: message,
+							provider: requestedProvider,
+						});
 						if (activeCurator) {
 							activeCurator.pushError(qi, message, requestedProvider);
 						}
@@ -1256,7 +1465,12 @@ export default function (pi: ExtensionAPI) {
 				if (activeCurator && !cancelled) {
 					activeCurator.searchesDone();
 					pc.onUpdate?.({
-						content: [{ type: "text", text: "All searches complete — waiting for summary approval in browser..." }],
+						content: [
+							{
+								type: "text",
+								text: "All searches complete — waiting for summary approval in browser...",
+							},
+						],
 						details: { phase: "curating", progress: 1 },
 					});
 				}
@@ -1267,14 +1481,25 @@ export default function (pi: ExtensionAPI) {
 			const searchResults: QueryResultData[] = [];
 			const allUrls: string[] = [];
 			const allInlineContent: ExtractedContent[] = [];
-			const resolvedProvider = normalizeProviderInput(params.provider ?? loadConfig().provider);
+			const resolvedProvider = normalizeProviderInput(
+				params.provider ?? loadConfig().provider
+			);
 
 			for (let i = 0; i < queryList.length; i++) {
 				const query = queryList[i];
 
 				onUpdate?.({
-					content: [{ type: "text", text: `Searching ${i + 1}/${queryList.length}: "${query}"...` }],
-					details: { phase: "search", progress: i / queryList.length, currentQuery: query },
+					content: [
+						{
+							type: "text",
+							text: `Searching ${i + 1}/${queryList.length}: "${query}"...`,
+						},
+					],
+					details: {
+						phase: "search",
+						progress: i / queryList.length,
+						currentQuery: query,
+					},
 				});
 
 				try {
@@ -1296,10 +1521,17 @@ export default function (pi: ExtensionAPI) {
 					if (inlineContent) allInlineContent.push(...inlineContent);
 				} catch (err) {
 					const message = err instanceof Error ? err.message : String(err);
-					const requestedProvider = typeof resolvedProvider === "string" && resolvedProvider !== "auto"
-						? resolvedProvider
-						: undefined;
-					searchResults.push({ query, answer: "", results: [], error: message, provider: requestedProvider });
+					const requestedProvider =
+						typeof resolvedProvider === "string" && resolvedProvider !== "auto"
+							? resolvedProvider
+							: undefined;
+					searchResults.push({
+						query,
+						answer: "",
+						results: [],
+						error: message,
+						provider: requestedProvider,
+					});
 				}
 			}
 
@@ -1316,17 +1548,31 @@ export default function (pi: ExtensionAPI) {
 			const input = args as { query?: unknown; queries?: unknown };
 			const rawQueryList: unknown[] = Array.isArray(input.queries)
 				? input.queries
-				: (input.query !== undefined ? [input.query] : []);
+				: input.query !== undefined
+					? [input.query]
+					: [];
 			const queryList = normalizeQueryList(rawQueryList);
 			if (queryList.length === 0) {
-				return new Text(theme.fg("toolTitle", theme.bold("search ")) + theme.fg("error", "(no query)"), 0, 0);
+				return new Text(
+					theme.fg("toolTitle", theme.bold("search ")) + theme.fg("error", "(no query)"),
+					0,
+					0
+				);
 			}
 			if (queryList.length === 1) {
 				const q = queryList[0];
 				const display = q.length > 60 ? q.slice(0, 57) + "..." : q;
-				return new Text(theme.fg("toolTitle", theme.bold("search ")) + theme.fg("accent", `"${display}"`), 0, 0);
+				return new Text(
+					theme.fg("toolTitle", theme.bold("search ")) +
+						theme.fg("accent", `"${display}"`),
+					0,
+					0
+				);
 			}
-			const lines = [theme.fg("toolTitle", theme.bold("search ")) + theme.fg("accent", `${queryList.length} queries`)];
+			const lines = [
+				theme.fg("toolTitle", theme.bold("search ")) +
+					theme.fg("accent", `${queryList.length} queries`),
+			];
 			for (const q of queryList.slice(0, 5)) {
 				const display = q.length > 50 ? q.slice(0, 47) + "..." : q;
 				lines.push(theme.fg("muted", `  "${display}"`));
@@ -1379,14 +1625,22 @@ export default function (pi: ExtensionAPI) {
 				}
 				if (details?.phase === "searching") {
 					const progress = details?.progress ?? 0;
-					const bar = "\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
+					const bar =
+						"\u2588".repeat(Math.floor(progress * 10)) +
+						"\u2591".repeat(10 - Math.floor(progress * 10));
 					const query = details?.currentQuery || "";
 					const display = query.length > 40 ? query.slice(0, 37) + "..." : query;
 					return new Text(theme.fg("accent", `[${bar}] ${display}`), 0, 0);
 				}
 				const progress = details?.progress ?? 0;
-				const bar = "\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
-				return new Text(theme.fg("accent", `[${bar}] ${details?.phase || "searching"}`), 0, 0);
+				const bar =
+					"\u2588".repeat(Math.floor(progress * 10)) +
+					"\u2591".repeat(10 - Math.floor(progress * 10));
+				return new Text(
+					theme.fg("accent", `[${bar}] ${details?.phase || "searching"}`),
+					0,
+					0
+				);
 			}
 
 			if (details?.error) {
@@ -1394,12 +1648,21 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			let statusLine: string;
-			const queryInfo = details?.queryCount === 1 ? "" : `${details?.successfulQueries}/${details?.queryCount} queries, `;
+			const queryInfo =
+				details?.queryCount === 1
+					? ""
+					: `${details?.successfulQueries}/${details?.queryCount} queries, `;
 			const providers = details?.providers?.filter(Boolean) as string[] | undefined;
-			const providerLabel = providers && providers.length > 0 ? ` · ${providers.join(", ")}` : "";
-			statusLine = theme.fg("success", `${queryInfo}${details?.totalResults ?? 0} sources`) + theme.fg("muted", providerLabel);
+			const providerLabel =
+				providers && providers.length > 0 ? ` · ${providers.join(", ")}` : "";
+			statusLine =
+				theme.fg("success", `${queryInfo}${details?.totalResults ?? 0} sources`) +
+				theme.fg("muted", providerLabel);
 			if (details?.curated && details?.curatedFrom) {
-				statusLine += theme.fg("muted", ` (${details.queryCount}/${details.curatedFrom} queries curated)`);
+				statusLine += theme.fg(
+					"muted",
+					` (${details.queryCount}/${details.curatedFrom} queries curated)`
+				);
 			}
 			if (details?.fetchId && details?.fetchUrls) {
 				statusLine += theme.fg("muted", ` (fetching ${details.fetchUrls.length} URLs)`);
@@ -1411,14 +1674,18 @@ export default function (pi: ExtensionAPI) {
 			const lines = [statusLine];
 			if (details?.summary?.text) {
 				lines.push("");
-				lines.push(theme.fg("accent", `── Summary (${details.summary.workflow}) ` + "─".repeat(32)));
+				lines.push(
+					theme.fg("accent", `── Summary (${details.summary.workflow}) ` + "─".repeat(32))
+				);
 				lines.push("");
 				for (const line of details.summary.text.split("\n")) {
 					lines.push(`  ${line}`);
 				}
 				lines.push("");
 				const metaParts = [
-					details.summary.model ? `model=${details.summary.model}` : "model=deterministic",
+					details.summary.model
+						? `model=${details.summary.model}`
+						: "model=deterministic",
 					`duration=${details.summary.durationMs}ms`,
 					`tokens~${details.summary.tokenEstimate}`,
 					details.summary.fallbackUsed ? "fallback=true" : "fallback=false",
@@ -1435,7 +1702,13 @@ export default function (pi: ExtensionAPI) {
 				const kept = queryDetails.length;
 				const from = details?.curatedFrom ?? kept;
 				lines.push("");
-				lines.push(theme.fg("accent", `\u2500\u2500 Curated Results (${kept} of ${from} queries kept) ` + "\u2500".repeat(24)));
+				lines.push(
+					theme.fg(
+						"accent",
+						`\u2500\u2500 Curated Results (${kept} of ${from} queries kept) ` +
+							"\u2500".repeat(24)
+					)
+				);
 
 				for (const cq of queryDetails) {
 					lines.push("");
@@ -1456,15 +1729,20 @@ export default function (pi: ExtensionAPI) {
 						lines.push("");
 						for (const s of cq.sources) {
 							const domain = s.url.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
-							const title = s.title.length > 50 ? s.title.slice(0, 47) + "..." : s.title;
-							lines.push(theme.fg("muted", `  \u25b8 ${title}`) + theme.fg("dim", ` \u00b7 ${domain}`));
+							const title =
+								s.title.length > 50 ? s.title.slice(0, 47) + "..." : s.title;
+							lines.push(
+								theme.fg("muted", `  \u25b8 ${title}`) +
+									theme.fg("dim", ` \u00b7 ${domain}`)
+							);
 						}
 					}
 				}
 				lines.push("");
 			} else {
 				const textContent = result.content.find((c) => c.type === "text")?.text || "";
-				const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
+				const preview =
+					textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
 				for (const line of preview.split("\n")) {
 					lines.push(theme.fg("dim", line));
 				}
@@ -1472,7 +1750,9 @@ export default function (pi: ExtensionAPI) {
 
 			if (details?.fetchUrls && details.fetchUrls.length > 0) {
 				if (details.curated) {
-					lines.push(theme.fg("muted", `Fetching ${details.fetchUrls.length} URLs in background`));
+					lines.push(
+						theme.fg("muted", `Fetching ${details.fetchUrls.length} URLs in background`)
+					);
 				} else {
 					lines.push(theme.fg("muted", "Fetching:"));
 					for (const u of details.fetchUrls.slice(0, 5)) {
@@ -1480,7 +1760,9 @@ export default function (pi: ExtensionAPI) {
 						lines.push(theme.fg("dim", "  " + display));
 					}
 					if (details.fetchUrls.length > 5) {
-						lines.push(theme.fg("dim", `  ... and ${details.fetchUrls.length - 5} more`));
+						lines.push(
+							theme.fg("dim", `  ... and ${details.fetchUrls.length - 5} more`)
+						);
 					}
 				}
 			}
@@ -1494,37 +1776,65 @@ export default function (pi: ExtensionAPI) {
 				let collapsedLines = 1; // statusLine
 				const summaryPreview = details?.summary?.text?.trim() || "";
 				if (summaryPreview) {
-					const preview = summaryPreview.length > 120 ? summaryPreview.slice(0, 117) + "..." : summaryPreview;
+					const preview =
+						summaryPreview.length > 120
+							? summaryPreview.slice(0, 117) + "..."
+							: summaryPreview;
 					box.addChild(new Text(theme.fg("dim", preview), 0, 0));
 					collapsedLines++;
 				} else if (details?.curatedQueries?.length) {
 					for (const cq of details.curatedQueries.slice(0, 3)) {
 						const dq = cq.query.length > 55 ? cq.query.slice(0, 52) + "..." : cq.query;
 						const srcCount = cq.sources?.length ?? 0;
-						const suffix = cq.error ? theme.fg("error", " (error)") : theme.fg("dim", ` · ${srcCount} sources`);
+						const suffix = cq.error
+							? theme.fg("error", " (error)")
+							: theme.fg("dim", ` · ${srcCount} sources`);
 						box.addChild(new Text(theme.fg("accent", `  "${dq}"`) + suffix, 0, 0));
 						collapsedLines++;
 					}
 					if (details.curatedQueries.length > 3) {
-						box.addChild(new Text(theme.fg("dim", `  ... and ${details.curatedQueries.length - 3} more`), 0, 0));
+						box.addChild(
+							new Text(
+								theme.fg(
+									"dim",
+									`  ... and ${details.curatedQueries.length - 3} more`
+								),
+								0,
+								0
+							)
+						);
 						collapsedLines++;
 					}
 				} else {
 					const textContent = result.content.find((c) => c.type === "text")?.text || "";
-					const firstContentLine = textContent.split("\n").find(l => {
+					const firstContentLine = textContent.split("\n").find((l) => {
 						const t = l.trim();
-						return t && !t.startsWith("[") && !t.startsWith("#") && !t.startsWith("---");
+						return (
+							t && !t.startsWith("[") && !t.startsWith("#") && !t.startsWith("---")
+						);
 					});
 					const fallbackLine = (firstContentLine?.trim() || "").replace(/\*\*/g, "");
 					if (fallbackLine) {
-						const preview = fallbackLine.length > 120 ? fallbackLine.slice(0, 117) + "..." : fallbackLine;
+						const preview =
+							fallbackLine.length > 120
+								? fallbackLine.slice(0, 117) + "..."
+								: fallbackLine;
 						box.addChild(new Text(theme.fg("dim", preview), 0, 0));
 						collapsedLines++;
 					}
 				}
 				const moreLines = Math.max(0, totalLines - collapsedLines);
 				if (moreLines > 0) {
-					box.addChild(new Text(theme.fg("muted", `\n... (${moreLines} more lines, ${totalLines} total, ctrl+o to expand)`), 0, 0));
+					box.addChild(
+						new Text(
+							theme.fg(
+								"muted",
+								`\n... (${moreLines} more lines, ${totalLines} total, ctrl+o to expand)`
+							),
+							0,
+							0
+						)
+					);
 				}
 				return box;
 			}
@@ -1537,15 +1847,18 @@ export default function (pi: ExtensionAPI) {
 		name: "code_search",
 		label: "Code Search",
 		description: "Search for code examples, documentation, and API references.",
-		promptSnippet:
-			"Use for programming questions to find code examples and documentation.",
+		promptSnippet: "Use for programming questions to find code examples and documentation.",
 		parameters: Type.Object({
-			query: Type.String({ description: "Programming question, API, library, or debugging topic." }),
-			maxTokens: Type.Optional(Type.Integer({
-				minimum: 1000,
-				maximum: 50000,
-				description: "Maximum tokens of context to return (default: 5000, max: 50000).",
-			})),
+			query: Type.String({
+				description: "Programming question, API, library, or debugging topic.",
+			}),
+			maxTokens: Type.Optional(
+				Type.Integer({
+					minimum: 1000,
+					maximum: 50000,
+					description: "Maximum tokens of context to return (default: 5000, max: 50000).",
+				})
+			),
 		}),
 
 		async execute(toolCallId, params, signal) {
@@ -1556,22 +1869,34 @@ export default function (pi: ExtensionAPI) {
 			const { query } = args as { query?: string };
 			const display = !query
 				? "(no query)"
-				: query.length > 70 ? query.slice(0, 67) + "..." : query;
-			return new Text(theme.fg("toolTitle", theme.bold("code_search ")) + theme.fg("accent", display), 0, 0);
+				: query.length > 70
+					? query.slice(0, 67) + "..."
+					: query;
+			return new Text(
+				theme.fg("toolTitle", theme.bold("code_search ")) + theme.fg("accent", display),
+				0,
+				0
+			);
 		},
 
 		renderResult(result, { expanded }, theme) {
-			const details = result.details as { query?: string; maxTokens?: number; error?: string };
+			const details = result.details as {
+				query?: string;
+				maxTokens?: number;
+				error?: string;
+			};
 			if (details?.error) {
 				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
 			}
 
-			const summary = theme.fg("success", "code context returned") +
+			const summary =
+				theme.fg("success", "code context returned") +
 				theme.fg("muted", ` (${details?.maxTokens ?? 5000} tokens max)`);
 			if (!expanded) return new Text(summary, 0, 0);
 
 			const textContent = result.content.find((c) => c.type === "text")?.text || "";
-			const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
+			const preview =
+				textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
 			return new Text(summary + "\n" + theme.fg("dim", preview), 0, 0);
 		},
 	});
@@ -1579,29 +1904,46 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "fetch_content",
 		label: "Fetch Content",
-		description: "Fetch URL(s) and extract readable content as markdown. Supports YouTube videos (transcripts, frames), GitHub repos (cloned locally), PDFs, local video files, and web pages. Content is stored and retrievable via get_search_content.",
+		description:
+			"Fetch URL(s) and extract readable content as markdown. Supports YouTube videos (transcripts, frames), GitHub repos (cloned locally), PDFs, local video files, and web pages. Content is stored and retrievable via get_search_content.",
 		promptSnippet:
 			"Use to extract content from URLs, YouTube videos, GitHub repos, PDFs, and local video files.",
 		parameters: Type.Object({
 			url: Type.Optional(Type.String({ description: "Single URL to fetch." })),
-			urls: Type.Optional(Type.Array(Type.String(), { description: "Multiple URLs (fetched in parallel)." })),
-			forceClone: Type.Optional(Type.Boolean({
-				description: "Force clone large GitHub repos that would normally return an API-only view.",
-			})),
-			prompt: Type.Optional(Type.String({
-				description: "Question or instruction for video analysis (YouTube and local videos).",
-			})),
-			timestamp: Type.Optional(Type.String({
-				description: "Extract frame(s) at a timestamp or range (e.g. '23:41' or '23:41-25:00').",
-			})),
-			frames: Type.Optional(Type.Integer({
-				minimum: 1,
-				maximum: 12,
-				description: "Number of frames to extract. Use with timestamp for density control, or alone to sample the whole video.",
-			})),
-			model: Type.Optional(Type.String({
-				description: "Override the model used for video analysis.",
-			})),
+			urls: Type.Optional(
+				Type.Array(Type.String(), { description: "Multiple URLs (fetched in parallel)." })
+			),
+			forceClone: Type.Optional(
+				Type.Boolean({
+					description:
+						"Force clone large GitHub repos that would normally return an API-only view.",
+				})
+			),
+			prompt: Type.Optional(
+				Type.String({
+					description:
+						"Question or instruction for video analysis (YouTube and local videos).",
+				})
+			),
+			timestamp: Type.Optional(
+				Type.String({
+					description:
+						"Extract frame(s) at a timestamp or range (e.g. '23:41' or '23:41-25:00').",
+				})
+			),
+			frames: Type.Optional(
+				Type.Integer({
+					minimum: 1,
+					maximum: 12,
+					description:
+						"Number of frames to extract. Use with timestamp for density control, or alone to sample the whole video.",
+				})
+			),
+			model: Type.Optional(
+				Type.String({
+					description: "Override the model used for video analysis.",
+				})
+			),
 		}),
 
 		async execute(_toolCallId, params, signal, onUpdate) {
@@ -1645,7 +1987,17 @@ export default function (pi: ExtensionAPI) {
 				if (result.error) {
 					return {
 						content: [{ type: "text", text: `Error: ${result.error}` }],
-						details: { urls: urlList, urlCount: 1, successful: 0, error: result.error, responseId, extractionMethod: result.extractionMethod || null, prompt: params.prompt, timestamp: params.timestamp, frames: params.frames },
+						details: {
+							urls: urlList,
+							urlCount: 1,
+							successful: 0,
+							error: result.error,
+							responseId,
+							extractionMethod: result.extractionMethod || null,
+							prompt: params.prompt,
+							timestamp: params.timestamp,
+							frames: params.frames,
+						},
 					};
 				}
 
@@ -1656,18 +2008,28 @@ export default function (pi: ExtensionAPI) {
 					: result.content;
 
 				if (truncated) {
-					output += `\n\n---\nShowing ${MAX_INLINE_CONTENT} of ${fullLength} chars. ` +
+					output +=
+						`\n\n---\nShowing ${MAX_INLINE_CONTENT} of ${fullLength} chars. ` +
 						`Use get_search_content({ responseId: "${responseId}", urlIndex: 0 }) for full content.`;
 				}
 
-				const content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> = [];
+				const content: Array<{
+					type: string;
+					text?: string;
+					data?: string;
+					mimeType?: string;
+				}> = [];
 				if (result.frames?.length) {
 					for (const frame of result.frames) {
 						content.push({ type: "image", data: frame.data, mimeType: frame.mimeType });
 						content.push({ type: "text", text: `Frame at ${frame.timestamp}` });
 					}
 				} else if (result.thumbnail) {
-					content.push({ type: "image", data: result.thumbnail.data, mimeType: result.thumbnail.mimeType });
+					content.push({
+						type: "image",
+						data: result.thumbnail.data,
+						mimeType: result.thumbnail.mimeType,
+					});
 				}
 				content.push({ type: "text", text: output });
 
@@ -1706,22 +2068,46 @@ export default function (pi: ExtensionAPI) {
 
 			return {
 				content: [{ type: "text", text: output }],
-				details: { urls: urlList, urlCount: urlList.length, successful, totalChars, responseId, extractionMethods: fetchResults.map(r => r.extractionMethod || null) },
+				details: {
+					urls: urlList,
+					urlCount: urlList.length,
+					successful,
+					totalChars,
+					responseId,
+					extractionMethods: fetchResults.map((r) => r.extractionMethod || null),
+				},
 			};
 		},
 
 		renderCall(args, theme) {
-			const { url, urls, prompt, timestamp, frames, model } = args as { url?: string; urls?: string[]; prompt?: string; timestamp?: string; frames?: number; model?: string };
+			const { url, urls, prompt, timestamp, frames, model } = args as {
+				url?: string;
+				urls?: string[];
+				prompt?: string;
+				timestamp?: string;
+				frames?: number;
+				model?: string;
+			};
 			const urlList = urls ?? (url ? [url] : []);
 			if (urlList.length === 0) {
-				return new Text(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("error", "(no URL)"), 0, 0);
+				return new Text(
+					theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("error", "(no URL)"),
+					0,
+					0
+				);
 			}
 			const lines: string[] = [];
 			if (urlList.length === 1) {
-				const display = urlList[0].length > 60 ? urlList[0].slice(0, 57) + "..." : urlList[0];
-				lines.push(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("accent", display));
+				const display =
+					urlList[0].length > 60 ? urlList[0].slice(0, 57) + "..." : urlList[0];
+				lines.push(
+					theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("accent", display)
+				);
 			} else {
-				lines.push(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("accent", `${urlList.length} URLs`));
+				lines.push(
+					theme.fg("toolTitle", theme.bold("fetch ")) +
+						theme.fg("accent", `${urlList.length} URLs`)
+				);
 				for (const u of urlList.slice(0, 5)) {
 					const display = u.length > 60 ? u.slice(0, 57) + "..." : u;
 					lines.push(theme.fg("muted", "  " + display));
@@ -1767,8 +2153,14 @@ export default function (pi: ExtensionAPI) {
 
 			if (isPartial) {
 				const progress = details?.progress ?? 0;
-				const bar = "\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
-				return new Text(theme.fg("accent", `[${bar}] ${details?.phase || "fetching"}`), 0, 0);
+				const bar =
+					"\u2588".repeat(Math.floor(progress * 10)) +
+					"\u2591".repeat(10 - Math.floor(progress * 10));
+				return new Text(
+					theme.fg("accent", `[${bar}] ${details?.phase || "fetching"}`),
+					0,
+					0
+				);
 			}
 
 			if (details?.error) {
@@ -1778,26 +2170,37 @@ export default function (pi: ExtensionAPI) {
 			if (details?.urlCount === 1) {
 				const title = details?.title || "Untitled";
 				const imgCount = details?.imageCount ?? (details?.hasImage ? 1 : 0);
-				const imageBadge = imgCount > 1
-					? theme.fg("accent", ` [${imgCount} images]`)
-					: imgCount === 1
-						? theme.fg("accent", " [image]")
-						: "";
-				let statusLine = theme.fg("success", title) + theme.fg("muted", ` (${details?.totalChars ?? 0} chars)`) + imageBadge;
+				const imageBadge =
+					imgCount > 1
+						? theme.fg("accent", ` [${imgCount} images]`)
+						: imgCount === 1
+							? theme.fg("accent", " [image]")
+							: "";
+				let statusLine =
+					theme.fg("success", title) +
+					theme.fg("muted", ` (${details?.totalChars ?? 0} chars)`) +
+					imageBadge;
 				if (details?.truncated) {
 					statusLine += theme.fg("warning", " [truncated]");
 				}
 				if (typeof details?.duration === "number") {
-					statusLine += theme.fg("muted", ` | ${formatSeconds(Math.floor(details.duration))} total`);
+					statusLine += theme.fg(
+						"muted",
+						` | ${formatSeconds(Math.floor(details.duration))} total`
+					);
 				}
 				const textContent = result.content.find((c) => c.type === "text")?.text || "";
 				if (!expanded) {
-					const brief = textContent.length > 200 ? textContent.slice(0, 200) + "..." : textContent;
+					const brief =
+						textContent.length > 200 ? textContent.slice(0, 200) + "..." : textContent;
 					return new Text(statusLine + "\n" + theme.fg("dim", brief), 0, 0);
 				}
 				const lines = [statusLine];
 				if (details?.prompt) {
-					const display = details.prompt.length > 250 ? details.prompt.slice(0, 247) + "..." : details.prompt;
+					const display =
+						details.prompt.length > 250
+							? details.prompt.slice(0, 247) + "..."
+							: details.prompt;
 					lines.push(theme.fg("dim", `  prompt: "${display}"`));
 				}
 				if (details?.timestamp) {
@@ -1806,18 +2209,22 @@ export default function (pi: ExtensionAPI) {
 				if (typeof details?.frames === "number") {
 					lines.push(theme.fg("dim", `  frames: ${details.frames}`));
 				}
-				const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
+				const preview =
+					textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
 				lines.push(theme.fg("dim", preview));
 				return new Text(lines.join("\n"), 0, 0);
 			}
 
 			const countColor = (details?.successful ?? 0) > 0 ? "success" : "error";
-			const statusLine = theme.fg(countColor, `${details?.successful}/${details?.urlCount} URLs`) + theme.fg("muted", " (content stored)");
+			const statusLine =
+				theme.fg(countColor, `${details?.successful}/${details?.urlCount} URLs`) +
+				theme.fg("muted", " (content stored)");
 			if (!expanded) {
 				return new Text(statusLine, 0, 0);
 			}
 			const textContent = result.content.find((c) => c.type === "text")?.text || "";
-			const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
+			const preview =
+				textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
 			return new Text(statusLine + "\n" + theme.fg("dim", preview), 0, 0);
 		},
 	});
@@ -1826,12 +2233,17 @@ export default function (pi: ExtensionAPI) {
 		name: "get_search_content",
 		label: "Get Search Content",
 		description: "Retrieve stored content from a previous web_search or fetch_content call.",
-		promptSnippet:
-			"Use to retrieve stored content via responseId and query or url selectors.",
+		promptSnippet: "Use to retrieve stored content via responseId and query or url selectors.",
 		parameters: Type.Object({
-			responseId: Type.String({ description: "The responseId from web_search or fetch_content" }),
-			query: Type.Optional(Type.String({ description: "Get content for this query (web_search)" })),
-			queryIndex: Type.Optional(Type.Number({ description: "Get content for query at index" })),
+			responseId: Type.String({
+				description: "The responseId from web_search or fetch_content",
+			}),
+			query: Type.Optional(
+				Type.String({ description: "Get content for this query (web_search)" })
+			),
+			queryIndex: Type.Optional(
+				Type.Number({ description: "Get content for query at index" })
+			),
 			url: Type.Optional(Type.String({ description: "Get content for this URL" })),
 			urlIndex: Type.Optional(Type.Number({ description: "Get content for URL at index" })),
 		}),
@@ -1840,7 +2252,12 @@ export default function (pi: ExtensionAPI) {
 			const data = getResult(params.responseId);
 			if (!data) {
 				return {
-					content: [{ type: "text", text: `Error: No stored results for "${params.responseId}"` }],
+					content: [
+						{
+							type: "text",
+							text: `Error: No stored results for "${params.responseId}"`,
+						},
+					],
 					details: { error: "Not found", responseId: params.responseId },
 				};
 			}
@@ -1853,7 +2270,12 @@ export default function (pi: ExtensionAPI) {
 					if (!queryData) {
 						const available = data.queries.map((q) => `"${q.query}"`).join(", ");
 						return {
-							content: [{ type: "text", text: `Query "${params.query}" not found. Available: ${available}` }],
+							content: [
+								{
+									type: "text",
+									text: `Query "${params.query}" not found. Available: ${available}`,
+								},
+							],
 							details: { error: "Query not found" },
 						};
 					}
@@ -1861,21 +2283,36 @@ export default function (pi: ExtensionAPI) {
 					queryData = data.queries[params.queryIndex];
 					if (!queryData) {
 						return {
-							content: [{ type: "text", text: `Index ${params.queryIndex} out of range (0-${data.queries.length - 1})` }],
+							content: [
+								{
+									type: "text",
+									text: `Index ${params.queryIndex} out of range (0-${data.queries.length - 1})`,
+								},
+							],
 							details: { error: "Index out of range" },
 						};
 					}
 				} else {
 					const available = data.queries.map((q, i) => `${i}: "${q.query}"`).join(", ");
 					return {
-						content: [{ type: "text", text: `Specify query or queryIndex. Available: ${available}` }],
+						content: [
+							{
+								type: "text",
+								text: `Specify query or queryIndex. Available: ${available}`,
+							},
+						],
 						details: { error: "No query specified" },
 					};
 				}
 
 				if (queryData.error) {
 					return {
-						content: [{ type: "text", text: `Error for "${queryData.query}": ${queryData.error}` }],
+						content: [
+							{
+								type: "text",
+								text: `Error for "${queryData.query}": ${queryData.error}`,
+							},
+						],
 						details: { error: queryData.error, query: queryData.query },
 					};
 				}
@@ -1894,7 +2331,9 @@ export default function (pi: ExtensionAPI) {
 					if (!urlData) {
 						const available = data.urls.map((u) => u.url).join("\n  ");
 						return {
-							content: [{ type: "text", text: `URL not found. Available:\n  ${available}` }],
+							content: [
+								{ type: "text", text: `URL not found. Available:\n  ${available}` },
+							],
 							details: { error: "URL not found" },
 						};
 					}
@@ -1902,28 +2341,44 @@ export default function (pi: ExtensionAPI) {
 					urlData = data.urls[params.urlIndex];
 					if (!urlData) {
 						return {
-							content: [{ type: "text", text: `Index ${params.urlIndex} out of range (0-${data.urls.length - 1})` }],
+							content: [
+								{
+									type: "text",
+									text: `Index ${params.urlIndex} out of range (0-${data.urls.length - 1})`,
+								},
+							],
 							details: { error: "Index out of range" },
 						};
 					}
 				} else {
 					const available = data.urls.map((u, i) => `${i}: ${u.url}`).join("\n  ");
 					return {
-						content: [{ type: "text", text: `Specify url or urlIndex. Available:\n  ${available}` }],
+						content: [
+							{
+								type: "text",
+								text: `Specify url or urlIndex. Available:\n  ${available}`,
+							},
+						],
 						details: { error: "No URL specified" },
 					};
 				}
 
 				if (urlData.error) {
 					return {
-						content: [{ type: "text", text: `Error for ${urlData.url}: ${urlData.error}` }],
+						content: [
+							{ type: "text", text: `Error for ${urlData.url}: ${urlData.error}` },
+						],
 						details: { error: urlData.error, url: urlData.url },
 					};
 				}
 
 				return {
 					content: [{ type: "text", text: `# ${urlData.title}\n\n${urlData.content}` }],
-					details: { url: urlData.url, title: urlData.title, contentLength: urlData.content.length },
+					details: {
+						url: urlData.url,
+						title: urlData.title,
+						contentLength: urlData.content.length,
+					},
 				};
 			}
 
@@ -1946,7 +2401,12 @@ export default function (pi: ExtensionAPI) {
 			else if (queryIndex !== undefined) target = `queryIndex=${queryIndex}`;
 			else if (url) target = url.length > 30 ? url.slice(0, 27) + "..." : url;
 			else if (urlIndex !== undefined) target = `urlIndex=${urlIndex}`;
-			return new Text(theme.fg("toolTitle", theme.bold("get_content ")) + theme.fg("accent", target || responseId.slice(0, 8)), 0, 0);
+			return new Text(
+				theme.fg("toolTitle", theme.bold("get_content ")) +
+					theme.fg("accent", target || responseId.slice(0, 8)),
+				0,
+				0
+			);
 		},
 
 		renderResult(result, { expanded }, theme) {
@@ -1965,9 +2425,13 @@ export default function (pi: ExtensionAPI) {
 
 			let statusLine: string;
 			if (details?.query) {
-				statusLine = theme.fg("success", `"${details.query}"`) + theme.fg("muted", ` (${details.resultCount} results)`);
+				statusLine =
+					theme.fg("success", `"${details.query}"`) +
+					theme.fg("muted", ` (${details.resultCount} results)`);
 			} else {
-				statusLine = theme.fg("success", details?.title || "Content") + theme.fg("muted", ` (${details?.contentLength ?? 0} chars)`);
+				statusLine =
+					theme.fg("success", details?.title || "Content") +
+					theme.fg("muted", ` (${details?.contentLength ?? 0} chars)`);
 			}
 
 			if (!expanded) {
@@ -1975,7 +2439,8 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			const textContent = result.content.find((c) => c.type === "text")?.text || "";
-			const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
+			const preview =
+				textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
 			return new Text(statusLine + "\n" + theme.fg("dim", preview), 0, 0);
 		},
 	});
@@ -1987,9 +2452,7 @@ export default function (pi: ExtensionAPI) {
 			const sessionToken = randomUUID();
 
 			const raw = args.trim();
-			const queries = raw.length > 0
-				? normalizeQueryList(raw.split(","))
-				: [];
+			const queries = raw.length > 0 ? normalizeQueryList(raw.split(",")) : [];
 
 			let bootstrap: CuratorBootstrap;
 			try {
@@ -2017,12 +2480,15 @@ export default function (pi: ExtensionAPI) {
 			let commandHandle: CuratorServerHandle | null = null;
 
 			function sendFollowUpFromReturn(payload: ReturnType<typeof buildSearchReturn>) {
-				pi.sendMessage({
-					customType: "web-search-results",
-					content: payload.content,
-					display: "tool",
-					details: payload.details,
-				}, { triggerTurn: true, deliverAs: "followUp" });
+				pi.sendMessage(
+					{
+						customType: "web-search-results",
+						content: payload.content,
+						display: "tool",
+						details: payload.details,
+					},
+					{ triggerTurn: true, deliverAs: "followUp" }
+				);
 			}
 
 			try {
@@ -2047,18 +2513,19 @@ export default function (pi: ExtensionAPI) {
 								summaryContext,
 								summarizeSignal,
 								model,
-								feedback,
+								feedback
 							);
 						},
 						onSubmit(payload) {
 							if (commandHandle && activeCurator !== commandHandle) return;
 							aborted = true;
 							searchAbort.abort();
-							const filtered = payload.selectedQueryIndices.length > 0
-								? filterByQueryIndices(payload.selectedQueryIndices, collected)
-								: collectAllResultsAndUrls(collected);
+							const filtered =
+								payload.selectedQueryIndices.length > 0
+									? filterByQueryIndices(payload.selectedQueryIndices, collected)
+									: collectAllResultsAndUrls(collected);
 							const base: SearchReturnOptions = {
-								queryList: filtered.results.map(r => r.query),
+								queryList: filtered.results.map((r) => r.query),
 								results: filtered.results,
 								urls: filtered.urls,
 								includeContent: false,
@@ -2080,18 +2547,27 @@ export default function (pi: ExtensionAPI) {
 							searchAbort.abort();
 							if (reason === "timeout") {
 								const all = collectAllResultsAndUrls(collected);
-								const resolvedSummary = resolveSummaryForSubmit({ selectedQueryIndices: [], summary: undefined, summaryMeta: undefined }, collected);
-								sendFollowUpFromReturn(buildSearchReturn({
-									queryList: all.results.map(r => r.query),
-									results: all.results,
-									urls: all.urls,
-									includeContent: false,
-									curated: true,
-									curatedFrom: collected.size,
-									workflow: "summary-review",
-									approvedSummary: resolvedSummary.approvedSummary,
-									summaryMeta: resolvedSummary.summaryMeta,
-								}));
+								const resolvedSummary = resolveSummaryForSubmit(
+									{
+										selectedQueryIndices: [],
+										summary: undefined,
+										summaryMeta: undefined,
+									},
+									collected
+								);
+								sendFollowUpFromReturn(
+									buildSearchReturn({
+										queryList: all.results.map((r) => r.query),
+										results: all.results,
+										urls: all.urls,
+										includeContent: false,
+										curated: true,
+										curatedFrom: collected.size,
+										workflow: "summary-review",
+										approvedSummary: resolvedSummary.approvedSummary,
+										summaryMeta: resolvedSummary.summaryMeta,
+									})
+								);
 							}
 							closeCurator();
 						},
@@ -2112,27 +2588,48 @@ export default function (pi: ExtensionAPI) {
 								throw new Error("Curator session is no longer active.");
 							}
 							const normalizedProvider = normalizeProviderInput(provider);
-							const requestedProvider = !normalizedProvider || normalizedProvider === "auto"
-								? currentProvider
-								: normalizedProvider;
+							const requestedProvider =
+								!normalizedProvider || normalizedProvider === "auto"
+									? currentProvider
+									: normalizedProvider;
 							try {
-								const { answer, results, provider: actualProvider } = await search(query, {
+								const {
+									answer,
+									results,
+									provider: actualProvider,
+								} = await search(query, {
 									provider: requestedProvider,
 									signal: searchAbort.signal,
 								});
 								if (commandHandle && activeCurator !== commandHandle) {
 									throw new Error("Curator session is no longer active.");
 								}
-								collected.set(queryIndex, { query, answer, results, error: null, provider: actualProvider });
+								collected.set(queryIndex, {
+									query,
+									answer,
+									results,
+									error: null,
+									provider: actualProvider,
+								});
 								return {
 									answer,
-									results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+									results: results.map((r) => ({
+										title: r.title,
+										url: r.url,
+										domain: extractDomain(r.url),
+									})),
 									provider: actualProvider,
 								};
 							} catch (err) {
 								const message = err instanceof Error ? err.message : String(err);
 								if (!commandHandle || activeCurator === commandHandle) {
-									collected.set(queryIndex, { query, answer: "", results: [], error: message, provider: requestedProvider });
+									collected.set(queryIndex, {
+										query,
+										answer: "",
+										results: [],
+										error: message,
+										provider: requestedProvider,
+									});
 								}
 								throw err;
 							}
@@ -2143,7 +2640,7 @@ export default function (pi: ExtensionAPI) {
 							}
 							return rewriteSearchQuery(query, summaryContext, rewriteSignal);
 						},
-					},
+					}
 				);
 
 				commandHandle = handle;
@@ -2182,15 +2679,31 @@ export default function (pi: ExtensionAPI) {
 								if (aborted || activeCurator !== handle) break;
 								handle.pushResult(qi, {
 									answer,
-									results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+									results: results.map((r) => ({
+										title: r.title,
+										url: r.url,
+										domain: extractDomain(r.url),
+									})),
 									provider,
 								});
-								collected.set(qi, { query: queries[qi], answer, results, error: null, provider });
+								collected.set(qi, {
+									query: queries[qi],
+									answer,
+									results,
+									error: null,
+									provider,
+								});
 							} catch (err) {
 								if (aborted || activeCurator !== handle) break;
 								const message = err instanceof Error ? err.message : String(err);
 								handle.pushError(qi, message, requestedProvider);
-								collected.set(qi, { query: queries[qi], answer: "", results: [], error: message, provider: requestedProvider });
+								collected.set(qi, {
+									query: queries[qi],
+									answer: "",
+									results: [],
+									error: message,
+									provider: requestedProvider,
+								});
 							}
 						}
 						if (!aborted && activeCurator === handle) handle.searchesDone();
@@ -2234,15 +2747,19 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
-			const label = newWorkflow === "none"
-				? "Curator disabled — web_search will return raw results"
-				: "Curator enabled — web_search will open curator and auto-generate a summary draft";
-			pi.sendMessage({
-				customType: "curator-config",
-				content: [{ type: "text", text: label }],
-				display: "tool",
-				details: { workflow: newWorkflow },
-			}, { triggerTurn: false, deliverAs: "followUp" });
+			const label =
+				newWorkflow === "none"
+					? "Curator disabled — web_search will return raw results"
+					: "Curator enabled — web_search will open curator and auto-generate a summary draft";
+			pi.sendMessage(
+				{
+					customType: "curator-config",
+					content: [{ type: "text", text: label }],
+					display: "tool",
+					details: { workflow: newWorkflow },
+				},
+				{ triggerTurn: false, deliverAs: "followUp" }
+			);
 		},
 	});
 
@@ -2250,23 +2767,39 @@ export default function (pi: ExtensionAPI) {
 		description: "Show the active Google account for Gemini Web",
 		handler: async () => {
 			if (!isBrowserCookieAccessAllowed()) {
-				pi.sendMessage({
-					customType: "google-account",
-					content: [{ type: "text", text: "Gemini Web browser cookie access is disabled. Set allowBrowserCookies: true in ~/.pi/web-search.json to enable it." }],
-					display: "tool",
-					details: { available: false, cookieAccessAllowed: false },
-				}, { triggerTurn: true, deliverAs: "followUp" });
+				pi.sendMessage(
+					{
+						customType: "google-account",
+						content: [
+							{
+								type: "text",
+								text: "Gemini Web browser cookie access is disabled. Set allowBrowserCookies: true in ~/.pi/web-search.json to enable it.",
+							},
+						],
+						display: "tool",
+						details: { available: false, cookieAccessAllowed: false },
+					},
+					{ triggerTurn: true, deliverAs: "followUp" }
+				);
 				return;
 			}
 
 			const cookies = await isGeminiWebAvailable();
 			if (!cookies) {
-				pi.sendMessage({
-					customType: "google-account",
-					content: [{ type: "text", text: "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser." }],
-					display: "tool",
-					details: { available: false, cookieAccessAllowed: true },
-				}, { triggerTurn: true, deliverAs: "followUp" });
+				pi.sendMessage(
+					{
+						customType: "google-account",
+						content: [
+							{
+								type: "text",
+								text: "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser.",
+							},
+						],
+						display: "tool",
+						details: { available: false, cookieAccessAllowed: true },
+					},
+					{ triggerTurn: true, deliverAs: "followUp" }
+				);
 				return;
 			}
 
@@ -2275,12 +2808,15 @@ export default function (pi: ExtensionAPI) {
 				? `Active Google account: ${email}`
 				: "Gemini Web is available, but the active Google account could not be determined.";
 
-			pi.sendMessage({
-				customType: "google-account",
-				content: [{ type: "text", text }],
-				display: "tool",
-				details: { available: true, email: email ?? null },
-			}, { triggerTurn: true, deliverAs: "followUp" });
+			pi.sendMessage(
+				{
+					customType: "google-account",
+					content: [{ type: "text", text }],
+					display: "tool",
+					details: { available: true, email: email ?? null },
+				},
+				{ triggerTurn: true, deliverAs: "followUp" }
+			);
 		},
 	});
 

--- a/index.ts
+++ b/index.ts
@@ -1348,6 +1348,7 @@ export default function (pi: ExtensionAPI) {
 				queryCount?: number;
 				successfulQueries?: number;
 				totalResults?: number;
+				providers?: (string | null)[];
 				error?: string;
 				fetchId?: string;
 				fetchUrls?: string[];
@@ -1393,7 +1394,9 @@ export default function (pi: ExtensionAPI) {
 
 			let statusLine: string;
 			const queryInfo = details?.queryCount === 1 ? "" : `${details?.successfulQueries}/${details?.queryCount} queries, `;
-			statusLine = theme.fg("success", `${queryInfo}${details?.totalResults ?? 0} sources`);
+			const providers = details?.providers?.filter(Boolean) as string[] | undefined;
+			const providerLabel = providers && providers.length > 0 ? ` · ${providers.join(", ")}` : "";
+			statusLine = theme.fg("success", `${queryInfo}${details?.totalResults ?? 0} sources`) + theme.fg("muted", providerLabel);
 			if (details?.curated && details?.curatedFrom) {
 				statusLine += theme.fg("muted", ` (${details.queryCount}/${details.curatedFrom} queries curated)`);
 			}

--- a/index.ts
+++ b/index.ts
@@ -750,7 +750,8 @@ export default function (pi: ExtensionAPI) {
 						: `## Query: "${query}"\n\n`;
 				}
 				if (error) output += `Error: ${error}\n\n`;
-				else if (results.length === 0) output += "No results found.\n\n";
+				else if (results.length === 0) output += answer ? `${answer}\n\n---\n
+**Sources:** None found.\n` : "No results found.\n\n";
 				else output += formatSearchSummary(results, answer) + "\n\n";
 			}
 		}

--- a/index.ts
+++ b/index.ts
@@ -129,8 +129,8 @@ function normalizeCuratorTimeoutSeconds(value: unknown): number | undefined {
 
 function resolveWorkflow(input: unknown, hasUI: boolean): WebSearchWorkflow {
 	if (!hasUI) return "none";
-	if (typeof input === "string" && input.trim().toLowerCase() === "none") return "none";
-	return "summary-review";
+	if (typeof input === "string" && input.trim().toLowerCase() === "summary-review") return "summary-review";
+	return "none";
 }
 
 function normalizeQueryList(queryList: unknown[]): string[] {
@@ -784,6 +784,7 @@ export default function (pi: ExtensionAPI) {
 			content: [{ type: "text", text: output.trim() }],
 			details: {
 				queries: opts.queryList,
+				providers: opts.results.map(r => r.provider || null),
 				queryCount: opts.queryList.length,
 				successfulQueries: sc,
 				totalResults: tr,
@@ -1089,24 +1090,24 @@ export default function (pi: ExtensionAPI) {
 		name: "web_search",
 		label: "Web Search",
 		description:
-			`Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).`,
+			`Search the web. Returns an AI-synthesized answer with source citations. Use queries (plural) with 2-4 varied angles for comprehensive research.`,
 		promptSnippet:
-			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
+			"Use for web research. Prefer {queries:[...]} with 2-4 varied angles for broader coverage.",
 		parameters: Type.Object({
-			query: Type.Optional(Type.String({ description: "Single search query. For research tasks, prefer 'queries' with multiple varied angles instead." })),
-			queries: Type.Optional(Type.Array(Type.String(), { description: "Multiple queries searched in sequence, each returning its own synthesized answer. Prefer this for research — vary phrasing, scope, and angle across 2-4 queries to maximize coverage. Good: ['React vs Vue performance benchmarks 2026', 'React vs Vue developer experience comparison', 'React ecosystem size vs Vue ecosystem']. Bad: ['React vs Vue', 'React vs Vue comparison', 'React vs Vue review'] (too similar, redundant results)." })),
-			numResults: Type.Optional(Type.Number({ description: "Results per query (default: 5, max: 20)" })),
-			includeContent: Type.Optional(Type.Boolean({ description: "Fetch full page content (async)" })),
+			query: Type.Optional(Type.String({ description: "Single search query." })),
+			queries: Type.Optional(Type.Array(Type.String(), { description: "Multiple queries, each returning its own answer. Use 2-4 varied angles for research." })),
+			numResults: Type.Optional(Type.Number({ description: "Results per query (default: 5, max: 20)." })),
+			includeContent: Type.Optional(Type.Boolean({ description: "Fetch full page content from results (async)." })),
 			recencyFilter: Type.Optional(
-				StringEnum(["day", "week", "month", "year"], { description: "Filter by recency" }),
+				StringEnum(["day", "week", "month", "year"], { description: "Filter results by recency." }),
 			),
-			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
+			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit or exclude domains (prefix with - to exclude)." })),
 			provider: Type.Optional(
-				StringEnum(["auto", "perplexity", "gemini", "exa"], { description: "Search provider (default: auto)" }),
+				StringEnum(["auto", "perplexity", "gemini", "exa"], { description: "Search provider (default: auto)." }),
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review"], {
-					description: "Search workflow mode: none = no curator, summary-review = open curator with auto summary draft (default)",
+					description: "Workflow: none = return results directly; summary-review = open browser curator for curation (default: none).",
 				}),
 			),
 		}),
@@ -1531,15 +1532,15 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "code_search",
 		label: "Code Search",
-		description: "Search for code examples, documentation, and API references. Returns relevant code snippets and docs from GitHub, Stack Overflow, and official documentation. Use for any programming question — API usage, library examples, debugging help.",
+		description: "Search for code examples, documentation, and API references.",
 		promptSnippet:
-			"Use for programming/API/library questions to retrieve concrete examples and docs before implementing or debugging code.",
+			"Use for programming questions to find code examples and documentation.",
 		parameters: Type.Object({
-			query: Type.String({ description: "Programming question, API, library, or debugging topic to search for" }),
+			query: Type.String({ description: "Programming question, API, library, or debugging topic." }),
 			maxTokens: Type.Optional(Type.Integer({
 				minimum: 1000,
 				maximum: 50000,
-				description: "Maximum tokens of code/documentation context to return (default: 5000)",
+				description: "Maximum tokens of context to return (default: 5000, max: 50000).",
 			})),
 		}),
 
@@ -1574,28 +1575,28 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "fetch_content",
 		label: "Fetch Content",
-		description: "Fetch URL(s) and extract readable content as markdown. Supports YouTube video transcripts (with thumbnail), GitHub repository contents, and local video files (with frame thumbnail). Video frames can be extracted via timestamp/range or sampled across the entire video with frames alone. Falls back to Gemini for pages that block bots or fail Readability extraction. For YouTube and video files: ALWAYS pass the user's specific question via the prompt parameter — this directs the AI to focus on that aspect of the video, producing much better results than a generic extraction. Content is always stored and can be retrieved with get_search_content.",
+		description: "Fetch URL(s) and extract readable content as markdown. Supports YouTube videos (transcripts, frames), GitHub repos (cloned locally), PDFs, local video files, and web pages. Content is stored and retrievable via get_search_content.",
 		promptSnippet:
-			"Use to extract readable content from URL(s), YouTube, GitHub repos, or local videos. For video questions, pass the user's exact question in prompt.",
+			"Use to extract content from URLs, YouTube videos, GitHub repos, PDFs, and local video files.",
 		parameters: Type.Object({
-			url: Type.Optional(Type.String({ description: "Single URL to fetch" })),
-			urls: Type.Optional(Type.Array(Type.String(), { description: "Multiple URLs (parallel)" })),
+			url: Type.Optional(Type.String({ description: "Single URL to fetch." })),
+			urls: Type.Optional(Type.Array(Type.String(), { description: "Multiple URLs (fetched in parallel)." })),
 			forceClone: Type.Optional(Type.Boolean({
-				description: "Force cloning large GitHub repositories that exceed the size threshold",
+				description: "Force clone large GitHub repos that would normally return an API-only view.",
 			})),
 			prompt: Type.Optional(Type.String({
-				description: "Question or instruction for video analysis (YouTube and video files). Pass the user's specific question here — e.g. 'describe the book shown at the advice for beginners section'. Without this, a generic transcript extraction is used which may miss what the user is asking about.",
+				description: "Question or instruction for video analysis (YouTube and local videos).",
 			})),
 			timestamp: Type.Optional(Type.String({
-				description: "Extract video frame(s) at a timestamp or time range. Single: '1:23:45', '23:45', or '85' (seconds). Range: '23:41-25:00' extracts evenly-spaced frames across that span (default 6). Use frames with ranges to control density; single+frames uses a fixed 5s interval. YouTube requires yt-dlp + ffmpeg; local videos require ffmpeg. Use a range when you know the approximate area but not the exact moment — you'll get a contact sheet to visually identify the right frame.",
+				description: "Extract frame(s) at a timestamp or range (e.g. '23:41' or '23:41-25:00').",
 			})),
 			frames: Type.Optional(Type.Integer({
 				minimum: 1,
 				maximum: 12,
-				description: "Number of frames to extract. Use with timestamp range for custom density, with single timestamp to get N frames at 5s intervals, or alone to sample across the entire video. Requires yt-dlp + ffmpeg for YouTube, ffmpeg for local video.",
+				description: "Number of frames to extract. Use with timestamp for density control, or alone to sample the whole video.",
 			})),
 			model: Type.Optional(Type.String({
-				description: "Override the Gemini model for video/YouTube analysis (e.g. 'gemini-2.5-flash', 'gemini-3-flash-preview'). Defaults to config or gemini-3-flash-preview.",
+				description: "Override the model used for video analysis.",
 			})),
 		}),
 
@@ -1640,7 +1641,7 @@ export default function (pi: ExtensionAPI) {
 				if (result.error) {
 					return {
 						content: [{ type: "text", text: `Error: ${result.error}` }],
-						details: { urls: urlList, urlCount: 1, successful: 0, error: result.error, responseId, prompt: params.prompt, timestamp: params.timestamp, frames: params.frames },
+						details: { urls: urlList, urlCount: 1, successful: 0, error: result.error, responseId, extractionMethod: result.extractionMethod || null, prompt: params.prompt, timestamp: params.timestamp, frames: params.frames },
 					};
 				}
 
@@ -1677,6 +1678,7 @@ export default function (pi: ExtensionAPI) {
 						title: result.title,
 						responseId,
 						truncated,
+						extractionMethod: result.extractionMethod || null,
 						hasImage: imageCount > 0,
 						imageCount,
 						prompt: params.prompt,
@@ -1700,7 +1702,7 @@ export default function (pi: ExtensionAPI) {
 
 			return {
 				content: [{ type: "text", text: output }],
-				details: { urls: urlList, urlCount: urlList.length, successful, totalChars, responseId },
+				details: { urls: urlList, urlCount: urlList.length, successful, totalChars, responseId, extractionMethods: fetchResults.map(r => r.extractionMethod || null) },
 			};
 		},
 
@@ -1819,9 +1821,9 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "get_search_content",
 		label: "Get Search Content",
-		description: "Retrieve full content from a previous web_search or fetch_content call.",
+		description: "Retrieve stored content from a previous web_search or fetch_content call.",
 		promptSnippet:
-			"Use after web_search/fetch_content when full stored content is needed via responseId plus query/url selectors.",
+			"Use to retrieve stored content via responseId and query or url selectors.",
 		parameters: Type.Object({
 			responseId: Type.String({ description: "The responseId from web_search or fetch_content" }),
 			query: Type.Optional(Type.String({ description: "Get content for this query (web_search)" })),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,248 +1,267 @@
 {
-  "name": "pi-web-access",
-  "version": "0.10.7",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "pi-web-access",
-      "version": "0.10.7",
-      "license": "MIT",
-      "dependencies": {
-        "@mozilla/readability": "^0.5.0",
-        "linkedom": "^0.16.0",
-        "p-limit": "^6.1.0",
-        "turndown": "^7.2.0",
-        "unpdf": "^1.6.2"
-      }
-    },
-    "node_modules/@mixmark-io/domino": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
-      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@mozilla/readability": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.5.0.tgz",
-      "integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
-    },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "license": "MIT"
-    },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/html-escaper": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
-      "license": "MIT"
-    },
-    "node_modules/htmlparser2": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.1.0",
-        "entities": "^4.5.0"
-      }
-    },
-    "node_modules/linkedom": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.11.tgz",
-      "integrity": "sha512-WgaTVbj7itjyXTsCvgerpneERXShcnNJF5VIV+/4SLtyRLN+HppPre/WDHRofAr2IpEuujSNgJbCBd5lMl6lRw==",
-      "license": "ISC",
-      "dependencies": {
-        "css-select": "^5.1.0",
-        "cssom": "^0.5.0",
-        "html-escaper": "^3.0.3",
-        "htmlparser2": "^9.1.0",
-        "uhyphen": "^0.2.0"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
-      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/turndown": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
-      "integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mixmark-io/domino": "^2.2.0"
-      }
-    },
-    "node_modules/uhyphen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
-      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
-      "license": "ISC"
-    },
-    "node_modules/unpdf": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
-      "integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@napi-rs/canvas": "^0.1.69"
-      },
-      "peerDependenciesMeta": {
-        "@napi-rs/canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    }
-  }
+	"name": "pi-web-access",
+	"version": "0.10.7",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "pi-web-access",
+			"version": "0.10.7",
+			"license": "MIT",
+			"dependencies": {
+				"@mozilla/readability": "^0.5.0",
+				"linkedom": "^0.16.0",
+				"p-limit": "^6.1.0",
+				"turndown": "^7.2.0",
+				"unpdf": "^1.6.2"
+			},
+			"devDependencies": {
+				"prettier": "^3.8.3"
+			}
+		},
+		"node_modules/@mixmark-io/domino": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/@mozilla/readability": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.5.0.tgz",
+			"integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"license": "ISC"
+		},
+		"node_modules/css-select": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cssom": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+			"license": "MIT"
+		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+			"integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+			"license": "MIT"
+		},
+		"node_modules/htmlparser2": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+			"integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.1.0",
+				"entities": "^4.5.0"
+			}
+		},
+		"node_modules/linkedom": {
+			"version": "0.16.11",
+			"resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.11.tgz",
+			"integrity": "sha512-WgaTVbj7itjyXTsCvgerpneERXShcnNJF5VIV+/4SLtyRLN+HppPre/WDHRofAr2IpEuujSNgJbCBd5lMl6lRw==",
+			"license": "ISC",
+			"dependencies": {
+				"css-select": "^5.1.0",
+				"cssom": "^0.5.0",
+				"html-escaper": "^3.0.3",
+				"htmlparser2": "^9.1.0",
+				"uhyphen": "^0.2.0"
+			}
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+			"integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/turndown": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
+			"integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@mixmark-io/domino": "^2.2.0"
+			}
+		},
+		"node_modules/uhyphen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+			"integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+			"license": "ISC"
+		},
+		"node_modules/unpdf": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
+			"integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@napi-rs/canvas": "^0.1.69"
+			},
+			"peerDependenciesMeta": {
+				"@napi-rs/canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+			"integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,45 +1,50 @@
 {
-  "name": "pi-web-access",
-  "version": "0.10.7",
-  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent",
-  "type": "module",
-  "scripts": {
-    "test": "node --test"
-  },
-  "keywords": [
-    "pi-package",
-    "pi",
-    "pi-coding-agent",
-    "extension",
-    "web-search",
-    "perplexity",
-    "fetch",
-    "scraping"
-  ],
-  "author": "Nico Bailon",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nicobailon/pi-web-access.git"
-  },
-  "bugs": {
-    "url": "https://github.com/nicobailon/pi-web-access/issues"
-  },
-  "homepage": "https://github.com/nicobailon/pi-web-access#readme",
-  "dependencies": {
-    "@mozilla/readability": "^0.5.0",
-    "linkedom": "^0.16.0",
-    "p-limit": "^6.1.0",
-    "turndown": "^7.2.0",
-    "unpdf": "^1.6.2"
-  },
-  "pi": {
-    "extensions": [
-      "./index.ts"
-    ],
-    "skills": [
-      "./skills"
-    ],
-    "video": "https://github.com/nicobailon/pi-web-access/raw/refs/heads/main/pi-web-fetch-demo.mp4"
-  }
+	"name": "pi-web-access",
+	"version": "0.10.7",
+	"description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent",
+	"type": "module",
+	"scripts": {
+		"format": "prettier --write '*.ts' '*.json' 'test/**/*.mjs'",
+		"format:check": "prettier --check '*.ts' '*.json' 'test/**/*.mjs'",
+		"test": "node --test"
+	},
+	"keywords": [
+		"pi-package",
+		"pi",
+		"pi-coding-agent",
+		"extension",
+		"web-search",
+		"perplexity",
+		"fetch",
+		"scraping"
+	],
+	"author": "Nico Bailon",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/nicobailon/pi-web-access.git"
+	},
+	"bugs": {
+		"url": "https://github.com/nicobailon/pi-web-access/issues"
+	},
+	"homepage": "https://github.com/nicobailon/pi-web-access#readme",
+	"dependencies": {
+		"@mozilla/readability": "^0.5.0",
+		"linkedom": "^0.16.0",
+		"p-limit": "^6.1.0",
+		"turndown": "^7.2.0",
+		"unpdf": "^1.6.2"
+	},
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		],
+		"skills": [
+			"./skills"
+		],
+		"video": "https://github.com/nicobailon/pi-web-access/raw/refs/heads/main/pi-web-fetch-demo.mp4"
+	},
+	"devDependencies": {
+		"prettier": "^3.8.3"
+	}
 }

--- a/pdf-extract.ts
+++ b/pdf-extract.ts
@@ -1,6 +1,6 @@
 /**
  * PDF Content Extractor
- * 
+ *
  * Extracts text from PDF files and saves to markdown.
  * Uses unpdf (pdfjs-dist wrapper) for text extraction.
  */
@@ -11,16 +11,16 @@ import { join, basename } from "node:path";
 import { homedir } from "node:os";
 
 export interface PDFExtractResult {
-  title: string;
-  pages: number;
-  chars: number;
-  outputPath: string;
+	title: string;
+	pages: number;
+	chars: number;
+	outputPath: string;
 }
 
 export interface PDFExtractOptions {
-  maxPages?: number;
-  outputDir?: string;
-  filename?: string;
+	maxPages?: number;
+	outputDir?: string;
+	filename?: string;
 }
 
 const DEFAULT_MAX_PAGES = 100;
@@ -30,163 +30,162 @@ const DEFAULT_OUTPUT_DIR = join(homedir(), "Downloads");
  * Extract text from a PDF buffer and save to markdown file
  */
 export async function extractPDFToMarkdown(
-  buffer: ArrayBuffer,
-  url: string,
-  options: PDFExtractOptions = {}
+	buffer: ArrayBuffer,
+	url: string,
+	options: PDFExtractOptions = {}
 ): Promise<PDFExtractResult> {
-  const {
-    maxPages = DEFAULT_MAX_PAGES,
-    outputDir = DEFAULT_OUTPUT_DIR,
-    filename,
-  } = options;
+	const { maxPages = DEFAULT_MAX_PAGES, outputDir = DEFAULT_OUTPUT_DIR, filename } = options;
 
-  const safeMaxPages = Number.isFinite(maxPages)
-    ? Math.max(1, Math.floor(maxPages))
-    : DEFAULT_MAX_PAGES;
+	const safeMaxPages = Number.isFinite(maxPages)
+		? Math.max(1, Math.floor(maxPages))
+		: DEFAULT_MAX_PAGES;
 
-  const pdf = await getDocumentProxy(new Uint8Array(buffer));
-  const metadata = await pdf.getMetadata();
-  const metadataInfo = metadata.info && typeof metadata.info === "object"
-    ? metadata.info as Record<string, unknown>
-    : null;
+	const pdf = await getDocumentProxy(new Uint8Array(buffer));
+	const metadata = await pdf.getMetadata();
+	const metadataInfo =
+		metadata.info && typeof metadata.info === "object"
+			? (metadata.info as Record<string, unknown>)
+			: null;
 
-  // Extract title from metadata or URL
-  const metaTitle = typeof metadataInfo?.Title === "string" ? metadataInfo.Title : undefined;
-  const metaAuthor = typeof metadataInfo?.Author === "string" ? metadataInfo.Author : undefined;
-  const urlTitle = extractTitleFromURL(url);
-  const title = metaTitle?.trim() || urlTitle;
+	// Extract title from metadata or URL
+	const metaTitle = typeof metadataInfo?.Title === "string" ? metadataInfo.Title : undefined;
+	const metaAuthor = typeof metadataInfo?.Author === "string" ? metadataInfo.Author : undefined;
+	const urlTitle = extractTitleFromURL(url);
+	const title = metaTitle?.trim() || urlTitle;
 
-  // Determine pages to extract
-  const pagesToExtract = Math.min(pdf.numPages, safeMaxPages);
-  const truncated = pdf.numPages > safeMaxPages;
+	// Determine pages to extract
+	const pagesToExtract = Math.min(pdf.numPages, safeMaxPages);
+	const truncated = pdf.numPages > safeMaxPages;
 
-  // Extract text page by page for better structure
-  const pages: { pageNum: number; text: string }[] = [];
-  for (let i = 1; i <= pagesToExtract; i++) {
-    const page = await pdf.getPage(i);
-    const textContent = await page.getTextContent();
-    const pageText = textContent.items
-      .map((item: unknown) => {
-        const textItem = item as { str?: string };
-        return textItem.str || "";
-      })
-      .join(" ")
-      .replace(/\s+/g, " ")
-      .trim();
-    
-    if (pageText) {
-      pages.push({ pageNum: i, text: pageText });
-    }
-  }
+	// Extract text page by page for better structure
+	const pages: { pageNum: number; text: string }[] = [];
+	for (let i = 1; i <= pagesToExtract; i++) {
+		const page = await pdf.getPage(i);
+		const textContent = await page.getTextContent();
+		const pageText = textContent.items
+			.map((item: unknown) => {
+				const textItem = item as { str?: string };
+				return textItem.str || "";
+			})
+			.join(" ")
+			.replace(/\s+/g, " ")
+			.trim();
 
-  // Build markdown content
-  const lines: string[] = [];
-  
-  // Header with metadata
-  lines.push(`# ${title}`);
-  lines.push("");
-  lines.push(`> Source: ${url}`);
-  lines.push(`> Pages: ${pdf.numPages}${truncated ? ` (extracted first ${pagesToExtract})` : ""}`);
-  if (metaAuthor) {
-    lines.push(`> Author: ${metaAuthor}`);
-  }
-  lines.push("");
-  lines.push("---");
-  lines.push("");
+		if (pageText) {
+			pages.push({ pageNum: i, text: pageText });
+		}
+	}
 
-  // Content with page markers
-  for (let i = 0; i < pages.length; i++) {
-    if (i > 0) {
-      lines.push("");
-      lines.push(`<!-- Page ${pages[i].pageNum} -->`);
-      lines.push("");
-    }
-    lines.push(pages[i].text);
-  }
+	// Build markdown content
+	const lines: string[] = [];
 
-  if (truncated) {
-    lines.push("");
-    lines.push("---");
-    lines.push("");
-    lines.push(`*[Truncated: Only first ${pagesToExtract} of ${pdf.numPages} pages extracted]*`);
-  }
+	// Header with metadata
+	lines.push(`# ${title}`);
+	lines.push("");
+	lines.push(`> Source: ${url}`);
+	lines.push(
+		`> Pages: ${pdf.numPages}${truncated ? ` (extracted first ${pagesToExtract})` : ""}`
+	);
+	if (metaAuthor) {
+		lines.push(`> Author: ${metaAuthor}`);
+	}
+	lines.push("");
+	lines.push("---");
+	lines.push("");
 
-  const content = lines.join("\n");
+	// Content with page markers
+	for (let i = 0; i < pages.length; i++) {
+		if (i > 0) {
+			lines.push("");
+			lines.push(`<!-- Page ${pages[i].pageNum} -->`);
+			lines.push("");
+		}
+		lines.push(pages[i].text);
+	}
 
-  // Generate output filename
-  const outputFilename = filename || sanitizeFilename(title) + ".md";
-  const outputPath = join(outputDir, outputFilename);
+	if (truncated) {
+		lines.push("");
+		lines.push("---");
+		lines.push("");
+		lines.push(
+			`*[Truncated: Only first ${pagesToExtract} of ${pdf.numPages} pages extracted]*`
+		);
+	}
 
-  // Ensure output directory exists
-  await mkdir(outputDir, { recursive: true });
+	const content = lines.join("\n");
 
-  // Write file
-  await writeFile(outputPath, content, "utf-8");
+	// Generate output filename
+	const outputFilename = filename || sanitizeFilename(title) + ".md";
+	const outputPath = join(outputDir, outputFilename);
 
-  return {
-    title,
-    pages: pdf.numPages,
-    chars: content.length,
-    outputPath,
-  };
+	// Ensure output directory exists
+	await mkdir(outputDir, { recursive: true });
+
+	// Write file
+	await writeFile(outputPath, content, "utf-8");
+
+	return {
+		title,
+		pages: pdf.numPages,
+		chars: content.length,
+		outputPath,
+	};
 }
 
 /**
  * Extract a reasonable title from URL
  */
 function extractTitleFromURL(url: string): string {
-  try {
-    const urlObj = new URL(url);
-    const pathname = urlObj.pathname;
-    
-    // Get filename without extension
-    let filename = basename(pathname, ".pdf");
-    
-    // Handle arxiv URLs: /pdf/1706.03762 → "arxiv-1706.03762"
-    if (urlObj.hostname.includes("arxiv.org")) {
-      const match = pathname.match(/\/(?:pdf|abs)\/(\d+\.\d+)/);
-      if (match) {
-        filename = `arxiv-${match[1]}`;
-      }
-    }
-    
-    // Clean up filename
-    filename = filename
-      .replace(/[_-]+/g, " ")
-      .replace(/\s+/g, " ")
-      .trim();
-    
-    return filename || "document";
-  } catch {
-    return "document";
-  }
+	try {
+		const urlObj = new URL(url);
+		const pathname = urlObj.pathname;
+
+		// Get filename without extension
+		let filename = basename(pathname, ".pdf");
+
+		// Handle arxiv URLs: /pdf/1706.03762 → "arxiv-1706.03762"
+		if (urlObj.hostname.includes("arxiv.org")) {
+			const match = pathname.match(/\/(?:pdf|abs)\/(\d+\.\d+)/);
+			if (match) {
+				filename = `arxiv-${match[1]}`;
+			}
+		}
+
+		// Clean up filename
+		filename = filename.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+
+		return filename || "document";
+	} catch {
+		return "document";
+	}
 }
 
 /**
  * Sanitize string for use as filename
  */
 function sanitizeFilename(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .slice(0, 100)
-    .replace(/^-|-$/g, "")
-    || "document";
+	return (
+		name
+			.toLowerCase()
+			.replace(/[^a-z0-9\s-]/g, "")
+			.replace(/\s+/g, "-")
+			.replace(/-+/g, "-")
+			.slice(0, 100)
+			.replace(/^-|-$/g, "") || "document"
+	);
 }
 
 /**
  * Check if URL or content-type indicates a PDF
  */
 export function isPDF(url: string, contentType?: string): boolean {
-  if (contentType?.includes("application/pdf")) {
-    return true;
-  }
-  try {
-    const urlObj = new URL(url);
-    return urlObj.pathname.toLowerCase().endsWith(".pdf");
-  } catch {
-    return false;
-  }
+	if (contentType?.includes("application/pdf")) {
+		return true;
+	}
+	try {
+		const urlObj = new URL(url);
+		return urlObj.pathname.toLowerCase().endsWith(".pdf");
+	} catch {
+		return false;
+	}
 }

--- a/perplexity.ts
+++ b/perplexity.ts
@@ -64,13 +64,14 @@ function normalizeApiKey(value: unknown): string | null {
 
 function getApiKey(): string {
 	const config = loadConfig();
-	const key = normalizeApiKey(process.env.PERPLEXITY_API_KEY) ?? normalizeApiKey(config.perplexityApiKey);
+	const key =
+		normalizeApiKey(process.env.PERPLEXITY_API_KEY) ?? normalizeApiKey(config.perplexityApiKey);
 	if (!key) {
 		throw new Error(
 			"Perplexity API key not found. Either:\n" +
-			`  1. Create ${CONFIG_PATH} with { "perplexityApiKey": "your-key" }\n` +
-			"  2. Set PERPLEXITY_API_KEY environment variable\n" +
-			"Get a key at https://perplexity.ai/settings/api"
+				`  1. Create ${CONFIG_PATH} with { "perplexityApiKey": "your-key" }\n` +
+				"  2. Set PERPLEXITY_API_KEY environment variable\n" +
+				"Get a key at https://perplexity.ai/settings/api"
 		);
 	}
 	return key;
@@ -101,10 +102,15 @@ function validateDomainFilter(domains: string[]): string[] {
 
 export function isPerplexityAvailable(): boolean {
 	const config = loadConfig();
-	return !!(normalizeApiKey(process.env.PERPLEXITY_API_KEY) ?? normalizeApiKey(config.perplexityApiKey));
+	return !!(
+		normalizeApiKey(process.env.PERPLEXITY_API_KEY) ?? normalizeApiKey(config.perplexityApiKey)
+	);
 }
 
-export async function searchWithPerplexity(query: string, options: SearchOptions = {}): Promise<SearchResponse> {
+export async function searchWithPerplexity(
+	query: string,
+	options: SearchOptions = {}
+): Promise<SearchResponse> {
 	checkRateLimit();
 
 	const activityId = activityMonitor.logStart({ type: "api", query });
@@ -173,7 +179,8 @@ export async function searchWithPerplexity(query: string, options: SearchOptions
 		throw new Error(`Perplexity API returned invalid JSON: ${message}`);
 	}
 
-	const answer = (data.choices as Array<{ message?: { content?: string } }>)?.[0]?.message?.content || "";
+	const answer =
+		(data.choices as Array<{ message?: { content?: string } }>)?.[0]?.message?.content || "";
 	const citations = Array.isArray(data.citations) ? data.citations : [];
 
 	const results: SearchResult[] = [];

--- a/rsc-extract.ts
+++ b/rsc-extract.ts
@@ -1,338 +1,384 @@
 /**
  * RSC Content Extractor
- * 
+ *
  * Extracts readable content from Next.js React Server Components (RSC) flight payloads.
  * RSC pages embed content as JSON in <script>self.__next_f.push([...])</script> tags.
  */
 
 export interface RSCExtractResult {
-  title: string;
-  content: string;
+	title: string;
+	content: string;
 }
 
 export function extractRSCContent(html: string): RSCExtractResult | null {
-  if (!html.includes("self.__next_f.push")) {
-    return null;
-  }
+	if (!html.includes("self.__next_f.push")) {
+		return null;
+	}
 
-  // Parse all RSC chunks into a map
-  const chunkMap = new Map<string, string>();
-  const scriptRegex = /<script>self\.__next_f\.push\(\[1,"([\s\S]*?)"\]\)<\/script>/g;
+	// Parse all RSC chunks into a map
+	const chunkMap = new Map<string, string>();
+	const scriptRegex = /<script>self\.__next_f\.push\(\[1,"([\s\S]*?)"\]\)<\/script>/g;
 
-  for (const match of html.matchAll(scriptRegex)) {
-    let content: string;
-    try {
-      content = JSON.parse('"' + match[1] + '"');
-    } catch {
-      continue;
-    }
+	for (const match of html.matchAll(scriptRegex)) {
+		let content: string;
+		try {
+			content = JSON.parse('"' + match[1] + '"');
+		} catch {
+			continue;
+		}
 
-    // Parse each line as "id:payload"
-    // Lines are separated by \n, each line is one chunk
-    // Chunk IDs are hex strings, typically 1-4 chars (supports up to 65535 chunks)
-    for (const line of content.split("\n")) {
-      if (!line.trim()) continue;
-      
-      const colonIdx = line.indexOf(":");
-      if (colonIdx <= 0 || colonIdx > 4) continue;
-      
-      const id = line.slice(0, colonIdx);
-      if (!/^[0-9a-f]+$/i.test(id)) continue;
-      
-      const payload = line.slice(colonIdx + 1);
-      if (!payload) continue;
-      
-      const existing = chunkMap.get(id);
-      if (!existing || payload.length > existing.length) {
-        chunkMap.set(id, payload);
-      }
-    }
-  }
+		// Parse each line as "id:payload"
+		// Lines are separated by \n, each line is one chunk
+		// Chunk IDs are hex strings, typically 1-4 chars (supports up to 65535 chunks)
+		for (const line of content.split("\n")) {
+			if (!line.trim()) continue;
 
-  if (chunkMap.size === 0) return null;
+			const colonIdx = line.indexOf(":");
+			if (colonIdx <= 0 || colonIdx > 4) continue;
 
-  // Extract title
-  const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/);
-  const title = titleMatch?.[1]?.split("|")[0]?.trim() || "";
+			const id = line.slice(0, colonIdx);
+			if (!/^[0-9a-f]+$/i.test(id)) continue;
 
-  // Parse and cache parsed chunks
-  const parsedCache = new Map<string, unknown>();
-  
-  function getParsedChunk(id: string): unknown | null {
-    if (parsedCache.has(id)) return parsedCache.get(id);
-    
-    const chunk = chunkMap.get(id);
-    if (!chunk || !chunk.startsWith("[")) {
-      parsedCache.set(id, null);
-      return null;
-    }
-    
-    try {
-      const parsed = JSON.parse(chunk);
-      parsedCache.set(id, parsed);
-      return parsed;
-    } catch {
-      parsedCache.set(id, null);
-      return null;
-    }
-  }
+			const payload = line.slice(colonIdx + 1);
+			if (!payload) continue;
 
-  // Extract markdown from nodes, resolving refs on the fly
-  type Node = unknown;
-  const visitedRefs = new Set<string>();
+			const existing = chunkMap.get(id);
+			if (!existing || payload.length > existing.length) {
+				chunkMap.set(id, payload);
+			}
+		}
+	}
 
-  function extractNode(node: Node, ctx = { inTable: false, inCode: false }): string {
-    if (node === null || node === undefined) return "";
-    
-    if (typeof node === "string") {
-      // Check if it's a reference like "$L30"
-      const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
-      if (refMatch) {
-        const refId = refMatch[1];
-        if (visitedRefs.has(refId)) return ""; // Prevent cycles
-        visitedRefs.add(refId);
-        const refNode = getParsedChunk(refId);
-        const result = refNode ? extractNode(refNode, ctx) : "";
-        visitedRefs.delete(refId);
-        return result;
-      }
-      // Filter out RSC-specific artifacts, but preserve content inside code blocks
-      if (!ctx.inCode && (node === "$undefined" || node === "$" || /^\$[A-Z]/.test(node))) return "";
-      return node.trim() ? node : "";
-    }
-    
-    if (typeof node === "number") return String(node);
-    if (typeof node === "boolean") return "";
-    if (!Array.isArray(node)) return "";
+	if (chunkMap.size === 0) return null;
 
-    // RSC element: ["$", "tag", key, props]
-    if (node[0] === "$" && typeof node[1] === "string") {
-      const tag = node[1] as string;
-      const props = (node[3] || {}) as Record<string, unknown>;
+	// Extract title
+	const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/);
+	const title = titleMatch?.[1]?.split("|")[0]?.trim() || "";
 
-      // Skip non-content
-      const skipTags = ["script", "style", "svg", "path", "circle", "link", "meta", 
-                        "template", "button", "input", "nav", "footer", "aside"];
-      if (skipTags.includes(tag)) return "";
+	// Parse and cache parsed chunks
+	const parsedCache = new Map<string, unknown>();
 
-      // Component ref like $L25
-      if (tag.startsWith("$L")) {
-        const refId = tag.slice(2);
-        if (visitedRefs.has(refId)) return "";
-        
-        // Check for heading components with baseId
-        if (props.baseId && props.children) {
-          return `## ${String(props.children)}\n\n`;
-        }
-        
-        visitedRefs.add(refId);
-        const refNode = getParsedChunk(refId);
-        let result = "";
-        if (refNode) {
-          result = extractNode(refNode, ctx);
-        } else if (props.children) {
-          result = extractNode(props.children as Node, ctx);
-        }
-        visitedRefs.delete(refId);
-        return result;
-      }
+	function getParsedChunk(id: string): unknown | null {
+		if (parsedCache.has(id)) return parsedCache.get(id);
 
-      const children = props.children;
-      const content = children ? extractNode(children as Node, ctx) : "";
+		const chunk = chunkMap.get(id);
+		if (!chunk || !chunk.startsWith("[")) {
+			parsedCache.set(id, null);
+			return null;
+		}
 
-      switch (tag) {
-        case "h1": return `# ${content.trim()}\n\n`;
-        case "h2": return `## ${content.trim()}\n\n`;
-        case "h3": return `### ${content.trim()}\n\n`;
-        case "h4": return `#### ${content.trim()}\n\n`;
-        case "h5": return `##### ${content.trim()}\n\n`;
-        case "h6": return `###### ${content.trim()}\n\n`;
-        case "p": return ctx.inTable ? content : `${content.trim()}\n\n`;
-        case "code": {
-          const codeContent = children ? extractNode(children as Node, { ...ctx, inCode: true }) : "";
-          return ctx.inCode ? codeContent : `\`${codeContent}\``;
-        }
-        case "pre": {
-          const preContent = children ? extractNode(children as Node, { ...ctx, inCode: true }) : "";
-          return "```\n" + preContent + "\n```\n\n";
-        }
-        case "strong": case "b": return `**${content}**`;
-        case "em": case "i": return `*${content}*`;
-        case "li": return `- ${content.trim()}\n`;
-        case "ul": case "ol": return content + "\n";
-        case "blockquote": return `> ${content.trim()}\n\n`;
-        case "table": return extractTable(node as unknown[]) + "\n";
-        case "thead": case "tbody": case "tr": case "th": case "td":
-          return content;
-        case "div":
-          if (props.role === "alert" || props["data-slot"] === "alert") {
-            return `> ${content.trim()}\n\n`;
-          }
-          return content;
-        case "a": {
-          const href = props.href as string | undefined;
-          return href && !href.startsWith("#") ? `[${content}](${href})` : content;
-        }
-        default: return content;
-      }
-    }
+		try {
+			const parsed = JSON.parse(chunk);
+			parsedCache.set(id, parsed);
+			return parsed;
+		} catch {
+			parsedCache.set(id, null);
+			return null;
+		}
+	}
 
-    // Array of child nodes
-    return (node as Node[]).map(n => extractNode(n, ctx)).join("");
-  }
+	// Extract markdown from nodes, resolving refs on the fly
+	type Node = unknown;
+	const visitedRefs = new Set<string>();
 
-  function extractTable(tableNode: unknown[]): string {
-    const props = (tableNode[3] || {}) as Record<string, unknown>;
-    const rows: string[][] = [];
-    let headerRowCount = 0;
+	function extractNode(node: Node, ctx = { inTable: false, inCode: false }): string {
+		if (node === null || node === undefined) return "";
 
-    function walkTable(node: unknown, isHeader = false): void {
-      if (node === null || node === undefined) return;
-      
-      // Handle string refs
-      if (typeof node === "string") {
-        const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
-        if (refMatch && !visitedRefs.has(refMatch[1])) {
-          visitedRefs.add(refMatch[1]);
-          const refNode = getParsedChunk(refMatch[1]);
-          if (refNode) walkTable(refNode, isHeader);
-          visitedRefs.delete(refMatch[1]);
-        }
-        return;
-      }
-      
-      if (!Array.isArray(node)) return;
-      
-      if (node[0] === "$") {
-        const tag = node[1] as string;
-        const nodeProps = (node[3] || {}) as Record<string, unknown>;
-        
-        // Handle component refs
-        if (tag.startsWith("$L")) {
-          const refId = tag.slice(2);
-          if (!visitedRefs.has(refId)) {
-            visitedRefs.add(refId);
-            const refNode = getParsedChunk(refId);
-            if (refNode) walkTable(refNode, isHeader);
-            visitedRefs.delete(refId);
-          }
-          return;
-        }
-        
-        if (tag === "thead") walkTable(nodeProps.children, true);
-        else if (tag === "tbody") walkTable(nodeProps.children, false);
-        else if (tag === "tr") {
-          const cells: string[] = [];
-          walkCells(nodeProps.children, cells);
-          if (cells.length > 0) {
-            rows.push(cells);
-            if (isHeader) headerRowCount++;
-          }
-        } else walkTable(nodeProps.children, isHeader);
-      } else {
-        for (const child of node) walkTable(child, isHeader);
-      }
-    }
+		if (typeof node === "string") {
+			// Check if it's a reference like "$L30"
+			const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
+			if (refMatch) {
+				const refId = refMatch[1];
+				if (visitedRefs.has(refId)) return ""; // Prevent cycles
+				visitedRefs.add(refId);
+				const refNode = getParsedChunk(refId);
+				const result = refNode ? extractNode(refNode, ctx) : "";
+				visitedRefs.delete(refId);
+				return result;
+			}
+			// Filter out RSC-specific artifacts, but preserve content inside code blocks
+			if (!ctx.inCode && (node === "$undefined" || node === "$" || /^\$[A-Z]/.test(node)))
+				return "";
+			return node.trim() ? node : "";
+		}
 
-    function walkCells(node: unknown, cells: string[]): void {
-      if (node === null || node === undefined) return;
-      
-      // Handle string refs
-      if (typeof node === "string") {
-        const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
-        if (refMatch && !visitedRefs.has(refMatch[1])) {
-          visitedRefs.add(refMatch[1]);
-          const refNode = getParsedChunk(refMatch[1]);
-          if (refNode) walkCells(refNode, cells);
-          visitedRefs.delete(refMatch[1]);
-        }
-        return;
-      }
-      
-      if (!Array.isArray(node)) return;
-      
-      if (node[0] === "$" && (node[1] === "td" || node[1] === "th")) {
-        const cellProps = (node[3] || {}) as Record<string, unknown>;
-        const text = extractNode(cellProps.children, { inTable: true, inCode: false })
-          .trim()
-          .replace(/\n/g, " ")
-          .replace(/\\/g, "\\\\")  // Escape backslashes first
-          .replace(/\|/g, "\\|");  // Then escape pipes
-        cells.push(text);
-      } else if (node[0] === "$" && typeof node[1] === "string" && (node[1] as string).startsWith("$L")) {
-        // Component ref for a cell
-        const refId = (node[1] as string).slice(2);
-        if (!visitedRefs.has(refId)) {
-          visitedRefs.add(refId);
-          const refNode = getParsedChunk(refId);
-          if (refNode) walkCells(refNode, cells);
-          visitedRefs.delete(refId);
-        }
-      } else {
-        for (const child of node) walkCells(child, cells);
-      }
-    }
+		if (typeof node === "number") return String(node);
+		if (typeof node === "boolean") return "";
+		if (!Array.isArray(node)) return "";
 
-    walkTable(props.children);
-    if (rows.length === 0) return "";
+		// RSC element: ["$", "tag", key, props]
+		if (node[0] === "$" && typeof node[1] === "string") {
+			const tag = node[1] as string;
+			const props = (node[3] || {}) as Record<string, unknown>;
 
-    const colCount = Math.max(...rows.map(r => r.length));
-    let md = "";
-    for (let i = 0; i < rows.length; i++) {
-      const row = rows[i].concat(Array(colCount - rows[i].length).fill(""));
-      md += "| " + row.join(" | ") + " |\n";
-      if (i === headerRowCount - 1 || (headerRowCount === 0 && i === 0)) {
-        md += "| " + Array(colCount).fill("---").join(" | ") + " |\n";
-      }
-    }
-    return md;
-  }
+			// Skip non-content
+			const skipTags = [
+				"script",
+				"style",
+				"svg",
+				"path",
+				"circle",
+				"link",
+				"meta",
+				"template",
+				"button",
+				"input",
+				"nav",
+				"footer",
+				"aside",
+			];
+			if (skipTags.includes(tag)) return "";
 
-  // Process main content chunk (usually "23")
-  const mainChunk = getParsedChunk("23");
-  
-  if (mainChunk) {
-    const content = extractNode(mainChunk);
-    if (content.trim().length > 100) {
-      const cleaned = content
-        .replace(/\n{3,}/g, "\n\n")
-        .trim();
-      return { title, content: cleaned };
-    }
-  }
+			// Component ref like $L25
+			if (tag.startsWith("$L")) {
+				const refId = tag.slice(2);
+				if (visitedRefs.has(refId)) return "";
 
-  // Fallback: try other chunks
-  const contentParts: { order: number; text: string }[] = [];
+				// Check for heading components with baseId
+				if (props.baseId && props.children) {
+					return `## ${String(props.children)}\n\n`;
+				}
 
-  for (const [id] of chunkMap) {
-    if (id === "23") continue;
-    const parsed = getParsedChunk(id);
-    if (!parsed) continue;
+				visitedRefs.add(refId);
+				const refNode = getParsedChunk(refId);
+				let result = "";
+				if (refNode) {
+					result = extractNode(refNode, ctx);
+				} else if (props.children) {
+					result = extractNode(props.children as Node, ctx);
+				}
+				visitedRefs.delete(refId);
+				return result;
+			}
 
-    visitedRefs.clear();
-    const text = extractNode(parsed);
+			const children = props.children;
+			const content = children ? extractNode(children as Node, ctx) : "";
 
-    if (text.trim().length > 50 && 
-        !text.includes("page was not found") && 
-        !text.includes("404")) {
-      contentParts.push({ order: parseInt(id, 16), text: text.trim() });
-    }
-  }
+			switch (tag) {
+				case "h1":
+					return `# ${content.trim()}\n\n`;
+				case "h2":
+					return `## ${content.trim()}\n\n`;
+				case "h3":
+					return `### ${content.trim()}\n\n`;
+				case "h4":
+					return `#### ${content.trim()}\n\n`;
+				case "h5":
+					return `##### ${content.trim()}\n\n`;
+				case "h6":
+					return `###### ${content.trim()}\n\n`;
+				case "p":
+					return ctx.inTable ? content : `${content.trim()}\n\n`;
+				case "code": {
+					const codeContent = children
+						? extractNode(children as Node, { ...ctx, inCode: true })
+						: "";
+					return ctx.inCode ? codeContent : `\`${codeContent}\``;
+				}
+				case "pre": {
+					const preContent = children
+						? extractNode(children as Node, { ...ctx, inCode: true })
+						: "";
+					return "```\n" + preContent + "\n```\n\n";
+				}
+				case "strong":
+				case "b":
+					return `**${content}**`;
+				case "em":
+				case "i":
+					return `*${content}*`;
+				case "li":
+					return `- ${content.trim()}\n`;
+				case "ul":
+				case "ol":
+					return content + "\n";
+				case "blockquote":
+					return `> ${content.trim()}\n\n`;
+				case "table":
+					return extractTable(node as unknown[]) + "\n";
+				case "thead":
+				case "tbody":
+				case "tr":
+				case "th":
+				case "td":
+					return content;
+				case "div":
+					if (props.role === "alert" || props["data-slot"] === "alert") {
+						return `> ${content.trim()}\n\n`;
+					}
+					return content;
+				case "a": {
+					const href = props.href as string | undefined;
+					return href && !href.startsWith("#") ? `[${content}](${href})` : content;
+				}
+				default:
+					return content;
+			}
+		}
 
-  if (contentParts.length === 0) return null;
+		// Array of child nodes
+		return (node as Node[]).map((n) => extractNode(n, ctx)).join("");
+	}
 
-  contentParts.sort((a, b) => a.order - b.order);
-  
-  const seen = new Set<string>();
-  const uniqueParts: string[] = [];
-  for (const part of contentParts) {
-    const key = part.text.slice(0, 150);
-    if (!seen.has(key)) {
-      seen.add(key);
-      uniqueParts.push(part.text);
-    }
-  }
+	function extractTable(tableNode: unknown[]): string {
+		const props = (tableNode[3] || {}) as Record<string, unknown>;
+		const rows: string[][] = [];
+		let headerRowCount = 0;
 
-  const content = uniqueParts.join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
-  return content.length > 100 ? { title, content } : null;
+		function walkTable(node: unknown, isHeader = false): void {
+			if (node === null || node === undefined) return;
+
+			// Handle string refs
+			if (typeof node === "string") {
+				const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
+				if (refMatch && !visitedRefs.has(refMatch[1])) {
+					visitedRefs.add(refMatch[1]);
+					const refNode = getParsedChunk(refMatch[1]);
+					if (refNode) walkTable(refNode, isHeader);
+					visitedRefs.delete(refMatch[1]);
+				}
+				return;
+			}
+
+			if (!Array.isArray(node)) return;
+
+			if (node[0] === "$") {
+				const tag = node[1] as string;
+				const nodeProps = (node[3] || {}) as Record<string, unknown>;
+
+				// Handle component refs
+				if (tag.startsWith("$L")) {
+					const refId = tag.slice(2);
+					if (!visitedRefs.has(refId)) {
+						visitedRefs.add(refId);
+						const refNode = getParsedChunk(refId);
+						if (refNode) walkTable(refNode, isHeader);
+						visitedRefs.delete(refId);
+					}
+					return;
+				}
+
+				if (tag === "thead") walkTable(nodeProps.children, true);
+				else if (tag === "tbody") walkTable(nodeProps.children, false);
+				else if (tag === "tr") {
+					const cells: string[] = [];
+					walkCells(nodeProps.children, cells);
+					if (cells.length > 0) {
+						rows.push(cells);
+						if (isHeader) headerRowCount++;
+					}
+				} else walkTable(nodeProps.children, isHeader);
+			} else {
+				for (const child of node) walkTable(child, isHeader);
+			}
+		}
+
+		function walkCells(node: unknown, cells: string[]): void {
+			if (node === null || node === undefined) return;
+
+			// Handle string refs
+			if (typeof node === "string") {
+				const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
+				if (refMatch && !visitedRefs.has(refMatch[1])) {
+					visitedRefs.add(refMatch[1]);
+					const refNode = getParsedChunk(refMatch[1]);
+					if (refNode) walkCells(refNode, cells);
+					visitedRefs.delete(refMatch[1]);
+				}
+				return;
+			}
+
+			if (!Array.isArray(node)) return;
+
+			if (node[0] === "$" && (node[1] === "td" || node[1] === "th")) {
+				const cellProps = (node[3] || {}) as Record<string, unknown>;
+				const text = extractNode(cellProps.children, { inTable: true, inCode: false })
+					.trim()
+					.replace(/\n/g, " ")
+					.replace(/\\/g, "\\\\") // Escape backslashes first
+					.replace(/\|/g, "\\|"); // Then escape pipes
+				cells.push(text);
+			} else if (
+				node[0] === "$" &&
+				typeof node[1] === "string" &&
+				(node[1] as string).startsWith("$L")
+			) {
+				// Component ref for a cell
+				const refId = (node[1] as string).slice(2);
+				if (!visitedRefs.has(refId)) {
+					visitedRefs.add(refId);
+					const refNode = getParsedChunk(refId);
+					if (refNode) walkCells(refNode, cells);
+					visitedRefs.delete(refId);
+				}
+			} else {
+				for (const child of node) walkCells(child, cells);
+			}
+		}
+
+		walkTable(props.children);
+		if (rows.length === 0) return "";
+
+		const colCount = Math.max(...rows.map((r) => r.length));
+		let md = "";
+		for (let i = 0; i < rows.length; i++) {
+			const row = rows[i].concat(Array(colCount - rows[i].length).fill(""));
+			md += "| " + row.join(" | ") + " |\n";
+			if (i === headerRowCount - 1 || (headerRowCount === 0 && i === 0)) {
+				md += "| " + Array(colCount).fill("---").join(" | ") + " |\n";
+			}
+		}
+		return md;
+	}
+
+	// Process main content chunk (usually "23")
+	const mainChunk = getParsedChunk("23");
+
+	if (mainChunk) {
+		const content = extractNode(mainChunk);
+		if (content.trim().length > 100) {
+			const cleaned = content.replace(/\n{3,}/g, "\n\n").trim();
+			return { title, content: cleaned };
+		}
+	}
+
+	// Fallback: try other chunks
+	const contentParts: { order: number; text: string }[] = [];
+
+	for (const [id] of chunkMap) {
+		if (id === "23") continue;
+		const parsed = getParsedChunk(id);
+		if (!parsed) continue;
+
+		visitedRefs.clear();
+		const text = extractNode(parsed);
+
+		if (
+			text.trim().length > 50 &&
+			!text.includes("page was not found") &&
+			!text.includes("404")
+		) {
+			contentParts.push({ order: parseInt(id, 16), text: text.trim() });
+		}
+	}
+
+	if (contentParts.length === 0) return null;
+
+	contentParts.sort((a, b) => a.order - b.order);
+
+	const seen = new Set<string>();
+	const uniqueParts: string[] = [];
+	for (const part of contentParts) {
+		const key = part.text.slice(0, 150);
+		if (!seen.has(key)) {
+			seen.add(key);
+			uniqueParts.push(part.text);
+		}
+	}
+
+	const content = uniqueParts
+		.join("\n\n")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
+	return content.length > 100 ? { title, content } : null;
 }

--- a/skills/librarian/SKILL.md
+++ b/skills/librarian/SKILL.md
@@ -1,195 +1,43 @@
 ---
 name: librarian
-description: Research open-source libraries with evidence-backed answers and GitHub permalinks. Use when the user asks about library internals, needs implementation details with source code references, wants to understand why something was changed, or needs authoritative answers backed by actual code. Excels at navigating large open-source repos and providing citations to exact lines of code.
+description: Research github libraries. Use for questions about implementation details, history, etc. of github-served repos.
 ---
 
 # Librarian
 
 Answer questions about open-source libraries by finding evidence with GitHub permalinks. Every claim backed by actual code.
 
-## Execution Model
+## Research Strategy
 
-Pi executes tool calls sequentially, even when you emit multiple calls in one turn. But batching independent calls in a single turn still saves LLM round-trips (~5-10s each). Use these patterns:
+| Type                | Trigger                 | Approach                                 |
+| ------------------- | ----------------------- | ---------------------------------------- |
+| **Conceptual**      | "How do I use X?"       | web_search + fetch_content (README/docs) |
+| **Implementation**  | "How does X work?"      | fetch_content (clone) + grep + read      |
+| **Context/History** | "Why was this changed?" | git log, git blame, gh issue/pr search   |
+| **Comprehensive**   | Complex requests        | Combine the above                        |
 
-| Pattern | When | Actually parallel? |
-|---------|------|-------------------|
-| Batch tool calls in one turn | Independent ops (web_search + fetch_content + read) | No, but saves round-trips |
-| `fetch_content({ urls: [...] })` | Multiple URLs to fetch | Yes (3 concurrent) |
-| Bash with `&` + `wait` | Multiple git/gh commands | Yes (OS-level) |
+## Workflow
 
-## Step 1: Classify the Request
+1. **fetch_content** the GitHub repo URL to clone it locally
+2. Use **bash** to search the clone (`grep -rn`, `find`)
+3. Use **read** to examine specific files
+4. Build permalinks with the commit SHA: `https://github.com/owner/repo/blob/<sha>/path#L10-L20`
 
-Before doing anything, classify the request to pick the right research strategy.
+Get the commit SHA: `cd /tmp/pi-github-repos/owner/repo && git rev-parse HEAD`
 
-| Type | Trigger | Primary Approach |
-|------|---------|-----------------|
-| **Conceptual** | "How do I use X?", "Best practice for Y?" | web_search + fetch_content (README/docs) |
-| **Implementation** | "How does X implement Y?", "Show me the source" | fetch_content (clone) + code search |
-| **Context/History** | "Why was this changed?", "History of X?" | git log + git blame + issue/PR search |
-| **Comprehensive** | Complex or ambiguous requests, "deep dive" | All of the above |
+For history questions, use `git log --oneline -n 20 -- path/to/file` and `git blame`.
+For issues/PRs, use `gh search issues/prs "keyword" --repo owner/repo`.
 
-## Step 2: Research by Type
+## Citing
 
-### Conceptual Questions
-
-Batch these in one turn:
-
-1. **web_search**: `"library-name topic"` via Perplexity for recent articles and discussions
-2. **fetch_content**: the library's GitHub repo URL to clone and check README, docs, or examples
-
-Synthesize web results + repo docs. Cite official documentation and link to relevant source files.
-
-### Implementation Questions
-
-The core workflow -- clone, find, permalink:
-
-1. **fetch_content** the GitHub repo URL -- this clones it locally and returns the file tree
-2. Use **bash** to search the cloned repo: `grep -rn "function_name"`, `find . -name "*.ts"`
-3. Use **read** to examine specific files once you've located them
-4. Get the commit SHA: `cd /tmp/pi-github-repos/owner/repo && git rev-parse HEAD`
-5. Construct permalink: `https://github.com/owner/repo/blob/<sha>/path/to/file#L10-L20`
-
-Batch the initial calls: fetch_content (clone) + web_search (recent discussions) in one turn. Then dig into the clone with grep/read once it's available.
-
-### Context/History Questions
-
-Use git operations on the cloned repo:
-
-```bash
-cd /tmp/pi-github-repos/owner/repo
-
-# Recent changes to a specific file
-git log --oneline -n 20 -- path/to/file.ts
-
-# Who changed what and when
-git blame -L 10,30 path/to/file.ts
-
-# Full diff for a specific commit
-git show <sha> -- path/to/file.ts
-
-# Search commit messages
-git log --oneline --grep="keyword" -n 10
-```
-
-For issues and PRs, use bash:
-
-```bash
-# Search issues
-gh search issues "keyword" --repo owner/repo --state all --limit 10
-
-# Search merged PRs
-gh search prs "keyword" --repo owner/repo --state merged --limit 10
-
-# View specific issue/PR with comments
-gh issue view <number> --repo owner/repo --comments
-gh pr view <number> --repo owner/repo --comments
-
-# Release notes
-gh api repos/owner/repo/releases --jq '.[0:5] | .[].tag_name'
-```
-
-### Comprehensive Research
-
-Combine everything. Batch these in one turn:
-
-1. **web_search**: recent articles and discussions
-2. **fetch_content**: clone the repo (or multiple repos if comparing)
-3. **bash**: `gh search issues "keyword" --repo owner/repo --limit 10 & gh search prs "keyword" --repo owner/repo --state merged --limit 10 & wait`
-
-Then dig into the clone with grep, read, git blame, git log as needed.
-
-## Step 3: Construct Permalinks
-
-Permalinks are the whole point. They make your answers citable and verifiable.
-
-```
-https://github.com/<owner>/<repo>/blob/<commit-sha>/<filepath>#L<start>-L<end>
-```
-
-Getting the SHA from a cloned repo:
-
-```bash
-cd /tmp/pi-github-repos/owner/repo && git rev-parse HEAD
-```
-
-Getting the SHA from a tag:
-
-```bash
-gh api repos/owner/repo/git/refs/tags/v1.0.0 --jq '.object.sha'
-```
-
-Always use full commit SHAs, not branch names. Branch links break when code changes. Permalinks don't.
-
-## Step 4: Cite Everything
-
-Every code-related claim needs a permalink. Format:
+Every code claim needs a permalink. Always use full commit SHAs, not branch names.
 
 ```markdown
-The stale time check happens in [`notifyManager.ts`](https://github.com/TanStack/query/blob/abc123/packages/query-core/src/notifyManager.ts#L42-L50):
-
-\`\`\`typescript
-function isStale(query: Query, staleTime: number): boolean {
-  return query.state.dataUpdatedAt + staleTime < Date.now()
-}
-\`\`\`
-```
-
-For conceptual answers, link to official docs and relevant source files. For implementation answers, every function/class reference should have a permalink.
-
-## Video Analysis
-
-For questions about video tutorials, conference talks, or screen recordings:
+The check is in [`file.ts`](https://github.com/owner/repo/blob/<sha>/file.ts#L10-L20):
 
 ```typescript
-// Full extraction (transcript + visual descriptions)
-fetch_content({ url: "https://youtube.com/watch?v=abc" })
-
-// Ask a specific question about a video
-fetch_content({ url: "https://youtube.com/watch?v=abc", prompt: "What libraries are imported in this tutorial?" })
-
-// Single frame at a known moment
-fetch_content({ url: "https://youtube.com/watch?v=abc", timestamp: "23:41" })
-
-// Range scan for visual discovery
-fetch_content({ url: "https://youtube.com/watch?v=abc", timestamp: "23:41-25:00" })
-
-// Custom density across a range
-fetch_content({ url: "https://youtube.com/watch?v=abc", timestamp: "23:41-25:00", frames: 3 })
-
-// Whole-video sampling
-fetch_content({ url: "https://youtube.com/watch?v=abc", frames: 6 })
-
-// Analyze a local recording
-fetch_content({ url: "/path/to/demo.mp4", prompt: "What error message appears on screen?" })
-
-// Batch multiple videos with the same question
-fetch_content({
-  urls: ["https://youtube.com/watch?v=abc", "https://youtube.com/watch?v=def"],
-  prompt: "What packages are installed?"
-})
+// relevant code
+```
 ```
 
-Use single timestamps for known moments, ranges for visual scanning, and frames-alone for a quick overview of the whole video.
-
-The `prompt` parameter only applies to video content (YouTube URLs and local video files). For non-video URLs, it's ignored.
-
-## Failure Recovery
-
-| Failure | Recovery |
-|---------|----------|
-| grep finds nothing | Broaden the query, try concept names instead of exact function names |
-| gh CLI rate limited | Use the already-cloned repo in /tmp/pi-github-repos/ for git operations |
-| Repo too large to clone | fetch_content returns an API-only view automatically; use that or add `forceClone: true` |
-| File not found in clone | Branch name with slashes may have misresolved; list the repo tree and navigate manually |
-| Uncertain about implementation | State your uncertainty explicitly, propose a hypothesis, show what evidence you did find |
-| Video extraction fails | Ensure Chrome is signed into gemini.google.com (free) or set GEMINI_API_KEY |
-| Page returns 403/bot block | Gemini fallback triggers automatically; no action needed if Gemini is configured |
-| web_search fails | Check provider config; try explicit `provider: "gemini"` if Perplexity key is missing |
-
-## Guidelines
-
-- Vary search queries when running multiple searches -- different angles, not the same pattern repeated
-- Prefer recent sources; filter out outdated results when they conflict with newer information
-- For version-specific questions, clone the tagged version: `fetch_content("https://github.com/owner/repo/tree/v1.0.0")`
-- When the repo is already cloned from a previous fetch_content call, reuse it -- check the path before cloning again
-- Answer directly. Skip preamble like "I'll help you with..." -- go straight to findings
+For conceptual answers, link to docs and relevant source files. For implementation answers, every reference needs a permalink.

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -58,7 +58,7 @@ export function buildSummaryPrompt(results: QueryResultData[], feedback?: string
 		"- Include key findings and caveats.",
 		"- Do not invent sources or claims.",
 		"- If evidence is weak or conflicting, say so explicitly.",
-		"- End with a short \"Sources\" section listing the most relevant URLs.",
+		'- End with a short "Sources" section listing the most relevant URLs.',
 	];
 
 	if (feedback) {
@@ -106,10 +106,7 @@ function buildDeterministicSummaryLines(results: QueryResultData[]): string[] {
 		];
 	}
 
-	const lines: string[] = [
-		"Summary based on the currently selected search results.",
-		"",
-	];
+	const lines: string[] = ["Summary based on the currently selected search results.", ""];
 
 	const sourceUrls: string[] = [];
 	let successful = 0;
@@ -127,7 +124,9 @@ function buildDeterministicSummaryLines(results: QueryResultData[]): string[] {
 		if (preview.length > 0) {
 			lines.push(`- ${result.query}: ${preview}`);
 		} else {
-			lines.push(`- ${result.query}: returned ${result.results.length} source${result.results.length === 1 ? "" : "s"} without answer text.`);
+			lines.push(
+				`- ${result.query}: returned ${result.results.length} source${result.results.length === 1 ? "" : "s"} without answer text.`
+			);
 		}
 
 		for (const source of result.results) {
@@ -158,11 +157,15 @@ function buildDeterministicSummaryLines(results: QueryResultData[]): string[] {
 	return lines;
 }
 
-export function buildDeterministicSummary(results: QueryResultData[]): { summary: string; meta: SummaryMeta } {
+export function buildDeterministicSummary(results: QueryResultData[]): {
+	summary: string;
+	meta: SummaryMeta;
+} {
 	const summary = buildDeterministicSummaryLines(results).join("\n").trim();
-	const nonEmptySummary = summary.length > 0
-		? summary
-		: "No completed search results were available when the curator session finished.\n\nSources\n- None";
+	const nonEmptySummary =
+		summary.length > 0
+			? summary
+			: "No completed search results were available when the curator session finished.\n\nSources\n- None";
 
 	return {
 		summary: nonEmptySummary,
@@ -179,7 +182,7 @@ export function buildDeterministicSummary(results: QueryResultData[]): { summary
 
 async function resolveSummaryModel(
 	ctx: SummaryGenerationContext,
-	modelOverride?: string,
+	modelOverride?: string
 ): Promise<{ model: Model; apiKey: string; headers?: Record<string, string> }> {
 	const normalizedOverride = typeof modelOverride === "string" ? modelOverride.trim() : "";
 	if (normalizedOverride.length > 0) {
@@ -207,7 +210,9 @@ async function resolveSummaryModel(
 		if (auth.ok && auth.apiKey) return { model, apiKey: auth.apiKey, headers: auth.headers };
 	}
 
-	throw new Error(`No API key available for summary models: ${PREFERRED_SUMMARY_MODELS.map(c => `${c.provider}/${c.id}`).join(", ")}`);
+	throw new Error(
+		`No API key available for summary models: ${PREFERRED_SUMMARY_MODELS.map((c) => `${c.provider}/${c.id}`).join(", ")}`
+	);
 }
 
 function getTextFromContentPart(part: unknown): string {
@@ -229,7 +234,7 @@ export async function generateSummaryDraft(
 	ctx: SummaryGenerationContext,
 	signal?: AbortSignal,
 	modelOverride?: string,
-	feedback?: string,
+	feedback?: string
 ): Promise<{ summary: string; meta: SummaryMeta }> {
 	if (!ctx || !ctx.modelRegistry) {
 		throw new Error("Summary generation context unavailable");
@@ -245,20 +250,24 @@ export async function generateSummaryDraft(
 		timestamp: Date.now(),
 	};
 
-	const response = await complete(model, { messages: [userMessage] }, { apiKey, headers, signal });
+	const response = await complete(
+		model,
+		{ messages: [userMessage] },
+		{ apiKey, headers, signal }
+	);
 	if (response.stopReason === "aborted") {
 		throw new Error("Aborted");
 	}
 
 	const contentParts = Array.isArray(response.content) ? response.content : [];
 	const summary = contentParts
-		.map(part => getTextFromContentPart(part))
-		.filter(text => text.trim().length > 0)
+		.map((part) => getTextFromContentPart(part))
+		.filter((text) => text.trim().length > 0)
 		.join("\n")
 		.trim();
 
 	if (summary.length === 0) {
-		const partTypes = contentParts.map(part => getContentPartType(part));
+		const partTypes = contentParts.map((part) => getContentPartType(part));
 		const typesLabel = partTypes.length > 0 ? partTypes.join(", ") : "none";
 		throw new Error(`Summary model returned empty response (content parts: ${typesLabel})`);
 	}

--- a/test/gemini-web-cookie-opt-in.test.mjs
+++ b/test/gemini-web-cookie-opt-in.test.mjs
@@ -28,7 +28,11 @@ test("browser cookie access is disabled unless explicitly allowed", async () => 
 	assert.equal(child.stdout.trim(), "false");
 
 	await mkdir(join(home, ".pi"), { recursive: true });
-	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify({ allowBrowserCookies: true }) + "\n", "utf8");
+	await writeFile(
+		join(home, ".pi", "web-search.json"),
+		JSON.stringify({ allowBrowserCookies: true }) + "\n",
+		"utf8"
+	);
 
 	child = runCookieAccessCheck(home);
 	assert.equal(child.status, 0, child.stderr);

--- a/test/pdf-extract.test.mjs
+++ b/test/pdf-extract.test.mjs
@@ -5,23 +5,23 @@ import { test } from "node:test";
 const extractorUrl = new URL("../pdf-extract.ts", import.meta.url).href;
 
 test("extractPDFToMarkdown works on Node 22 without native Promise.try", () => {
-  const child = spawnSync(process.execPath, ["--input-type=module"], {
-    input: buildChildScript(extractorUrl),
-    encoding: "utf8",
-    maxBuffer: 2 * 1024 * 1024,
-  });
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
 
-  assert.equal(
-    child.status,
-    0,
-    "PDF extraction failed in a child process. stderr summary:\n" + errorSummary(child.stderr),
-  );
+	assert.equal(
+		child.status,
+		0,
+		"PDF extraction failed in a child process. stderr summary:\n" + errorSummary(child.stderr)
+	);
 
-  assert.match(child.stdout, /Hello PDF/);
+	assert.match(child.stdout, /Hello PDF/);
 });
 
 function buildChildScript(moduleUrl) {
-  return `
+	return `
     import { mkdtemp, readFile } from "node:fs/promises";
     import { tmpdir } from "node:os";
     import { join } from "node:path";
@@ -85,11 +85,11 @@ function buildChildScript(moduleUrl) {
 }
 
 function errorSummary(value, size = 1200) {
-  const marker = "TypeError: Promise.try is not a function";
-  const index = value.indexOf(marker);
-  if (index >= 0) {
-    return value.slice(index, index + size);
-  }
+	const marker = "TypeError: Promise.try is not a function";
+	const index = value.indexOf(marker);
+	if (index >= 0) {
+		return value.slice(index, index + size);
+	}
 
-  return value.length > size ? value.slice(-size) : value;
+	return value.length > size ? value.slice(-size) : value;
 }

--- a/utils.ts
+++ b/utils.ts
@@ -27,7 +27,9 @@ export function isTimeoutError(err: unknown): boolean {
 	const name = (err as { name?: string }).name;
 	const code = (err as { code?: string }).code;
 	const message = (err as { message?: string }).message ?? "";
-	return name === "AbortError" || code === "ETIMEDOUT" || message.toLowerCase().includes("timed out");
+	return (
+		name === "AbortError" || code === "ETIMEDOUT" || message.toLowerCase().includes("timed out")
+	);
 }
 
 export function trimErrorText(text: string): string {

--- a/video-extract.ts
+++ b/video-extract.ts
@@ -6,7 +6,12 @@ import { homedir } from "node:os";
 import { activityMonitor } from "./activity.js";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.js";
 import { queryGeminiApiWithVideo, getApiKey, API_BASE } from "./gemini-api.js";
-import { extractHeadingTitle, type ExtractedContent, type ExtractOptions, type FrameResult } from "./extract.js";
+import {
+	extractHeadingTitle,
+	type ExtractedContent,
+	type ExtractOptions,
+	type FrameResult,
+} from "./extract.js";
 import { readExecError, trimErrorText, mapFfmpegError } from "./utils.js";
 
 const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
@@ -83,7 +88,9 @@ function loadVideoConfig(): VideoConfig {
 	const rawText = readFileSync(CONFIG_PATH, "utf-8");
 	let raw: { video?: { enabled?: boolean; preferredModel?: string; maxSizeMB?: number } };
 	try {
-		raw = JSON.parse(rawText) as { video?: { enabled?: boolean; preferredModel?: string; maxSizeMB?: number } };
+		raw = JSON.parse(rawText) as {
+			video?: { enabled?: boolean; preferredModel?: string; maxSizeMB?: number };
+		};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
@@ -92,7 +99,10 @@ function loadVideoConfig(): VideoConfig {
 	const v = raw.video ?? {};
 	cachedVideoConfig = {
 		enabled: normalizeEnabled(v.enabled, VIDEO_CONFIG_DEFAULTS.enabled),
-		preferredModel: normalizePreferredModel(v.preferredModel, VIDEO_CONFIG_DEFAULTS.preferredModel),
+		preferredModel: normalizePreferredModel(
+			v.preferredModel,
+			VIDEO_CONFIG_DEFAULTS.preferredModel
+		),
 		maxSizeMB: normalizeMaxSizeMB(v.maxSizeMB, VIDEO_CONFIG_DEFAULTS.maxSizeMB),
 	};
 	return cachedVideoConfig;
@@ -102,7 +112,11 @@ export function isVideoFile(input: string): VideoFileInfo | null {
 	const config = loadVideoConfig();
 	if (!config.enabled) return null;
 
-	const isFilePath = input.startsWith("/") || input.startsWith("./") || input.startsWith("../") || input.startsWith("file://");
+	const isFilePath =
+		input.startsWith("/") ||
+		input.startsWith("./") ||
+		input.startsWith("../") ||
+		input.startsWith("file://");
 	if (!isFilePath) return null;
 
 	let filePath = input;
@@ -145,7 +159,7 @@ function resolveFilePath(filePath: string): string | null {
 
 	try {
 		const normalizedBase = normalizeSpaces(base);
-		const match = readdirSync(dir).find(f => normalizeSpaces(f) === normalizedBase);
+		const match = readdirSync(dir).find((f) => normalizeSpaces(f) === normalizedBase);
 		return match ? join(dir, match) : null;
 	} catch {
 		return null;
@@ -159,7 +173,7 @@ function normalizeSpaces(s: string): string {
 export async function extractVideo(
 	info: VideoFileInfo,
 	signal?: AbortSignal,
-	options?: ExtractOptions,
+	options?: ExtractOptions
 ): Promise<ExtractedContent | null> {
 	const config = loadVideoConfig();
 	const effectivePrompt = options?.prompt ?? DEFAULT_VIDEO_PROMPT;
@@ -167,8 +181,9 @@ export async function extractVideo(
 	const displayName = basename(info.absolutePath);
 	const activityId = activityMonitor.logStart({ type: "fetch", url: `video:${displayName}` });
 
-	const result = await tryVideoGeminiApi(info, effectivePrompt, effectiveModel, signal)
-		?? await tryVideoGeminiWeb(info, effectivePrompt, effectiveModel, signal);
+	const result =
+		(await tryVideoGeminiApi(info, effectivePrompt, effectiveModel, signal)) ??
+		(await tryVideoGeminiWeb(info, effectivePrompt, effectiveModel, signal));
 
 	if (result) {
 		const thumbnail = await extractVideoFrame(info.absolutePath);
@@ -195,12 +210,28 @@ function mapFfprobeError(err: unknown): string {
 	return snippet ? `ffprobe failed: ${snippet}` : "ffprobe failed";
 }
 
-export async function extractVideoFrame(filePath: string, seconds: number = 1): Promise<FrameResult> {
+export async function extractVideoFrame(
+	filePath: string,
+	seconds: number = 1
+): Promise<FrameResult> {
 	try {
-		const buffer = execFileSync("ffmpeg", [
-			"-ss", String(seconds), "-i", filePath,
-			"-frames:v", "1", "-f", "image2pipe", "-vcodec", "mjpeg", "pipe:1",
-		], { maxBuffer: 5 * 1024 * 1024, timeout: 10000, stdio: ["pipe", "pipe", "pipe"] });
+		const buffer = execFileSync(
+			"ffmpeg",
+			[
+				"-ss",
+				String(seconds),
+				"-i",
+				filePath,
+				"-frames:v",
+				"1",
+				"-f",
+				"image2pipe",
+				"-vcodec",
+				"mjpeg",
+				"pipe:1",
+			],
+			{ maxBuffer: 5 * 1024 * 1024, timeout: 10000, stdio: ["pipe", "pipe", "pipe"] }
+		);
 		if (buffer.length === 0) return { error: "ffmpeg failed: empty output" };
 		return { data: buffer.toString("base64"), mimeType: "image/jpeg" };
 	} catch (err) {
@@ -210,12 +241,11 @@ export async function extractVideoFrame(filePath: string, seconds: number = 1): 
 
 export async function getLocalVideoDuration(filePath: string): Promise<number | { error: string }> {
 	try {
-		const output = execFileSync("ffprobe", [
-			"-v", "quiet",
-			"-show_entries", "format=duration",
-			"-of", "csv=p=0",
-			filePath,
-		], { timeout: 10000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+		const output = execFileSync(
+			"ffprobe",
+			["-v", "quiet", "-show_entries", "format=duration", "-of", "csv=p=0", filePath],
+			{ timeout: 10000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+		).trim();
 		const duration = Number.parseFloat(output);
 		if (!Number.isFinite(duration)) return { error: "ffprobe failed: invalid duration output" };
 		return duration;
@@ -228,7 +258,7 @@ async function tryVideoGeminiWeb(
 	info: VideoFileInfo,
 	prompt: string,
 	model: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	try {
 		const cookies = await isGeminiWebAvailable();
@@ -258,7 +288,7 @@ async function tryVideoGeminiApi(
 	info: VideoFileInfo,
 	prompt: string,
 	model: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	const apiKey = getApiKey();
 	if (!apiKey) return null;
@@ -295,7 +325,7 @@ async function tryVideoGeminiApi(
 async function uploadToFilesApi(
 	info: VideoFileInfo,
 	apiKey: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<{ name: string; uri: string }> {
 	const displayName = basename(info.absolutePath);
 
@@ -338,7 +368,7 @@ async function uploadToFilesApi(
 		throw new Error(`File upload failed: ${uploadRes.status} (${text.slice(0, 200)})`);
 	}
 
-	const result = await uploadRes.json() as { file: { name: string; uri: string } };
+	const result = (await uploadRes.json()) as { file: { name: string; uri: string } };
 	return result.file;
 }
 
@@ -346,7 +376,7 @@ async function pollFileState(
 	fileName: string,
 	apiKey: string,
 	signal?: AbortSignal,
-	timeoutMs: number = 120000,
+	timeoutMs: number = 120000
 ): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 
@@ -356,11 +386,11 @@ async function pollFileState(
 		const res = await fetch(`${API_BASE}/${fileName}?key=${apiKey}`, { signal });
 		if (!res.ok) throw new Error(`File state check failed: ${res.status}`);
 
-		const data = await res.json() as { state: string };
+		const data = (await res.json()) as { state: string };
 		if (data.state === "ACTIVE") return;
 		if (data.state === "FAILED") throw new Error("File processing failed");
 
-		await new Promise(r => setTimeout(r, 5000));
+		await new Promise((r) => setTimeout(r, 5000));
 	}
 
 	throw new Error("File processing timed out");

--- a/youtube-extract.ts
+++ b/youtube-extract.ts
@@ -6,8 +6,19 @@ import { activityMonitor } from "./activity.js";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.js";
 import { isGeminiApiAvailable, queryGeminiApiWithVideo } from "./gemini-api.js";
 import { searchWithPerplexity } from "./perplexity.js";
-import { extractHeadingTitle, type ExtractedContent, type FrameResult, type VideoFrame } from "./extract.js";
-import { formatSeconds, readExecError, isTimeoutError, trimErrorText, mapFfmpegError } from "./utils.js";
+import {
+	extractHeadingTitle,
+	type ExtractedContent,
+	type FrameResult,
+	type VideoFrame,
+} from "./extract.js";
+import {
+	formatSeconds,
+	readExecError,
+	isTimeoutError,
+	trimErrorText,
+	mapFfmpegError,
+} from "./utils.js";
 
 const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
 
@@ -75,8 +86,7 @@ export function isYouTubeURL(url: string): { isYouTube: boolean; videoId: string
 		if (parsed.pathname === "/playlist") {
 			return { isYouTube: false, videoId: null };
 		}
-	} catch {
-	}
+	} catch {}
 
 	const match = url.match(YOUTUBE_REGEX);
 	if (!match) return { isYouTube: false, videoId: null };
@@ -91,21 +101,23 @@ export async function extractYouTube(
 	url: string,
 	signal?: AbortSignal,
 	prompt?: string,
-	model?: string,
+	model?: string
 ): Promise<ExtractedContent | null> {
 	const config = loadYouTubeConfig();
 	const { videoId } = isYouTubeURL(url);
-	const canonicalUrl = videoId
-		? `https://www.youtube.com/watch?v=${videoId}`
-		: url;
+	const canonicalUrl = videoId ? `https://www.youtube.com/watch?v=${videoId}` : url;
 	const effectivePrompt = prompt ?? YOUTUBE_PROMPT;
 	const effectiveModel = model ?? config.preferredModel;
 
-	const activityId = activityMonitor.logStart({ type: "fetch", url: `youtube.com/${videoId ?? "video"}` });
+	const activityId = activityMonitor.logStart({
+		type: "fetch",
+		url: `youtube.com/${videoId ?? "video"}`,
+	});
 
-	const result = await tryGeminiWeb(canonicalUrl, effectivePrompt, effectiveModel, signal)
-		?? await tryGeminiApi(canonicalUrl, effectivePrompt, effectiveModel, signal)
-		?? await tryPerplexity(url, effectivePrompt, signal);
+	const result =
+		(await tryGeminiWeb(canonicalUrl, effectivePrompt, effectiveModel, signal)) ??
+		(await tryGeminiApi(canonicalUrl, effectivePrompt, effectiveModel, signal)) ??
+		(await tryPerplexity(url, effectivePrompt, signal));
 
 	if (result) {
 		result.url = url;
@@ -136,7 +148,8 @@ function mapYtDlpError(err: unknown): string {
 	const lower = stderr.toLowerCase();
 	if (lower.includes("private")) return "Video is private or unavailable";
 	if (lower.includes("sign in")) return "Video is age-restricted and requires authentication";
-	if (lower.includes("not available")) return "Video is unavailable in your region or has been removed";
+	if (lower.includes("not available"))
+		return "Video is unavailable in your region or has been removed";
 	if (lower.includes("live")) return "Cannot extract frames from a live stream";
 	const snippet = trimErrorText(stderr || message);
 	return snippet ? `yt-dlp failed: ${snippet}` : "yt-dlp failed";
@@ -144,15 +157,17 @@ function mapYtDlpError(err: unknown): string {
 
 export async function getYouTubeStreamInfo(videoId: string): Promise<StreamResult> {
 	try {
-		const output = execFileSync("yt-dlp", [
-			"--print", "duration",
-			"-g", `https://www.youtube.com/watch?v=${videoId}`,
-		], { timeout: 15000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+		const output = execFileSync(
+			"yt-dlp",
+			["--print", "duration", "-g", `https://www.youtube.com/watch?v=${videoId}`],
+			{ timeout: 15000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+		).trim();
 		const lines = output.split(/\r?\n/);
 		const rawDuration = lines[0]?.trim();
 		const streamUrl = lines[1]?.trim();
 		if (!streamUrl) return { error: "yt-dlp failed: missing stream URL" };
-		const parsedDuration = rawDuration && rawDuration !== "NA" ? Number.parseFloat(rawDuration) : NaN;
+		const parsedDuration =
+			rawDuration && rawDuration !== "NA" ? Number.parseFloat(rawDuration) : NaN;
 		const duration = Number.isFinite(parsedDuration) ? parsedDuration : null;
 		return { streamUrl, duration };
 	} catch (err) {
@@ -162,10 +177,23 @@ export async function getYouTubeStreamInfo(videoId: string): Promise<StreamResul
 
 async function extractFrameFromStream(streamUrl: string, seconds: number): Promise<FrameResult> {
 	try {
-		const buffer = execFileSync("ffmpeg", [
-			"-ss", String(seconds), "-i", streamUrl,
-			"-frames:v", "1", "-f", "image2pipe", "-vcodec", "mjpeg", "pipe:1",
-		], { maxBuffer: 5 * 1024 * 1024, timeout: 30000, stdio: ["pipe", "pipe", "pipe"] });
+		const buffer = execFileSync(
+			"ffmpeg",
+			[
+				"-ss",
+				String(seconds),
+				"-i",
+				streamUrl,
+				"-frames:v",
+				"1",
+				"-f",
+				"image2pipe",
+				"-vcodec",
+				"mjpeg",
+				"pipe:1",
+			],
+			{ maxBuffer: 5 * 1024 * 1024, timeout: 30000, stdio: ["pipe", "pipe", "pipe"] }
+		);
 		if (buffer.length === 0) return { error: "ffmpeg failed: empty output" };
 		return { data: buffer.toString("base64"), mimeType: "image/jpeg" };
 	} catch (err) {
@@ -176,9 +204,9 @@ async function extractFrameFromStream(streamUrl: string, seconds: number): Promi
 export async function extractYouTubeFrame(
 	videoId: string,
 	seconds: number,
-	streamInfo?: StreamInfo,
+	streamInfo?: StreamInfo
 ): Promise<FrameResult> {
-	const info = streamInfo ?? await getYouTubeStreamInfo(videoId);
+	const info = streamInfo ?? (await getYouTubeStreamInfo(videoId));
 	if ("error" in info) return info;
 	return extractFrameFromStream(info.streamUrl, seconds);
 }
@@ -186,21 +214,29 @@ export async function extractYouTubeFrame(
 export async function extractYouTubeFrames(
 	videoId: string,
 	timestamps: number[],
-	streamInfo?: StreamInfo,
+	streamInfo?: StreamInfo
 ): Promise<{ frames: VideoFrame[]; duration: number | null; error: string | null }> {
-	const info = streamInfo ?? await getYouTubeStreamInfo(videoId);
+	const info = streamInfo ?? (await getYouTubeStreamInfo(videoId));
 	if ("error" in info) return { frames: [], duration: null, error: info.error };
-	const results = await Promise.all(timestamps.map(async (t) => {
-		const frame = await extractFrameFromStream(info.streamUrl, t);
-		if ("error" in frame) return { error: frame.error };
-		return { ...frame, timestamp: formatSeconds(t) };
-	}));
+	const results = await Promise.all(
+		timestamps.map(async (t) => {
+			const frame = await extractFrameFromStream(info.streamUrl, t);
+			if ("error" in frame) return { error: frame.error };
+			return { ...frame, timestamp: formatSeconds(t) };
+		})
+	);
 	const frames = results.filter((f): f is VideoFrame => "data" in f);
 	const errorResult = results.find((f): f is { error: string } => "error" in f);
-	return { frames, duration: info.duration, error: frames.length === 0 && errorResult ? errorResult.error : null };
+	return {
+		frames,
+		duration: info.duration,
+		error: frames.length === 0 && errorResult ? errorResult.error : null,
+	};
 }
 
-export async function fetchYouTubeThumbnail(videoId: string): Promise<{ data: string; mimeType: string } | null> {
+export async function fetchYouTubeThumbnail(
+	videoId: string
+): Promise<{ data: string; mimeType: string } | null> {
 	try {
 		const res = await fetch(`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`, {
 			signal: AbortSignal.timeout(5000),
@@ -218,7 +254,7 @@ async function tryGeminiWeb(
 	url: string,
 	prompt: string,
 	model: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	try {
 		const cookies = await isGeminiWebAvailable();
@@ -249,7 +285,7 @@ async function tryGeminiApi(
 	url: string,
 	prompt: string,
 	model: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	try {
 		if (!isGeminiApiAvailable()) return null;
@@ -277,19 +313,17 @@ async function tryGeminiApi(
 async function tryPerplexity(
 	url: string,
 	prompt: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	try {
 		if (signal?.aborted) return null;
 
-		const perplexityQuery = prompt === YOUTUBE_PROMPT
-			? `Summarize this YouTube video in detail: ${url}`
-			: `${prompt} YouTube video: ${url}`;
+		const perplexityQuery =
+			prompt === YOUTUBE_PROMPT
+				? `Summarize this YouTube video in detail: ${url}`
+				: `${prompt} YouTube video: ${url}`;
 
-		const { answer } = await searchWithPerplexity(
-			perplexityQuery,
-			{ signal },
-		);
+		const { answer } = await searchWithPerplexity(perplexityQuery, { signal });
 
 		if (!answer) return null;
 


### PR DESCRIPTION
## Summary

Adds a  config matching the repo's existing style (tabs, semicolons, double quotes, trailing commas) and applies it across all TypeScript and test files.

### Changes
- Add  with consistent formatting rules
- Add  as a dev dependency
- Add `format` and `format:check` scripts to `package.json`
- Format all TypeScript and test files to match

### Why this helps
I have a few bug fixes and quality-of-life improvements I'd like to contribute upstream. Having deterministic formatting will make those PRs much cleaner to review — the diff will show only the actual logic changes, not whitespace noise.

Happy to rebase my other changes on top of this once it lands. No rush — just setting up a cleaner baseline for future contributions.