### PR TITLE
chore: add prettier formatting config and apply to codebase

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "useTabs": true,
+  "tabWidth": 4,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 120,
+  "endOfLine": "lf"
+}

--- a/activity.ts
+++ b/activity.ts
@@ -27,7 +27,12 @@ export class ActivityMonitor {
 	private entries: ActivityEntry[] = [];
 	private readonly maxEntries = 10;
 	private listeners = new Set<() => void>();
-	private rateLimitInfo: RateLimitInfo = { used: 0, max: 10, oldestTimestamp: null, windowMs: 60000 };
+	private rateLimitInfo: RateLimitInfo = {
+		used: 0,
+		max: 10,
+		oldestTimestamp: null,
+		windowMs: 60000,
+	};
 	private nextId = 1;
 
 	logStart(partial: Omit<ActivityEntry, "id" | "startTime" | "status">): string {
@@ -92,8 +97,7 @@ export class ActivityMonitor {
 		for (const cb of this.listeners) {
 			try {
 				cb();
-			} catch {
-			}
+			} catch {}
 		}
 	}
 }

--- a/chrome-cookies.ts
+++ b/chrome-cookies.ts
@@ -14,11 +14,7 @@ interface BrowserConfig {
 	secretToolApp?: string;
 }
 
-const GOOGLE_ORIGINS = [
-	"https://gemini.google.com",
-	"https://accounts.google.com",
-	"https://www.google.com",
-];
+const GOOGLE_ORIGINS = ["https://gemini.google.com", "https://accounts.google.com", "https://www.google.com"];
 
 const ALL_COOKIE_NAMES = new Set([
 	"__Secure-1PSID",
@@ -67,15 +63,13 @@ const LINUX_BROWSER_CONFIGS: BrowserConfig[] = [
 	{ name: "Chrome", baseDir: ".config/google-chrome", secretToolApp: "chrome" },
 ];
 
-export async function getGoogleCookies(
-	options?: { profile?: string; requiredCookies?: string[] },
-): Promise<{ cookies: CookieMap; warnings: string[] } | null> {
+export async function getGoogleCookies(options?: {
+	profile?: string;
+	requiredCookies?: string[];
+}): Promise<{ cookies: CookieMap; warnings: string[] } | null> {
 	const currentPlatform = platform();
-	const configs = currentPlatform === "darwin"
-		? MACOS_BROWSER_CONFIGS
-		: currentPlatform === "linux"
-			? LINUX_BROWSER_CONFIGS
-			: [];
+	const configs =
+		currentPlatform === "darwin" ? MACOS_BROWSER_CONFIGS : currentPlatform === "linux" ? LINUX_BROWSER_CONFIGS : [];
 	if (configs.length === 0) return null;
 
 	const warnings: string[] = [];
@@ -173,7 +167,7 @@ function removePkcs7Padding(buf: Buffer): Buffer {
 
 function readBrowserPassword(
 	config: BrowserConfig,
-	currentPlatform: ReturnType<typeof platform>,
+	currentPlatform: ReturnType<typeof platform>
 ): Promise<string | null> {
 	if (currentPlatform === "darwin") {
 		if (!config.keychainAccount || !config.keychainService) return Promise.resolve(null);
@@ -192,9 +186,12 @@ function readKeychainPassword(account: string, service: string): Promise<string 
 			["find-generic-password", "-w", "-a", account, "-s", service],
 			{ timeout: 5000 },
 			(err, stdout) => {
-				if (err) { resolve(null); return; }
+				if (err) {
+					resolve(null);
+					return;
+				}
 				resolve(stdout.trim() || null);
-			},
+			}
 		);
 	});
 }
@@ -203,19 +200,14 @@ function readLinuxPassword(secretToolApp: string | undefined): Promise<string> {
 	if (!secretToolApp) return Promise.resolve("peanuts");
 
 	return new Promise((resolve) => {
-		execFile(
-			"secret-tool",
-			["lookup", "application", secretToolApp],
-			{ timeout: 5000 },
-			(err, stdout) => {
-				if (err) {
-					// KDE Wallet users fall through to peanuts intentionally.
-					resolve("peanuts");
-					return;
-				}
-				resolve(stdout.trim() || "peanuts");
-			},
-		);
+		execFile("secret-tool", ["lookup", "application", secretToolApp], { timeout: 5000 }, (err, stdout) => {
+			if (err) {
+				// KDE Wallet users fall through to peanuts intentionally.
+				resolve("peanuts");
+				return;
+			}
+			resolve(stdout.trim() || "peanuts");
+		});
 	});
 }
 
@@ -225,7 +217,7 @@ async function importSqlite(): Promise<typeof import("node:sqlite") | null> {
 	if (sqliteModule) return sqliteModule;
 	const orig = process.emitWarning.bind(process);
 	process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
-		const msg = typeof warning === "string" ? warning : warning?.message ?? "";
+		const msg = typeof warning === "string" ? warning : (warning?.message ?? "");
 		if (msg.includes("SQLite is an experimental feature")) return;
 		return (orig as Function)(warning, ...args);
 	}) as typeof process.emitWarning;
@@ -266,10 +258,7 @@ async function readMetaVersion(dbPath: string): Promise<number> {
 	}
 }
 
-async function queryCookieRows(
-	dbPath: string,
-	hosts: string[],
-): Promise<Array<Record<string, unknown>> | null> {
+async function queryCookieRows(dbPath: string, hosts: string[]): Promise<Array<Record<string, unknown>> | null> {
 	const sqlite = await importSqlite();
 	if (!sqlite) return null;
 
@@ -290,7 +279,7 @@ async function queryCookieRows(
 	try {
 		return db
 			.prepare(
-				`SELECT name, value, host_key, encrypted_value FROM cookies WHERE (${where}) ORDER BY expires_utc DESC`,
+				`SELECT name, value, host_key, encrypted_value FROM cookies WHERE (${where}) ORDER BY expires_utc DESC`
 			)
 			.all() as Array<Record<string, unknown>>;
 	} catch {
@@ -317,6 +306,5 @@ function copySidecar(srcDb: string, targetDb: string, suffix: string): void {
 	if (!existsSync(sidecar)) return;
 	try {
 		copyFileSync(sidecar, `${targetDb}${suffix}`);
-	} catch {
-	}
+	} catch {}
 }

--- a/code-search.ts
+++ b/code-search.ts
@@ -14,7 +14,10 @@ function isMissingMcpToolError(message: string): boolean {
 
 function buildFallbackQuery(query: string): string {
 	const normalized = query.toLowerCase();
-	const hasCodeTerms = /\b(api|code|docs?|documentation|example|github|implementation|library|source|stackoverflow|stack overflow)\b/.test(normalized);
+	const hasCodeTerms =
+		/\b(api|code|docs?|documentation|example|github|implementation|library|source|stackoverflow|stack overflow)\b/.test(
+			normalized
+		);
 	return hasCodeTerms ? query : `${query} code examples documentation GitHub Stack Overflow official docs`;
 }
 
@@ -38,7 +41,7 @@ async function executeFallbackSearch(query: string, maxTokens: number, signal?: 
 			type: "auto",
 			contextMaxCharacters: Math.min(50000, Math.max(1000, maxTokens * 4)),
 		},
-		signal,
+		signal
 	);
 	return trimApproxTokens(text, maxTokens);
 }
@@ -46,16 +49,25 @@ async function executeFallbackSearch(query: string, maxTokens: number, signal?: 
 export async function executeCodeSearch(
 	_toolCallId: string,
 	params: { query: string; maxTokens?: number },
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<{
 	content: Array<{ type: "text"; text: string }>;
-	details: { query: string; maxTokens: number; error?: string; mode?: "code-context" | "web-search-fallback" };
+	details: {
+		query: string;
+		maxTokens: number;
+		error?: string;
+		mode?: "code-context" | "web-search-fallback";
+	};
 }> {
 	const query = params.query.trim();
 	if (!query) {
 		return {
 			content: [{ type: "text", text: "Error: No query provided." }],
-			details: { query: "", maxTokens: params.maxTokens ?? DEFAULT_MAX_TOKENS, error: "No query provided" },
+			details: {
+				query: "",
+				maxTokens: params.maxTokens ?? DEFAULT_MAX_TOKENS,
+				error: "No query provided",
+			},
 		};
 	}
 
@@ -76,7 +88,7 @@ export async function executeCodeSearch(
 						query,
 						tokensNum: maxTokens,
 					},
-					signal,
+					signal
 				);
 				mode = "code-context";
 			} catch (err) {

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -10,7 +10,7 @@ function safeInlineJSON(data: unknown): string {
 function buildProviderButtons(
 	available: { perplexity: boolean; exa: boolean; gemini: boolean },
 	selected: string,
-	hasInitialQueries: boolean,
+	hasInitialQueries: boolean
 ): string {
 	const providers = [
 		{ value: "perplexity", label: "Perplexity", available: available.perplexity },
@@ -19,7 +19,7 @@ function buildProviderButtons(
 	];
 
 	return providers
-		.filter(p => p.available)
+		.filter((p) => p.available)
 		.map((p) => {
 			const isDefault = p.value === selected;
 			const state = isDefault && hasInitialQueries ? "loading" : "idle";
@@ -37,10 +37,18 @@ export function generateCuratorPage(
 	availableProviders: { perplexity: boolean; exa: boolean; gemini: boolean },
 	defaultProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
-	defaultSummaryModel: string | null,
+	defaultSummaryModel: string | null
 ): string {
 	const providerButtonsHtml = buildProviderButtons(availableProviders, defaultProvider, queries.length > 0);
-	const inlineData = safeInlineJSON({ queries, sessionToken, timeout, defaultProvider, summaryModels, defaultSummaryModel, availableProviders });
+	const inlineData = safeInlineJSON({
+		queries,
+		sessionToken,
+		timeout,
+		defaultProvider,
+		summaryModels,
+		defaultSummaryModel,
+		availableProviders,
+	});
 
 	return `<!DOCTYPE html>
 <html lang="en">

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -19,10 +19,19 @@ export interface CuratorServerOptions {
 }
 
 export interface CuratorServerCallbacks {
-	onSubmit: (payload: { selectedQueryIndices: number[]; summary?: string; summaryMeta?: SummaryMeta; rawResults?: boolean }) => void;
+	onSubmit: (payload: {
+		selectedQueryIndices: number[];
+		summary?: string;
+		summaryMeta?: SummaryMeta;
+		rawResults?: boolean;
+	}) => void;
 	onCancel: (reason: "user" | "timeout" | "stale") => void;
 	onProviderChange: (provider: string) => void;
-	onAddSearch: (query: string, queryIndex: number, provider?: string) => Promise<{
+	onAddSearch: (
+		query: string,
+		queryIndex: number,
+		provider?: string
+	) => Promise<{
 		answer: string;
 		results: Array<{ title: string; url: string; domain: string }>;
 		provider: string;
@@ -31,7 +40,7 @@ export interface CuratorServerCallbacks {
 		selectedQueryIndices: number[],
 		signal: AbortSignal,
 		model?: string,
-		feedback?: string,
+		feedback?: string
 	) => Promise<{ summary: string; meta: SummaryMeta }>;
 	onRewriteQuery: (query: string, signal: AbortSignal) => Promise<string>;
 }
@@ -40,7 +49,14 @@ export interface CuratorServerHandle {
 	server: http.Server;
 	url: string;
 	close: () => void;
-	pushResult: (queryIndex: number, data: { answer: string; results: Array<{ title: string; url: string; domain: string }>; provider: string }) => void;
+	pushResult: (
+		queryIndex: number,
+		data: {
+			answer: string;
+			results: Array<{ title: string; url: string; domain: string }>;
+			provider: string;
+		}
+	) => void;
 	pushError: (queryIndex: number, error: string, provider?: string) => void;
 	searchesDone: () => void;
 }
@@ -91,7 +107,7 @@ async function parseBodyOrSend(req: IncomingMessage, res: ServerResponse): Promi
 
 function normalizeSelectedIndices(
 	value: unknown,
-	options: { allowEmpty: boolean; maxExclusive: number },
+	options: { allowEmpty: boolean; maxExclusive: number }
 ): { ok: true; indices: number[] } | { ok: false; error: string } {
 	if (!Array.isArray(value)) {
 		return { ok: false, error: "Invalid selection" };
@@ -158,17 +174,10 @@ function normalizeSummaryMeta(value: unknown): SummaryMeta | null {
 
 export function startCuratorServer(
 	options: CuratorServerOptions,
-	callbacks: CuratorServerCallbacks,
+	callbacks: CuratorServerCallbacks
 ): Promise<CuratorServerHandle> {
-	const {
-		queries,
-		sessionToken,
-		timeout,
-		availableProviders,
-		defaultProvider,
-		summaryModels,
-		defaultSummaryModel,
-	} = options;
+	const { queries, sessionToken, timeout, availableProviders, defaultProvider, summaryModels, defaultSummaryModel } =
+		options;
 	let browserConnected = false;
 	let lastHeartbeatAt = Date.now();
 	let completed = false;
@@ -202,7 +211,9 @@ export function startCuratorServer(
 		}
 		abortInFlightSummarize();
 		if (sseResponse) {
-			try { sseResponse.end(); } catch {}
+			try {
+				sseResponse.end();
+			} catch {}
 			sseResponse = null;
 		}
 		return true;
@@ -236,7 +247,10 @@ export function startCuratorServer(
 		const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 		const res = sseResponse;
 		if (res && !res.writableEnded && res.socket && !res.socket.destroyed) {
-			try { res.write(payload); return; } catch {}
+			try {
+				res.write(payload);
+				return;
+			} catch {}
 		}
 		sseBuffer.push(payload);
 	}
@@ -248,7 +262,7 @@ export function startCuratorServer(
 		availableProviders,
 		defaultProvider,
 		summaryModels,
-		defaultSummaryModel,
+		defaultSummaryModel
 	);
 
 	const server = http.createServer(async (req, res) => {
@@ -284,7 +298,9 @@ export function startCuratorServer(
 					return;
 				}
 				if (sseResponse) {
-					try { sseResponse.end(); } catch {}
+					try {
+						sseResponse.end();
+					} catch {}
 				}
 				res.writeHead(200, {
 					"Content-Type": "text/event-stream",
@@ -310,7 +326,9 @@ export function startCuratorServer(
 				if (sseKeepalive) clearInterval(sseKeepalive);
 				sseKeepalive = setInterval(() => {
 					if (sseResponse) {
-						try { sseResponse.write(":keepalive\n\n"); } catch {}
+						try {
+							sseResponse.write(":keepalive\n\n");
+						} catch {}
 					}
 				}, 15000);
 				req.on("close", () => {
@@ -365,7 +383,10 @@ export function startCuratorServer(
 						return;
 					}
 					if (!isAvailableProvider(provider)) {
-						sendJson(res, 400, { ok: false, error: `Provider unavailable: ${provider}` });
+						sendJson(res, 400, {
+							ok: false,
+							error: `Provider unavailable: ${provider}`,
+						});
 						return;
 					}
 				}
@@ -422,9 +443,10 @@ export function startCuratorServer(
 				}
 
 				const bodyFeedback = (body as { feedback?: unknown }).feedback;
-				const feedback = typeof bodyFeedback === "string" && bodyFeedback.trim().length > 0
-					? bodyFeedback.trim()
-					: undefined;
+				const feedback =
+					typeof bodyFeedback === "string" && bodyFeedback.trim().length > 0
+						? bodyFeedback.trim()
+						: undefined;
 
 				abortInFlightSummarize();
 				const controller = new AbortController();
@@ -527,7 +549,14 @@ export function startCuratorServer(
 				}
 				const rawResults = (body as { rawResults?: unknown }).rawResults === true;
 				sendJson(res, 200, { ok: true });
-				setImmediate(() => callbacks.onSubmit({ selectedQueryIndices: parsed.indices, summary, summaryMeta, rawResults }));
+				setImmediate(() =>
+					callbacks.onSubmit({
+						selectedQueryIndices: parsed.indices,
+						summary,
+						summaryMeta,
+						rawResults,
+					})
+				);
 				return;
 			}
 
@@ -581,7 +610,9 @@ export function startCuratorServer(
 				url,
 				close: () => {
 					const wasOpen = markCompleted();
-					try { server.close(); } catch {}
+					try {
+						server.close();
+					} catch {}
 					if (wasOpen) {
 						setImmediate(() => callbacks.onCancel("stale"));
 					}
@@ -592,7 +623,12 @@ export function startCuratorServer(
 				},
 				pushError: (queryIndex, error, provider) => {
 					if (completed) return;
-					sendSSE("search-error", { queryIndex, query: queries[queryIndex] ?? "", error, provider });
+					sendSSE("search-error", {
+						queryIndex,
+						query: queries[queryIndex] ?? "",
+						error,
+						provider,
+					});
 				},
 				searchesDone: () => {
 					if (completed) return;

--- a/exa.ts
+++ b/exa.ts
@@ -154,14 +154,15 @@ function recencyToStartDate(filter: string): string {
 	return new Date(now.getTime() - days * 86400000).toISOString();
 }
 
-function mapDomainFilter(domainFilter: string[] | undefined): { includeDomains?: string[]; excludeDomains?: string[] } {
+function mapDomainFilter(domainFilter: string[] | undefined): {
+	includeDomains?: string[];
+	excludeDomains?: string[];
+} {
 	if (!domainFilter?.length) return {};
-	const includeDomains = domainFilter
-		.filter(d => !d.startsWith("-") && d.trim().length > 0)
-		.map(d => d.trim());
+	const includeDomains = domainFilter.filter((d) => !d.startsWith("-") && d.trim().length > 0).map((d) => d.trim());
 	const excludeDomains = domainFilter
-		.filter(d => d.startsWith("-"))
-		.map(d => d.slice(1).trim())
+		.filter((d) => d.startsWith("-"))
+		.map((d) => d.slice(1).trim())
 		.filter(Boolean);
 	return {
 		...(includeDomains.length ? { includeDomains } : {}),
@@ -181,9 +182,12 @@ function buildAnswerFromSearchResults(results: ExaSearchResponse["results"]): st
 		const item = results[i];
 		if (!item?.url) continue;
 		const highlights = normalizeHighlights(item.highlights);
-		const content = highlights.length > 0
-			? highlights.join(" ")
-			: typeof item.text === "string" ? item.text.trim().slice(0, 1000) : "";
+		const content =
+			highlights.length > 0
+				? highlights.join(" ")
+				: typeof item.text === "string"
+					? item.text.trim().slice(0, 1000)
+					: "";
 		if (!content) continue;
 		const sourceTitle = item.title || `Source ${i + 1}`;
 		parts.push(`${content}\nSource: ${sourceTitle} (${item.url})`);
@@ -209,9 +213,15 @@ function mapResults(results: ExaSearchResponse["results"] | ExaAnswerResponse["c
 function mapInlineContent(results: ExaSearchResponse["results"]): ExtractedContent[] {
 	if (!results?.length) return [];
 	return results
-		.filter((r): r is NonNullable<ExaSearchResponse["results"]>[number] & { url: string; text: string } =>
-			!!r?.url && typeof r.text === "string" && r.text.length > 0)
-		.map(r => ({
+		.filter(
+			(
+				r
+			): r is NonNullable<ExaSearchResponse["results"]>[number] & {
+				url: string;
+				text: string;
+			} => !!r?.url && typeof r.text === "string" && r.text.length > 0
+		)
+		.map((r) => ({
 			url: r.url,
 			title: r.title || "",
 			content: r.text,
@@ -222,13 +232,13 @@ function mapInlineContent(results: ExaSearchResponse["results"]): ExtractedConte
 export async function callExaMcp(
 	toolName: string,
 	args: Record<string, unknown>,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<string> {
 	const response = await fetch(EXA_MCP_URL, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
-			"Accept": "application/json, text/event-stream",
+			Accept: "application/json, text/event-stream",
 		},
 		body: JSON.stringify({
 			jsonrpc: "2.0",
@@ -248,7 +258,7 @@ export async function callExaMcp(
 	}
 
 	const body = await response.text();
-	const dataLines = body.split("\n").filter(line => line.startsWith("data:"));
+	const dataLines = body.split("\n").filter((line) => line.startsWith("data:"));
 
 	let parsed: ExaMcpRpcResponse | null = null;
 	for (const line of dataLines) {
@@ -260,8 +270,7 @@ export async function callExaMcp(
 				parsed = candidate;
 				break;
 			}
-		} catch {
-		}
+		} catch {}
 	}
 
 	if (!parsed) {
@@ -270,8 +279,7 @@ export async function callExaMcp(
 			if (candidate?.result || candidate?.error) {
 				parsed = candidate;
 			}
-		} catch {
-		}
+		} catch {}
 	}
 
 	if (!parsed) {
@@ -286,14 +294,14 @@ export async function callExaMcp(
 
 	if (parsed.result?.isError) {
 		const message = parsed.result.content
-			?.find(item => item.type === "text" && typeof item.text === "string")
+			?.find((item) => item.type === "text" && typeof item.text === "string")
 			?.text?.trim();
 		throw new Error(message || "Exa MCP returned an error");
 	}
 
-	const text = parsed.result?.content
-		?.find(item => item.type === "text" && typeof item.text === "string" && item.text.trim().length > 0)
-		?.text;
+	const text = parsed.result?.content?.find(
+		(item) => item.type === "text" && typeof item.text === "string" && item.text.trim().length > 0
+	)?.text;
 
 	if (!text) {
 		throw new Error("Exa MCP returned empty content");
@@ -303,23 +311,25 @@ export async function callExaMcp(
 }
 
 function parseMcpResults(text: string): McpParsedResult[] | null {
-	const blocks = text.split(/(?=^Title: )/m).filter(block => block.trim().length > 0);
-	const parsed = blocks.map(block => {
-		const title = block.match(/^Title: (.+)/m)?.[1]?.trim() ?? "";
-		const url = block.match(/^URL: (.+)/m)?.[1]?.trim() ?? "";
-		let content = "";
-		const textStart = block.indexOf("\nText: ");
-		if (textStart >= 0) {
-			content = block.slice(textStart + 7).trim();
-		} else {
-			const hlMatch = block.match(/\nHighlights:\s*\n/);
-			if (hlMatch?.index != null) {
-				content = block.slice(hlMatch.index + hlMatch[0].length).trim();
+	const blocks = text.split(/(?=^Title: )/m).filter((block) => block.trim().length > 0);
+	const parsed = blocks
+		.map((block) => {
+			const title = block.match(/^Title: (.+)/m)?.[1]?.trim() ?? "";
+			const url = block.match(/^URL: (.+)/m)?.[1]?.trim() ?? "";
+			let content = "";
+			const textStart = block.indexOf("\nText: ");
+			if (textStart >= 0) {
+				content = block.slice(textStart + 7).trim();
+			} else {
+				const hlMatch = block.match(/\nHighlights:\s*\n/);
+				if (hlMatch?.index != null) {
+					content = block.slice(hlMatch.index + hlMatch[0].length).trim();
+				}
 			}
-		}
-		content = content.replace(/\n---\s*$/, "").trim();
-		return { title, url, content };
-	}).filter(result => result.url.length > 0);
+			content = content.replace(/\n---\s*$/, "").trim();
+			return { title, url, content };
+		})
+		.filter((result) => result.url.length > 0);
 	return parsed.length > 0 ? parsed : null;
 }
 
@@ -338,8 +348,8 @@ function buildAnswerFromMcpResults(results: McpParsedResult[]): string {
 
 function mapMcpInlineContent(results: McpParsedResult[]): ExtractedContent[] {
 	return results
-		.filter(result => result.content.length > 0)
-		.map(result => ({
+		.filter((result) => result.content.length > 0)
+		.map((result) => ({
 			url: result.url,
 			title: result.title,
 			content: result.content,
@@ -357,10 +367,18 @@ function buildMcpQuery(query: string, options: ExaSearchOptions): string {
 	if (options.recencyFilter) {
 		const now = new Date();
 		switch (options.recencyFilter) {
-			case "day": parts.push("past 24 hours"); break;
-			case "week": parts.push("past week"); break;
-			case "month": parts.push(`${now.toLocaleString("en", { month: "long" })} ${now.getFullYear()}`); break;
-			case "year": parts.push(String(now.getFullYear())); break;
+			case "day":
+				parts.push("past 24 hours");
+				break;
+			case "week":
+				parts.push("past week");
+				break;
+			case "month":
+				parts.push(`${now.toLocaleString("en", { month: "long" })} ${now.getFullYear()}`);
+				break;
+			case "year":
+				parts.push(String(now.getFullYear()));
+				break;
 		}
 	}
 	return parts.join(" ");
@@ -380,7 +398,7 @@ async function searchWithExaMcp(query: string, options: ExaSearchOptions = {}): 
 				type: "auto",
 				contextMaxCharacters: options.includeContent ? 50000 : 3000,
 			},
-			options.signal,
+			options.signal
 		);
 		const parsedResults = parseMcpResults(text);
 		activityMonitor.logComplete(activityId, 200);
@@ -434,10 +452,11 @@ export async function searchWithExa(query: string, options: ExaSearchOptions = {
 	const budget = reserveRequestBudget();
 	if (budget) return budget;
 
-	const useSearch = options.includeContent
-		|| !!options.recencyFilter
-		|| !!options.domainFilter?.length
-		|| !!(options.numResults && options.numResults !== 5);
+	const useSearch =
+		options.includeContent ||
+		!!options.recencyFilter ||
+		!!options.domainFilter?.length ||
+		!!(options.numResults && options.numResults !== 5);
 
 	const activityId = activityMonitor.logStart({ type: "api", query });
 
@@ -461,7 +480,7 @@ export async function searchWithExa(query: string, options: ExaSearchOptions = {
 				throw new Error(`Exa API error ${response.status}: ${errorText.slice(0, 300)}`);
 			}
 
-			const data = await response.json() as ExaAnswerResponse;
+			const data = (await response.json()) as ExaAnswerResponse;
 			activityMonitor.logComplete(activityId, response.status);
 			return {
 				answer: data.answer || "",
@@ -496,7 +515,7 @@ export async function searchWithExa(query: string, options: ExaSearchOptions = {
 			throw new Error(`Exa API error ${response.status}: ${errorText.slice(0, 300)}`);
 		}
 
-		const data = await response.json() as ExaSearchResponse;
+		const data = (await response.json()) as ExaSearchResponse;
 		activityMonitor.logComplete(activityId, response.status);
 
 		const mapped: SearchResponse = {

--- a/extract.ts
+++ b/extract.ts
@@ -6,7 +6,14 @@ import { activityMonitor } from "./activity.js";
 import { extractRSCContent } from "./rsc-extract.js";
 import { extractPDFToMarkdown, isPDF } from "./pdf-extract.js";
 import { extractGitHub } from "./github-extract.js";
-import { isYouTubeURL, isYouTubeEnabled, extractYouTube, extractYouTubeFrame, extractYouTubeFrames, getYouTubeStreamInfo } from "./youtube-extract.js";
+import {
+	isYouTubeURL,
+	isYouTubeEnabled,
+	extractYouTube,
+	extractYouTubeFrame,
+	extractYouTubeFrames,
+	getYouTubeStreamInfo,
+} from "./youtube-extract.js";
 import { extractWithUrlContext, extractWithGeminiWeb } from "./gemini-url-context.js";
 import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } from "./video-extract.js";
 import { formatSeconds } from "./utils.js";
@@ -71,10 +78,7 @@ export interface ExtractOptions {
 const JINA_READER_BASE = "https://r.jina.ai/";
 const JINA_TIMEOUT_MS = 30000;
 
-async function extractWithJinaReader(
-	url: string,
-	signal?: AbortSignal,
-): Promise<ExtractedContent | null> {
+async function extractWithJinaReader(url: string, signal?: AbortSignal): Promise<ExtractedContent | null> {
 	const jinaUrl = JINA_READER_BASE + url;
 
 	const activityId = activityMonitor.logStart({ type: "api", query: `jina: ${url}` });
@@ -82,13 +86,10 @@ async function extractWithJinaReader(
 	try {
 		const res = await fetch(jinaUrl, {
 			headers: {
-				"Accept": "text/markdown",
+				Accept: "text/markdown",
 				"X-No-Cache": "true",
 			},
-			signal: AbortSignal.any([
-				AbortSignal.timeout(JINA_TIMEOUT_MS),
-				...(signal ? [signal] : []),
-			]),
+			signal: AbortSignal.any([AbortSignal.timeout(JINA_TIMEOUT_MS), ...(signal ? [signal] : [])]),
 		});
 
 		if (!res.ok) {
@@ -107,9 +108,11 @@ async function extractWithJinaReader(
 		const markdownPart = content.slice(contentStart + 17).trim(); // 17 = "Markdown Content:".length
 
 		// Check for failed JS rendering or minimal content
-		if (markdownPart.length < 100 ||
+		if (
+			markdownPart.length < 100 ||
 			markdownPart.startsWith("Loading...") ||
-			markdownPart.startsWith("Please enable JavaScript")) {
+			markdownPart.startsWith("Please enable JavaScript")
+		) {
 			return null;
 		}
 
@@ -130,7 +133,7 @@ function parseTimestamp(ts: string): number | null {
 	const num = Number(ts);
 	if (!isNaN(num) && num >= 0) return Math.floor(num);
 	const parts = ts.split(":").map(Number);
-	if (parts.some(p => isNaN(p) || p < 0)) return null;
+	if (parts.some((p) => isNaN(p) || p < 0)) return null;
 	if (parts.length === 3) return Math.floor(parts[0] * 3600 + parts[1] * 60 + parts[2]);
 	if (parts.length === 2) return Math.floor(parts[0] * 60 + parts[1]);
 	return null;
@@ -167,8 +170,12 @@ function computeRangeTimestamps(start: number, end: number, maxFrames: number = 
 }
 
 function buildFrameResult(
-	url: string, label: string, requestedCount: number,
-	frames: VideoFrame[], error: string | null, duration?: number,
+	url: string,
+	label: string,
+	requestedCount: number,
+	frames: VideoFrame[],
+	error: string | null,
+	duration?: number
 ): ExtractedContent {
 	if (frames.length === 0) {
 		const msg = error ?? "Frame extraction failed";
@@ -185,13 +192,16 @@ function buildFrameResult(
 }
 
 async function extractLocalFrames(
-	filePath: string, timestamps: number[],
+	filePath: string,
+	timestamps: number[]
 ): Promise<{ frames: VideoFrame[]; error: string | null }> {
-	const results = await Promise.all(timestamps.map(async (t) => {
-		const frame = await extractVideoFrame(filePath, t);
-		if ("error" in frame) return { error: frame.error };
-		return { ...frame, timestamp: formatSeconds(t) };
-	}));
+	const results = await Promise.all(
+		timestamps.map(async (t) => {
+			const frame = await extractVideoFrame(filePath, t);
+			if ("error" in frame) return { error: frame.error };
+			return { ...frame, timestamp: formatSeconds(t) };
+		})
+	);
 	const frames = results.filter((f): f is VideoFrame => "data" in f);
 	const firstError = results.find((f): f is { error: string } => "error" in f);
 	return { frames, error: frames.length === 0 && firstError ? firstError.error : null };
@@ -208,7 +218,7 @@ function safeVideoInfo(url: string): { info: ReturnType<typeof isVideoFile>; err
 export async function extractContent(
 	url: string,
 	signal?: AbortSignal,
-	options?: ExtractOptions,
+	options?: ExtractOptions
 ): Promise<ExtractedContent> {
 	if (signal?.aborted) {
 		return { url, title: "", content: "", error: "Aborted" };
@@ -240,7 +250,12 @@ export async function extractContent(
 		if (localVideo.info) {
 			const durationResult = await getLocalVideoDuration(localVideo.info.absolutePath);
 			if (typeof durationResult !== "number") {
-				return { url, title: "Frames", content: durationResult.error, error: durationResult.error };
+				return {
+					url,
+					title: "Frames",
+					content: durationResult.error,
+					error: durationResult.error,
+				};
 			}
 			const dur = Math.floor(durationResult);
 			const timestamps = computeRangeTimestamps(0, dur, frameCount);
@@ -249,7 +264,12 @@ export async function extractContent(
 			return buildFrameResult(url, label, timestamps.length, result.frames, result.error, durationResult);
 		}
 
-		return { url, title: "", content: "", error: "Frame extraction only works with YouTube and local video files" };
+		return {
+			url,
+			title: "",
+			content: "",
+			error: "Frame extraction only works with YouTube and local video files",
+		};
 	}
 
 	if (options?.timestamp) {
@@ -270,14 +290,29 @@ export async function extractContent(
 			if ("error" in streamInfo) {
 				if (spec.type === "range") {
 					const label = `${formatSeconds(spec.start)}-${formatSeconds(spec.end)}`;
-					return { url, title: `Frames ${label}`, content: streamInfo.error, error: streamInfo.error };
+					return {
+						url,
+						title: `Frames ${label}`,
+						content: streamInfo.error,
+						error: streamInfo.error,
+					};
 				}
 				if (frameCount) {
 					const end = spec.seconds + (frameCount - 1) * MIN_FRAME_INTERVAL;
 					const label = `${formatSeconds(spec.seconds)}-${formatSeconds(end)}`;
-					return { url, title: `Frames ${label}`, content: streamInfo.error, error: streamInfo.error };
+					return {
+						url,
+						title: `Frames ${label}`,
+						content: streamInfo.error,
+						error: streamInfo.error,
+					};
 				}
-				return { url, title: `Frame at ${options.timestamp}`, content: streamInfo.error, error: streamInfo.error };
+				return {
+					url,
+					title: `Frame at ${options.timestamp}`,
+					content: streamInfo.error,
+					error: streamInfo.error,
+				};
 			}
 
 			if (spec.type === "range") {
@@ -290,7 +325,14 @@ export async function extractContent(
 					? computeRangeTimestamps(spec.start, spec.end, frameCount)
 					: computeRangeTimestamps(spec.start, spec.end);
 				const result = await extractYouTubeFrames(ytInfo.videoId, timestamps, streamInfo);
-				return buildFrameResult(url, label, timestamps.length, result.frames, result.error, result.duration ?? undefined);
+				return buildFrameResult(
+					url,
+					label,
+					timestamps.length,
+					result.frames,
+					result.error,
+					result.duration ?? undefined
+				);
 			}
 
 			if (frameCount) {
@@ -302,7 +344,14 @@ export async function extractContent(
 				}
 				const timestamps = computeRangeTimestamps(spec.seconds, end, frameCount);
 				const result = await extractYouTubeFrames(ytInfo.videoId, timestamps, streamInfo);
-				return buildFrameResult(url, label, timestamps.length, result.frames, result.error, result.duration ?? undefined);
+				return buildFrameResult(
+					url,
+					label,
+					timestamps.length,
+					result.frames,
+					result.error,
+					result.duration ?? undefined
+				);
 			}
 
 			if (streamInfo.duration !== null && spec.seconds > streamInfo.duration) {
@@ -311,9 +360,20 @@ export async function extractContent(
 			}
 			const frame = await extractYouTubeFrame(ytInfo.videoId, spec.seconds, streamInfo);
 			if ("error" in frame) {
-				return { url, title: `Frame at ${options.timestamp}`, content: frame.error, error: frame.error };
+				return {
+					url,
+					title: `Frame at ${options.timestamp}`,
+					content: frame.error,
+					error: frame.error,
+				};
 			}
-			return { url, title: `Frame at ${options.timestamp}`, content: `Video frame at ${options.timestamp}`, error: null, thumbnail: frame };
+			return {
+				url,
+				title: `Frame at ${options.timestamp}`,
+				content: `Video frame at ${options.timestamp}`,
+				error: null,
+				thumbnail: frame,
+			};
 		}
 
 		const localVideo = safeVideoInfo(url);
@@ -340,12 +400,28 @@ export async function extractContent(
 
 			const frame = await extractVideoFrame(localVideo.info.absolutePath, spec.seconds);
 			if ("error" in frame) {
-				return { url, title: `Frame at ${options.timestamp}`, content: frame.error, error: frame.error };
+				return {
+					url,
+					title: `Frame at ${options.timestamp}`,
+					content: frame.error,
+					error: frame.error,
+				};
 			}
-			return { url, title: `Frame at ${options.timestamp}`, content: `Video frame at ${options.timestamp}`, error: null, thumbnail: frame };
+			return {
+				url,
+				title: `Frame at ${options.timestamp}`,
+				content: `Video frame at ${options.timestamp}`,
+				error: null,
+				thumbnail: frame,
+			};
 		}
 
-		return { url, title: "", content: "", error: "Timestamp extraction only works with YouTube and local video files" };
+		return {
+			url,
+			title: "",
+			content: "",
+			error: "Timestamp extraction only works with YouTube and local video files",
+		};
 	}
 
 	const localVideo = safeVideoInfo(url);
@@ -356,7 +432,14 @@ export async function extractContent(
 		try {
 			const result = await extractVideo(localVideo.info, signal, options);
 			if (signal?.aborted) return abortedResult(url);
-			return result ?? { url, title: "", content: "", error: "Video analysis requires Gemini access. Either:\n  1. Sign into gemini.google.com in Chrome (free, uses cookies)\n  2. Set GEMINI_API_KEY in ~/.pi/web-search.json" };
+			return (
+				result ?? {
+					url,
+					title: "",
+					content: "",
+					error: "Video analysis requires Gemini access. Either:\n  1. Sign into gemini.google.com in Chrome (free, uses cookies)\n  2. Set GEMINI_API_KEY in ~/.pi/web-search.json",
+				}
+			);
 		} catch (err) {
 			if (isAbortError(err)) return abortedResult(url);
 			return { url, title: "", content: "", error: errorMessage(err) };
@@ -414,7 +497,7 @@ export async function extractContent(
 
 	if (signal?.aborted) return abortedResult(url);
 	if (!httpResult.error) return httpResult;
-	if (NON_RECOVERABLE_ERRORS.some(prefix => httpResult.error!.startsWith(prefix))) return httpResult;
+	if (NON_RECOVERABLE_ERRORS.some((prefix) => httpResult.error!.startsWith(prefix))) return httpResult;
 
 	const jinaResult = await extractWithJinaReader(url, signal);
 	if (jinaResult) return jinaResult;
@@ -422,8 +505,7 @@ export async function extractContent(
 
 	let geminiResult: ExtractedContent | null = null;
 	try {
-		geminiResult = await extractWithUrlContext(url, signal)
-			?? await extractWithGeminiWeb(url, signal);
+		geminiResult = (await extractWithUrlContext(url, signal)) ?? (await extractWithGeminiWeb(url, signal));
 	} catch (err) {
 		if (isAbortError(err)) return abortedResult(url);
 		if (isConfigParseError(err)) {
@@ -467,11 +549,7 @@ function isLikelyJSRendered(html: string): boolean {
 	return textContent.length < 500 && scriptCount > 3;
 }
 
-async function extractViaHttp(
-	url: string,
-	signal?: AbortSignal,
-	options?: ExtractOptions,
-): Promise<ExtractedContent> {
+async function extractViaHttp(url: string, signal?: AbortSignal, options?: ExtractOptions): Promise<ExtractedContent> {
 	const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	const activityId = activityMonitor.logStart({ type: "fetch", url });
 
@@ -485,8 +563,9 @@ async function extractViaHttp(
 		const response = await fetch(url, {
 			signal: controller.signal,
 			headers: {
-				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
-				"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+				"User-Agent":
+					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+				Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
 				"Accept-Language": "en-US,en;q=0.9",
 				"Cache-Control": "no-cache",
 				"Sec-Fetch-Dest": "document",
@@ -542,11 +621,13 @@ async function extractViaHttp(
 			}
 		}
 
-		if (contentType.includes("application/octet-stream") ||
+		if (
+			contentType.includes("application/octet-stream") ||
 			contentType.includes("image/") ||
 			contentType.includes("audio/") ||
 			contentType.includes("video/") ||
-			contentType.includes("application/zip")) {
+			contentType.includes("application/zip")
+		) {
 			activityMonitor.logComplete(activityId, response.status);
 			return {
 				url,
@@ -635,7 +716,7 @@ function extractTextTitle(text: string, url: string): string {
 export async function fetchAllContent(
 	urls: string[],
 	signal?: AbortSignal,
-	options?: ExtractOptions,
+	options?: ExtractOptions
 ): Promise<ExtractedContent[]> {
 	return Promise.all(urls.map((url) => fetchLimit(() => extractContent(url, signal, options))));
 }

--- a/gemini-api.ts
+++ b/gemini-api.ts
@@ -58,7 +58,7 @@ export interface GeminiApiOptions {
 export async function queryGeminiApiWithVideo(
 	prompt: string,
 	videoUri: string,
-	options: GeminiApiOptions = {},
+	options: GeminiApiOptions = {}
 ): Promise<string> {
 	const apiKey = getApiKey();
 	if (!apiKey) throw new Error("GEMINI_API_KEY not configured");
@@ -73,10 +73,7 @@ export async function queryGeminiApiWithVideo(
 	const body = {
 		contents: [
 			{
-				parts: [
-					{ fileData },
-					{ text: prompt },
-				],
+				parts: [{ fileData }, { text: prompt }],
 			},
 		],
 	};

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -4,7 +4,13 @@ import { join } from "node:path";
 import { activityMonitor } from "./activity.js";
 import { getApiKey, API_BASE, DEFAULT_MODEL } from "./gemini-api.js";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.js";
-import { isPerplexityAvailable, searchWithPerplexity, type SearchResult, type SearchResponse, type SearchOptions } from "./perplexity.js";
+import {
+	isPerplexityAvailable,
+	searchWithPerplexity,
+	type SearchResult,
+	type SearchResponse,
+	type SearchOptions,
+} from "./perplexity.js";
 import { hasExaApiKey, isExaAvailable, searchWithExa } from "./exa.js";
 
 export type SearchProvider = "auto" | "perplexity" | "gemini" | "exa";
@@ -78,7 +84,7 @@ function isAbortError(err: unknown): boolean {
 async function searchWithGemini(
 	query: string,
 	options: SearchOptions,
-	strictErrors: boolean,
+	strictErrors: boolean
 ): Promise<SearchResponse | null> {
 	const errors: string[] = [];
 
@@ -119,8 +125,8 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		if (result) return { ...result, provider: "gemini" };
 		throw new Error(
 			"Gemini search unavailable. Either:\n" +
-			"  1. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
-			"  2. Sign into gemini.google.com in a supported Chromium-based browser"
+				"  1. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
+				"  2. Sign into gemini.google.com in a supported Chromium-based browser"
 		);
 	}
 
@@ -131,7 +137,7 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 			if (result && "exhausted" in result) {
 				throw new Error(
 					"Exa monthly free tier exhausted (1,000 requests). Resets next month.\n" +
-					"  Use provider: 'perplexity' or 'gemini', or upgrade at exa.ai/pricing"
+						"  Use provider: 'perplexity' or 'gemini', or upgrade at exa.ai/pricing"
 				);
 			}
 			if (result && "answer" in result) return { ...result, provider: "exa" };
@@ -182,10 +188,10 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 
 	throw new Error(
 		"No search provider available. Either:\n" +
-		"  1. Set perplexityApiKey in ~/.pi/web-search.json\n" +
-		"  2. Set EXA_API_KEY (or exaApiKey) in ~/.pi/web-search.json\n" +
-		"  3. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
-		"  4. Sign into gemini.google.com in a supported Chromium-based browser"
+			"  1. Set perplexityApiKey in ~/.pi/web-search.json\n" +
+			"  2. Set EXA_API_KEY (or exaApiKey) in ~/.pi/web-search.json\n" +
+			"  3. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
+			"  4. Sign into gemini.google.com in a supported Chromium-based browser"
 	);
 }
 
@@ -206,10 +212,7 @@ async function searchWithGeminiApi(query: string, options: SearchOptions = {}): 
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(body),
-			signal: AbortSignal.any([
-				AbortSignal.timeout(60000),
-				...(options.signal ? [options.signal] : []),
-			]),
+			signal: AbortSignal.any([AbortSignal.timeout(60000), ...(options.signal ? [options.signal] : [])]),
 		});
 
 		if (!res.ok) {
@@ -217,11 +220,14 @@ async function searchWithGeminiApi(query: string, options: SearchOptions = {}): 
 			throw new Error(`Gemini API error ${res.status}: ${errorText.slice(0, 300)}`);
 		}
 
-		const data = await res.json() as GeminiSearchResponse;
+		const data = (await res.json()) as GeminiSearchResponse;
 		activityMonitor.logComplete(activityId, res.status);
 
-		const answer = data.candidates?.[0]?.content?.parts
-			?.map(p => p.text).filter(Boolean).join("\n") ?? "";
+		const answer =
+			data.candidates?.[0]?.content?.parts
+				?.map((p) => p.text)
+				.filter(Boolean)
+				.join("\n") ?? "";
 
 		const metadata = data.candidates?.[0]?.groundingMetadata;
 		const results = await resolveGroundingChunks(metadata?.groundingChunks, options.signal);
@@ -282,8 +288,8 @@ function buildSearchPrompt(query: string, options: SearchOptions): string {
 	}
 
 	if (options.domainFilter?.length) {
-		const includes = options.domainFilter.filter(d => !d.startsWith("-"));
-		const excludes = options.domainFilter.filter(d => d.startsWith("-")).map(d => d.slice(1));
+		const includes = options.domainFilter.filter((d) => !d.startsWith("-"));
+		const excludes = options.domainFilter.filter((d) => d.startsWith("-")).map((d) => d.slice(1));
 		if (includes.length) prompt += `\n\nOnly cite sources from: ${includes.join(", ")}`;
 		if (excludes.length) prompt += `\n\nDo not cite sources from: ${excludes.join(", ")}`;
 	}
@@ -306,7 +312,7 @@ function extractSourceUrls(markdown: string): SearchResult[] {
 
 async function resolveGroundingChunks(
 	chunks: GroundingChunk[] | undefined,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<SearchResult[]> {
 	if (!chunks?.length) return [];
 
@@ -331,10 +337,7 @@ async function resolveRedirect(proxyUrl: string, signal?: AbortSignal): Promise<
 		const res = await fetch(proxyUrl, {
 			method: "HEAD",
 			redirect: "manual",
-			signal: AbortSignal.any([
-				AbortSignal.timeout(5000),
-				...(signal ? [signal] : []),
-			]),
+			signal: AbortSignal.any([AbortSignal.timeout(5000), ...(signal ? [signal] : [])]),
 		});
 		return res.headers.get("location") || null;
 	} catch {

--- a/gemini-url-context.ts
+++ b/gemini-url-context.ts
@@ -14,10 +14,7 @@ function shouldRethrow(err: unknown): boolean {
 	return message.startsWith("Failed to parse ");
 }
 
-export async function extractWithUrlContext(
-	url: string,
-	signal?: AbortSignal,
-): Promise<ExtractedContent | null> {
+export async function extractWithUrlContext(url: string, signal?: AbortSignal): Promise<ExtractedContent | null> {
 	const apiKey = getApiKey();
 	if (!apiKey) return null;
 
@@ -34,10 +31,7 @@ export async function extractWithUrlContext(
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(body),
-			signal: AbortSignal.any([
-				AbortSignal.timeout(60000),
-				...(signal ? [signal] : []),
-			]),
+			signal: AbortSignal.any([AbortSignal.timeout(60000), ...(signal ? [signal] : [])]),
 		});
 
 		if (!res.ok) {
@@ -45,7 +39,7 @@ export async function extractWithUrlContext(
 			return null;
 		}
 
-		const data = await res.json() as UrlContextResponse;
+		const data = (await res.json()) as UrlContextResponse;
 		activityMonitor.logComplete(activityId, res.status);
 
 		const metadata = data.candidates?.[0]?.url_context_metadata;
@@ -56,8 +50,11 @@ export async function extractWithUrlContext(
 			}
 		}
 
-		const content = data.candidates?.[0]?.content?.parts
-			?.map(p => p.text).filter(Boolean).join("\n") ?? "";
+		const content =
+			data.candidates?.[0]?.content?.parts
+				?.map((p) => p.text)
+				.filter(Boolean)
+				.join("\n") ?? "";
 
 		if (!content || content.length < 50) return null;
 
@@ -75,10 +72,7 @@ export async function extractWithUrlContext(
 	}
 }
 
-export async function extractWithGeminiWeb(
-	url: string,
-	signal?: AbortSignal,
-): Promise<ExtractedContent | null> {
+export async function extractWithGeminiWeb(url: string, signal?: AbortSignal): Promise<ExtractedContent | null> {
 	const cookies = await isGeminiWebAvailable();
 	if (!cookies) return null;
 

--- a/gemini-web.ts
+++ b/gemini-web.ts
@@ -1,6 +1,10 @@
 import { basename } from "node:path";
 import { type CookieMap, getGoogleCookies } from "./chrome-cookies.js";
-import { getChromeProfileFromConfig, isBrowserCookieAccessAllowed, normalizeChromeProfile } from "./gemini-web-config.ts";
+import {
+	getChromeProfileFromConfig,
+	isBrowserCookieAccessAllowed,
+	normalizeChromeProfile,
+} from "./gemini-web-config.ts";
 
 const GEMINI_APP_URL = "https://gemini.google.com/app";
 const GEMINI_STREAM_GENERATE_URL =
@@ -46,23 +50,17 @@ export async function getActiveGoogleEmail(cookies: CookieMap): Promise<string |
 	if (!cookieHeader) return null;
 
 	try {
-		const html = await fetchWithCookieRedirects(
-			GEMINI_APP_URL,
-			cookieHeader,
-			10,
-			AbortSignal.timeout(10000),
-		);
+		const html = await fetchWithCookieRedirects(GEMINI_APP_URL, cookieHeader, 10, AbortSignal.timeout(10000));
 		const email = extractEmailFromGeminiHtml(html);
 		if (email) return email;
-	} catch {
-	}
+	} catch {}
 
 	try {
 		const response = await fetchWithCookieRedirects(
 			GOOGLE_LIST_ACCOUNTS_URL,
 			cookieHeader,
 			10,
-			AbortSignal.timeout(10000),
+			AbortSignal.timeout(10000)
 		);
 		return extractEmailFromListAccounts(response);
 	} catch {
@@ -73,7 +71,7 @@ export async function getActiveGoogleEmail(cookies: CookieMap): Promise<string |
 export async function queryWithCookies(
 	prompt: string,
 	cookieMap: CookieMap,
-	options: GeminiWebOptions = {},
+	options: GeminiWebOptions = {}
 ): Promise<string> {
 	const model = options.model && MODEL_HEADERS[options.model] ? options.model : "gemini-2.5-flash";
 	const timeoutMs = options.timeoutMs ?? 120000;
@@ -86,7 +84,14 @@ export async function queryWithCookies(
 	const result = await runGeminiWebOnce(fullPrompt, cookieMap, model, options.files, timeoutMs, options.signal);
 
 	if (isModelUnavailable(result.errorCode) && model !== "gemini-2.5-flash") {
-		const fallback = await runGeminiWebOnce(fullPrompt, cookieMap, "gemini-2.5-flash", options.files, timeoutMs, options.signal);
+		const fallback = await runGeminiWebOnce(
+			fullPrompt,
+			cookieMap,
+			"gemini-2.5-flash",
+			options.files,
+			timeoutMs,
+			options.signal
+		);
 		if (fallback.errorMessage) throw new Error(fallback.errorMessage);
 		if (!fallback.text) throw new Error("Gemini Web returned empty response (fallback model)");
 		return fallback.text;
@@ -109,7 +114,7 @@ async function runGeminiWebOnce(
 	model: string,
 	files: string[] | undefined,
 	timeoutMs: number,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<GeminiWebResult> {
 	const effectiveSignal = withTimeout(signal, timeoutMs);
 	const cookieHeader = buildCookieHeader(cookieMap);
@@ -156,8 +161,7 @@ async function runGeminiWebOnce(
 		try {
 			const json = JSON.parse(trimJsonEnvelope(rawText));
 			errorCode = extractErrorCode(json);
-		} catch {
-		}
+		} catch {}
 		return {
 			text: "",
 			errorCode,
@@ -166,10 +170,7 @@ async function runGeminiWebOnce(
 	}
 }
 
-async function fetchAccessToken(
-	cookieHeader: string,
-	signal: AbortSignal,
-): Promise<string> {
+async function fetchAccessToken(cookieHeader: string, signal: AbortSignal): Promise<string> {
 	const html = await fetchWithCookieRedirects(GEMINI_APP_URL, cookieHeader, 10, signal);
 
 	for (const key of ["SNlM0e", "thykhd"]) {
@@ -177,14 +178,16 @@ async function fetchAccessToken(
 		if (match?.[1]) return match[1];
 	}
 
-	throw new Error("Unable to authenticate with Gemini. Make sure you're signed into gemini.google.com in a supported Chromium-based browser.");
+	throw new Error(
+		"Unable to authenticate with Gemini. Make sure you're signed into gemini.google.com in a supported Chromium-based browser."
+	);
 }
 
 async function fetchWithCookieRedirects(
 	url: string,
 	cookieHeader: string,
 	maxRedirects: number,
-	signal: AbortSignal,
+	signal: AbortSignal
 ): Promise<string> {
 	let current = url;
 	for (let i = 0; i <= maxRedirects; i++) {
@@ -268,14 +271,14 @@ function decodeEmailEscapes(value: string): string {
 		.replace(/\\x40/gi, "@")
 		.replace(/&#64;/gi, "@")
 		.replace(/&commat;/gi, "@")
-		.replace(/\\"/g, "\"")
+		.replace(/\\"/g, '"')
 		.replace(/\\\\/g, "\\");
 }
 
 async function uploadFile(
 	filePath: string,
 	cookieHeader: string,
-	signal: AbortSignal,
+	signal: AbortSignal
 ): Promise<{ id: string; name: string }> {
 	const data = readFileSync(filePath);
 	const fileName = basename(filePath);
@@ -283,11 +286,7 @@ async function uploadFile(
 	const header = `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${fileName}"\r\nContent-Type: application/octet-stream\r\n\r\n`;
 	const footer = `\r\n--${boundary}--\r\n`;
 
-	const body = Buffer.concat([
-		Buffer.from(header, "utf-8"),
-		data,
-		Buffer.from(footer, "utf-8"),
-	]);
+	const body = Buffer.concat([Buffer.from(header, "utf-8"), data, Buffer.from(footer, "utf-8")]);
 
 	const res = await fetch(GEMINI_UPLOAD_URL, {
 		method: "POST",
@@ -309,14 +308,8 @@ async function uploadFile(
 	return { id: await res.text(), name: fileName };
 }
 
-function buildFReqPayload(
-	prompt: string,
-	uploaded: Array<{ id: string; name: string }>,
-): string {
-	const promptPayload =
-		uploaded.length > 0
-			? [prompt, 0, null, uploaded.map((file) => [[file.id, 1]])]
-			: [prompt];
+function buildFReqPayload(prompt: string, uploaded: Array<{ id: string; name: string }>): string {
+	const promptPayload = uploaded.length > 0 ? [prompt, 0, null, uploaded.map((file) => [[file.id, 1]])] : [prompt];
 	const innerList = [promptPayload, null, null];
 	return JSON.stringify([null, JSON.stringify(innerList)]);
 }
@@ -378,8 +371,7 @@ function parseStreamGenerateResponse(rawText: string): GeminiWebResult {
 				body = parsed;
 				break;
 			}
-		} catch {
-		}
+		} catch {}
 	}
 
 	const candidateList = getNestedValue(body, [4]);

--- a/github-api.ts
+++ b/github-api.ts
@@ -45,14 +45,19 @@ async function getDefaultBranch(owner: string, repo: string): Promise<string | n
 	if (!(await checkGhAvailable())) return null;
 
 	return new Promise((resolve) => {
-		execFile("gh", ["api", `repos/${owner}/${repo}`, "--jq", ".default_branch"], { timeout: 10000 }, (err, stdout) => {
-			if (err) {
-				resolve(null);
-				return;
+		execFile(
+			"gh",
+			["api", `repos/${owner}/${repo}`, "--jq", ".default_branch"],
+			{ timeout: 10000 },
+			(err, stdout) => {
+				if (err) {
+					resolve(null);
+					return;
+				}
+				const branch = stdout.trim();
+				resolve(branch || null);
 			}
-			const branch = stdout.trim();
-			resolve(branch || null);
-		});
+		);
 	});
 }
 
@@ -77,7 +82,7 @@ async function fetchTreeViaApi(owner: string, repo: string, ref: string): Promis
 				const truncated = paths.length > MAX_TREE_ENTRIES;
 				const display = paths.slice(0, MAX_TREE_ENTRIES).join("\n");
 				resolve(truncated ? display + `\n... (${paths.length} total entries)` : display);
-			},
+			}
 		);
 	});
 }
@@ -97,11 +102,13 @@ async function fetchReadmeViaApi(owner: string, repo: string, ref: string): Prom
 				}
 				try {
 					const decoded = Buffer.from(stdout.trim(), "base64").toString("utf-8");
-					resolve(decoded.length > 8192 ? decoded.slice(0, 8192) + "\n\n[README truncated at 8K chars]" : decoded);
+					resolve(
+						decoded.length > 8192 ? decoded.slice(0, 8192) + "\n\n[README truncated at 8K chars]" : decoded
+					);
 				} catch {
 					resolve(null);
 				}
-			},
+			}
 		);
 	});
 }
@@ -124,7 +131,7 @@ async function fetchFileViaApi(owner: string, repo: string, path: string, ref: s
 				} catch {
 					resolve(null);
 				}
-			},
+			}
 		);
 	});
 }
@@ -134,7 +141,7 @@ export async function fetchViaApi(
 	owner: string,
 	repo: string,
 	info: GitHubUrlInfo,
-	sizeNote?: string,
+	sizeNote?: string
 ): Promise<ExtractedContent | null> {
 	const ref = info.ref || (await getDefaultBranch(owner, repo));
 	if (!ref) return null;
@@ -165,10 +172,7 @@ export async function fetchViaApi(
 		};
 	}
 
-	const [tree, readme] = await Promise.all([
-		fetchTreeViaApi(owner, repo, ref),
-		fetchReadmeViaApi(owner, repo, ref),
-	]);
+	const [tree, readme] = await Promise.all([fetchTreeViaApi(owner, repo, ref), fetchReadmeViaApi(owner, repo, ref)]);
 
 	if (!tree && !readme) return null;
 

--- a/github-extract.ts
+++ b/github-extract.ts
@@ -1,4 +1,14 @@
-import { existsSync, readFileSync, rmSync, statSync, readdirSync, openSync, readSync, closeSync, realpathSync } from "node:fs";
+import {
+	existsSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	readdirSync,
+	openSync,
+	readSync,
+	closeSync,
+	realpathSync,
+} from "node:fs";
 import { execFile } from "node:child_process";
 import { homedir } from "node:os";
 import { extname, join, resolve as resolvePath, sep as pathSep } from "node:path";
@@ -9,21 +19,85 @@ import { checkGhAvailable, checkRepoSize, fetchViaApi, showGhHint } from "./gith
 const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
 
 const BINARY_EXTENSIONS = new Set([
-	".png", ".jpg", ".jpeg", ".gif", ".bmp", ".ico", ".webp", ".svg", ".tiff", ".tif",
-	".mp3", ".mp4", ".avi", ".mov", ".mkv", ".flv", ".wmv", ".wav", ".ogg", ".webm", ".flac", ".aac",
-	".zip", ".tar", ".gz", ".bz2", ".xz", ".7z", ".rar", ".zst",
-	".exe", ".dll", ".so", ".dylib", ".bin", ".o", ".a", ".lib",
-	".woff", ".woff2", ".ttf", ".otf", ".eot",
-	".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
-	".sqlite", ".db", ".sqlite3",
-	".pyc", ".pyo", ".class", ".jar", ".war",
-	".iso", ".img", ".dmg",
+	".png",
+	".jpg",
+	".jpeg",
+	".gif",
+	".bmp",
+	".ico",
+	".webp",
+	".svg",
+	".tiff",
+	".tif",
+	".mp3",
+	".mp4",
+	".avi",
+	".mov",
+	".mkv",
+	".flv",
+	".wmv",
+	".wav",
+	".ogg",
+	".webm",
+	".flac",
+	".aac",
+	".zip",
+	".tar",
+	".gz",
+	".bz2",
+	".xz",
+	".7z",
+	".rar",
+	".zst",
+	".exe",
+	".dll",
+	".so",
+	".dylib",
+	".bin",
+	".o",
+	".a",
+	".lib",
+	".woff",
+	".woff2",
+	".ttf",
+	".otf",
+	".eot",
+	".pdf",
+	".doc",
+	".docx",
+	".xls",
+	".xlsx",
+	".ppt",
+	".pptx",
+	".sqlite",
+	".db",
+	".sqlite3",
+	".pyc",
+	".pyo",
+	".class",
+	".jar",
+	".war",
+	".iso",
+	".img",
+	".dmg",
 ]);
 
 const NOISE_DIRS = new Set([
-	"node_modules", "vendor", ".next", "dist", "build", "__pycache__",
-	".venv", "venv", ".tox", ".mypy_cache", ".pytest_cache",
-	"target", ".gradle", ".idea", ".vscode",
+	"node_modules",
+	"vendor",
+	".next",
+	"dist",
+	"build",
+	"__pycache__",
+	".venv",
+	"venv",
+	".tox",
+	".mypy_cache",
+	".pytest_cache",
+	"target",
+	".gradle",
+	".idea",
+	".vscode",
 ]);
 
 const MAX_INLINE_FILE_CHARS = 100_000;
@@ -85,9 +159,23 @@ function loadGitHubConfig(): GitHubCloneConfig {
 	}
 
 	const rawText = readFileSync(CONFIG_PATH, "utf-8");
-	let raw: { githubClone?: { enabled?: unknown; maxRepoSizeMB?: unknown; cloneTimeoutSeconds?: unknown; clonePath?: unknown } };
+	let raw: {
+		githubClone?: {
+			enabled?: unknown;
+			maxRepoSizeMB?: unknown;
+			cloneTimeoutSeconds?: unknown;
+			clonePath?: unknown;
+		};
+	};
 	try {
-		raw = JSON.parse(rawText) as { githubClone?: { enabled?: unknown; maxRepoSizeMB?: unknown; cloneTimeoutSeconds?: unknown; clonePath?: unknown } };
+		raw = JSON.parse(rawText) as {
+			githubClone?: {
+				enabled?: unknown;
+				maxRepoSizeMB?: unknown;
+				cloneTimeoutSeconds?: unknown;
+				clonePath?: unknown;
+			};
+		};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
@@ -104,12 +192,35 @@ function loadGitHubConfig(): GitHubCloneConfig {
 }
 
 const NON_CODE_SEGMENTS = new Set([
-	"issues", "pull", "pulls", "discussions", "releases", "wiki",
-	"actions", "settings", "security", "projects", "graphs",
-	"compare", "commits", "tags", "branches", "stargazers",
-	"watchers", "network", "forks", "milestone", "labels",
-	"packages", "codespaces", "contribute", "community",
-	"sponsors", "invitations", "notifications", "insights",
+	"issues",
+	"pull",
+	"pulls",
+	"discussions",
+	"releases",
+	"wiki",
+	"actions",
+	"settings",
+	"security",
+	"projects",
+	"graphs",
+	"compare",
+	"commits",
+	"tags",
+	"branches",
+	"stargazers",
+	"watchers",
+	"network",
+	"forks",
+	"milestone",
+	"labels",
+	"packages",
+	"codespaces",
+	"contribute",
+	"community",
+	"sponsors",
+	"invitations",
+	"notifications",
+	"insights",
 ]);
 
 export function parseGitHubUrl(url: string): GitHubUrlInfo | null {
@@ -178,8 +289,7 @@ function execClone(args: string[], localPath: string, timeoutMs: number, signal?
 			if (err) {
 				try {
 					rmSync(localPath, { recursive: true, force: true });
-				} catch {
-				}
+				} catch {}
 				resolve(null);
 				return;
 			}
@@ -199,14 +309,13 @@ async function cloneRepo(
 	repo: string,
 	ref: string | undefined,
 	config: GitHubCloneConfig,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<string | null> {
 	const localPath = cloneDir(config, owner, repo, ref);
 
 	try {
 		rmSync(localPath, { recursive: true, force: true });
-	} catch {
-	}
+	} catch {}
 
 	const timeoutMs = config.cloneTimeoutSeconds * 1000;
 	const hasGh = await checkGhAvailable();
@@ -466,7 +575,9 @@ function generateContent(localPath: string, info: GitHubUrlInfo): string {
 		if (isBinaryFile(fullFilePath)) {
 			const ext = extname(filePath).replace(".", "");
 			lines.push(`## ${filePath}`);
-			lines.push(`Binary file (${ext}, ${formatFileSize(stat.size)}). Use \`read\` or \`bash\` tools at the path above to inspect.`);
+			lines.push(
+				`Binary file (${ext}, ${formatFileSize(stat.size)}). Use \`read\` or \`bash\` tools at the path above to inspect.`
+			);
 			return lines.join("\n");
 		}
 
@@ -501,7 +612,7 @@ async function awaitCachedClone(
 	owner: string,
 	repo: string,
 	info: GitHubUrlInfo,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	if (signal?.aborted) return null;
 	const result = await cached.clonePromise;
@@ -517,7 +628,7 @@ async function awaitCachedClone(
 export async function extractGitHub(
 	url: string,
 	signal?: AbortSignal,
-	forceClone?: boolean,
+	forceClone?: boolean
 ): Promise<ExtractedContent | null> {
 	const info = parseGitHubUrl(url);
 	if (!info) return null;
@@ -539,7 +650,10 @@ export async function extractGitHub(
 		return fetchViaApi(url, owner, repo, info, sizeNote);
 	}
 
-	const activityId = activityMonitor.logStart({ type: "fetch", url: `github.com/${owner}/${repo}` });
+	const activityId = activityMonitor.logStart({
+		type: "fetch",
+		url: `github.com/${owner}/${repo}`,
+	});
 
 	if (!forceClone) {
 		const sizeKB = await checkRepoSize(owner, repo);
@@ -626,8 +740,7 @@ export function clearCloneCache(): void {
 	for (const entry of cloneCache.values()) {
 		try {
 			rmSync(entry.localPath, { recursive: true, force: true });
-		} catch {
-		}
+		} catch {}
 	}
 	cloneCache.clear();
 	cachedConfig = null;

--- a/index.ts
+++ b/index.ts
@@ -166,10 +166,7 @@ async function loadCuratorBootstrap(requestedProvider: unknown): Promise<Curator
 	};
 }
 
-function resolveProvider(
-	requested: unknown,
-	available: ProviderAvailability,
-): ResolvedSearchProvider {
+function resolveProvider(requested: unknown, available: ProviderAvailability): ResolvedSearchProvider {
 	const provider = normalizeProviderInput(requested ?? loadConfig().provider ?? "auto") ?? "auto";
 
 	if (provider === "auto") {
@@ -216,7 +213,9 @@ interface PendingCurate {
 	summaryModels: Array<{ value: string; label: string }>;
 	defaultSummaryModel: string | null;
 	timeoutSeconds: number;
-	onUpdate: ((update: { content: Array<{ type: string; text: string }>; details?: Record<string, unknown> }) => void) | undefined;
+	onUpdate:
+		| ((update: { content: Array<{ type: string; text: string }>; details?: Record<string, unknown> }) => void)
+		| undefined;
 	signal: AbortSignal | undefined;
 	abortSearches: () => void;
 	finish: (value: unknown) => void;
@@ -261,8 +260,8 @@ function formatQueryHeader(query: string, provider: string | undefined, duplicat
 
 function hasFullInlineCoverage(urls: string[], inlineContent: ExtractedContent[] | undefined): boolean {
 	if (!inlineContent || inlineContent.length === 0) return false;
-	const coveredUrls = new Set(inlineContent.map(c => c.url));
-	return urls.every(url => coveredUrls.has(url));
+	const coveredUrls = new Set(inlineContent.map((c) => c.url));
+	return urls.every((url) => coveredUrls.has(url));
 }
 
 function formatFullResults(queryData: QueryResultData): string {
@@ -286,7 +285,9 @@ function abortPendingFetches(): void {
 function closeCurator(): void {
 	const win = glimpseWin;
 	glimpseWin = null;
-	try { win?.close(); } catch {}
+	try {
+		win?.close();
+	} catch {}
 	cancelPendingCurate();
 	if (activeCurator) {
 		activeCurator.close();
@@ -296,11 +297,12 @@ function closeCurator(): void {
 
 async function openInBrowser(pi: ExtensionAPI, url: string): Promise<void> {
 	const plat = platform();
-	const result = plat === "darwin"
-		? await pi.exec("open", [url])
-		: plat === "win32"
-			? await pi.exec("cmd", ["/c", "start", "", url])
-			: await pi.exec("xdg-open", [url]);
+	const result =
+		plat === "darwin"
+			? await pi.exec("open", [url])
+			: plat === "win32"
+				? await pi.exec("cmd", ["/c", "start", "", url])
+				: await pi.exec("xdg-open", [url]);
 	if (result.code !== 0) {
 		throw new Error(result.stderr || `Failed to open browser (exit code ${result.code})`);
 	}
@@ -349,7 +351,7 @@ async function getGlimpseOpen() {
 function openInGlimpse(
 	open: (html: string, opts: Record<string, unknown>) => GlimpseWindow,
 	url: string,
-	title: string,
+	title: string
 ): GlimpseWindow {
 	const shellHTML = `<!DOCTYPE html>
 <html>
@@ -383,8 +385,11 @@ function openInGlimpse(
 }
 
 function extractDomain(url: string): string {
-	try { return new URL(url).hostname; }
-	catch { return url; }
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return url;
+	}
 }
 
 function updateWidget(ctx: ExtensionContext): void {
@@ -405,20 +410,19 @@ function updateWidget(ctx: ExtensionContext): void {
 	lines.push(theme.fg("accent", "─".repeat(60)));
 
 	const rateInfo = activityMonitor.getRateLimitInfo();
-	const resetMs = rateInfo.oldestTimestamp ? Math.max(0, rateInfo.oldestTimestamp + rateInfo.windowMs - Date.now()) : 0;
+	const resetMs = rateInfo.oldestTimestamp
+		? Math.max(0, rateInfo.oldestTimestamp + rateInfo.windowMs - Date.now())
+		: 0;
 	const resetSec = Math.ceil(resetMs / 1000);
 	lines.push(
 		theme.fg("muted", `Rate: ${rateInfo.used}/${rateInfo.max}`) +
-			(resetMs > 0 ? theme.fg("dim", ` (resets in ${resetSec}s)`) : ""),
+			(resetMs > 0 ? theme.fg("dim", ` (resets in ${resetSec}s)`) : "")
 	);
 
 	ctx.ui.setWidget("web-activity", new Text(lines.join("\n"), 0, 0));
 }
 
-function formatEntryLine(
-	entry: ActivityEntry,
-	theme: { fg: (color: string, text: string) => string },
-): string {
+function formatEntryLine(entry: ActivityEntry, theme: { fg: (color: string, text: string) => string }): string {
 	const typeStr = entry.type === "api" ? "API" : "GET";
 	const target =
 		entry.type === "api"
@@ -486,20 +490,21 @@ export default function (pi: ExtensionAPI) {
 				};
 				storeResult(fetchId, data);
 				pi.appendEntry("web-search-results", data);
-				const ok = fetched.filter(f => !f.error).length;
+				const ok = fetched.filter((f) => !f.error).length;
 				pi.sendMessage(
 					{
 						customType: "web-search-content-ready",
 						content: `Content fetched for ${ok}/${fetched.length} URLs [${fetchId}]. Full page content now available.`,
 						display: true,
 					},
-					{ triggerTurn: true },
+					{ triggerTurn: true }
 				);
 			})
 			.catch((err) => {
 				if (!sessionActive || !pendingFetches.has(fetchId)) return;
 				const message = err instanceof Error ? err.message : String(err);
-				const isAbort = (err instanceof Error && err.name === "AbortError") || message.toLowerCase().includes("abort");
+				const isAbort =
+					(err instanceof Error && err.name === "AbortError") || message.toLowerCase().includes("abort");
 				if (!isAbort) {
 					pi.sendMessage(
 						{
@@ -507,18 +512,23 @@ export default function (pi: ExtensionAPI) {
 							content: `Content fetch failed [${fetchId}]: ${message}`,
 							display: true,
 						},
-						{ triggerTurn: false },
+						{ triggerTurn: false }
 					);
 				}
 			})
-			.finally(() => { pendingFetches.delete(fetchId); });
+			.finally(() => {
+				pendingFetches.delete(fetchId);
+			});
 		return fetchId;
 	}
 
 	function storeAndPublishSearch(results: QueryResultData[]): string {
 		const id = generateId();
 		const data: StoredSearchData = {
-			id, type: "search", timestamp: Date.now(), queries: results,
+			id,
+			type: "search",
+			timestamp: Date.now(),
+			queries: results,
 		};
 		storeResult(id, data);
 		pi.appendEntry("web-search-results", data);
@@ -553,9 +563,12 @@ export default function (pi: ExtensionAPI) {
 		return {
 			model: meta.model,
 			durationMs: Number.isFinite(meta.durationMs) && meta.durationMs >= 0 ? meta.durationMs : 0,
-			tokenEstimate: Number.isFinite(meta.tokenEstimate) && meta.tokenEstimate >= 0
-				? meta.tokenEstimate
-				: (normalizedText.length > 0 ? Math.max(1, Math.ceil(normalizedText.length / 4)) : 0),
+			tokenEstimate:
+				Number.isFinite(meta.tokenEstimate) && meta.tokenEstimate >= 0
+					? meta.tokenEstimate
+					: normalizedText.length > 0
+						? Math.max(1, Math.ceil(normalizedText.length / 4))
+						: 0,
 			fallbackUsed: meta.fallbackUsed === true,
 			fallbackReason: meta.fallbackReason,
 			edited: meta.edited === true,
@@ -576,7 +589,7 @@ export default function (pi: ExtensionAPI) {
 
 	async function resolveFirstAvailableModel(
 		ctx: SummaryGenerationContext,
-		candidates: Array<{ provider: string; id: string }>,
+		candidates: Array<{ provider: string; id: string }>
 	): Promise<{ model: Model; apiKey: string; headers?: Record<string, string> }> {
 		for (const { provider, id } of candidates) {
 			const model = getModel(provider, id);
@@ -584,10 +597,14 @@ export default function (pi: ExtensionAPI) {
 			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 			if (auth.ok && auth.apiKey) return { model, apiKey: auth.apiKey, headers: auth.headers };
 		}
-		throw new Error(`No model available: ${candidates.map(c => `${c.provider}/${c.id}`).join(", ")}`);
+		throw new Error(`No model available: ${candidates.map((c) => `${c.provider}/${c.id}`).join(", ")}`);
 	}
 
-	async function rewriteSearchQuery(query: string, ctx: SummaryGenerationContext, signal: AbortSignal): Promise<string> {
+	async function rewriteSearchQuery(
+		query: string,
+		ctx: SummaryGenerationContext,
+		signal: AbortSignal
+	): Promise<string> {
 		const { model, apiKey, headers } = await resolveFirstAvailableModel(ctx, [
 			{ provider: "anthropic", id: "claude-haiku-4-5" },
 			{ provider: "google", id: "gemini-2.5-flash" },
@@ -596,18 +613,25 @@ export default function (pi: ExtensionAPI) {
 		const response = await complete(
 			model,
 			{
-				messages: [{
-					role: "user",
-					content: [{ type: "text", text: `Rewrite this web search query to get better, more specific results. Add relevant year qualifiers, precise technical terms, and specificity. Return ONLY the improved query text, nothing else.\n\nQuery: ${query}` }],
-					timestamp: Date.now(),
-				}],
+				messages: [
+					{
+						role: "user",
+						content: [
+							{
+								type: "text",
+								text: `Rewrite this web search query to get better, more specific results. Add relevant year qualifiers, precise technical terms, and specificity. Return ONLY the improved query text, nothing else.\n\nQuery: ${query}`,
+							},
+						],
+						timestamp: Date.now(),
+					},
+				],
 			},
-			{ apiKey, headers, signal },
+			{ apiKey, headers, signal }
 		);
 		if (response.stopReason === "aborted") throw new Error("Aborted");
 		const contentParts = Array.isArray(response.content) ? response.content : [];
 		const text = contentParts
-			.map(p => {
+			.map((p) => {
 				if (!p || typeof p !== "object") return "";
 				const part = p as Record<string, unknown>;
 				return typeof part.text === "string" ? part.text : "";
@@ -624,7 +648,7 @@ export default function (pi: ExtensionAPI) {
 		summaryContext: SummaryGenerationContext,
 		signal?: AbortSignal,
 		modelOverride?: string,
-		feedback?: string,
+		feedback?: string
 	): Promise<{ summary: string; meta: SummaryMeta }> {
 		const selectedResults: QueryResultData[] = [];
 		for (const qi of selectedQueryIndices) {
@@ -637,7 +661,8 @@ export default function (pi: ExtensionAPI) {
 		try {
 			return await generateSummaryDraft(selectedResults, summaryContext, signal, modelOverride, feedback);
 		} catch (err) {
-			const isEmptyResponse = err instanceof Error && err.message.includes("Summary model returned empty response");
+			const isEmptyResponse =
+				err instanceof Error && err.message.includes("Summary model returned empty response");
 			if (!isEmptyResponse) throw err;
 			const deterministic = buildDeterministicSummary(selectedResults);
 			return {
@@ -650,9 +675,10 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
-	async function loadSummaryModelChoices(
-		summaryContext: SummaryGenerationContext,
-	): Promise<{ summaryModels: Array<{ value: string; label: string }>; defaultSummaryModel: string | null }> {
+	async function loadSummaryModelChoices(summaryContext: SummaryGenerationContext): Promise<{
+		summaryModels: Array<{ value: string; label: string }>;
+		defaultSummaryModel: string | null;
+	}> {
 		const summaryModels: Array<{ value: string; label: string }> = [];
 		const seen = new Set<string>();
 		const availableValues = new Set<string>();
@@ -685,10 +711,7 @@ export default function (pi: ExtensionAPI) {
 
 		const config = loadConfig();
 		const configuredSummaryModel = typeof config.summaryModel === "string" ? config.summaryModel.trim() : "";
-		const preferredDefaults = [
-			"anthropic/claude-haiku-4-5",
-			"openai-codex/gpt-5.3-codex-spark",
-		];
+		const preferredDefaults = ["anthropic/claude-haiku-4-5", "openai-codex/gpt-5.3-codex-spark"];
 
 		let defaultSummaryModel: string | null = null;
 		if (configuredSummaryModel.length > 0 && availableValues.has(configuredSummaryModel)) {
@@ -711,7 +734,7 @@ export default function (pi: ExtensionAPI) {
 
 	function resolveSummaryForSubmit(
 		payload: { selectedQueryIndices: number[]; summary?: string; summaryMeta?: SummaryMeta },
-		resultsByIndex: Map<number, QueryResultData>,
+		resultsByIndex: Map<number, QueryResultData>
 	): { approvedSummary: string; summaryMeta: SummaryMeta } {
 		const submittedSummary = typeof payload.summary === "string" ? payload.summary.trim() : "";
 		if (submittedSummary.length > 0) {
@@ -731,7 +754,7 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	function buildSearchReturn(opts: SearchReturnOptions) {
-		const sc = opts.results.filter(r => !r.error).length;
+		const sc = opts.results.filter((r) => !r.error).length;
 		const tr = opts.results.reduce((sum, r) => sum + r.results.length, 0);
 
 		const hasApprovedSummary = typeof opts.approvedSummary === "string" && opts.approvedSummary.trim().length > 0;
@@ -740,7 +763,8 @@ export default function (pi: ExtensionAPI) {
 			output = opts.approvedSummary!.trim();
 		} else {
 			if (opts.curated) {
-				output += "[These results were manually curated by the user in the browser. Use them as-is — do not re-search or discard.]\n\n";
+				output +=
+					"[These results were manually curated by the user in the browser. Use them as-is — do not re-search or discard.]\n\n";
 			}
 			const duplicateQueries = opts.curated ? duplicateQuerySet(opts.results) : new Set<string>();
 			for (const { query, answer, results, error, provider } of opts.results) {
@@ -791,30 +815,32 @@ export default function (pi: ExtensionAPI) {
 				fetchId,
 				fetchUrls: isBackgroundFetch ? opts.urls : undefined,
 				searchId,
-				...(opts.curated ? {
-					curated: true,
-					curatedFrom: opts.curatedFrom,
-					curatedQueries: opts.results.map(r => ({
-						query: r.query,
-						provider: r.provider || null,
-						answer: r.answer || null,
-						sources: r.results.map(s => ({ title: s.title, url: s.url })),
-						error: r.error,
-					})),
-				} : {}),
-				...((opts.workflow && hasApprovedSummary)
+				...(opts.curated
 					? {
-						summary: {
-							text: opts.approvedSummary!.trim(),
-							workflow: opts.workflow,
-							model: opts.summaryMeta?.model ?? null,
-							durationMs: opts.summaryMeta?.durationMs ?? 0,
-							tokenEstimate: opts.summaryMeta?.tokenEstimate ?? 0,
-							fallbackUsed: opts.summaryMeta?.fallbackUsed === true,
-							fallbackReason: opts.summaryMeta?.fallbackReason,
-							edited: opts.summaryMeta?.edited === true,
-						},
-					}
+							curated: true,
+							curatedFrom: opts.curatedFrom,
+							curatedQueries: opts.results.map((r) => ({
+								query: r.query,
+								provider: r.provider || null,
+								answer: r.answer || null,
+								sources: r.results.map((s) => ({ title: s.title, url: s.url })),
+								error: r.error,
+							})),
+						}
+					: {}),
+				...(opts.workflow && hasApprovedSummary
+					? {
+							summary: {
+								text: opts.approvedSummary!.trim(),
+								workflow: opts.workflow,
+								model: opts.summaryMeta?.model ?? null,
+								durationMs: opts.summaryMeta?.durationMs ?? 0,
+								tokenEstimate: opts.summaryMeta?.tokenEstimate ?? 0,
+								fallbackUsed: opts.summaryMeta?.fallbackUsed === true,
+								fallbackReason: opts.summaryMeta?.fallbackReason,
+								edited: opts.summaryMeta?.edited === true,
+							},
+						}
 					: {}),
 			},
 		};
@@ -852,9 +878,7 @@ export default function (pi: ExtensionAPI) {
 			pc.phase = "curating";
 
 			const searchAbort = new AbortController();
-			const addSearchSignal = pc.signal
-				? AbortSignal.any([pc.signal, searchAbort.signal])
-				: searchAbort.signal;
+			const addSearchSignal = pc.signal ? AbortSignal.any([pc.signal, searchAbort.signal]) : searchAbort.signal;
 
 			const sessionToken = randomUUID();
 			handle = await startCuratorServer(
@@ -880,11 +904,16 @@ export default function (pi: ExtensionAPI) {
 							pc.summaryContext,
 							summarizeSignal,
 							model,
-							feedback,
+							feedback
 						);
 						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
 						pc.onUpdate?.({
-							content: [{ type: "text", text: "Summary draft ready — waiting for approval..." }],
+							content: [
+								{
+									type: "text",
+									text: "Summary draft ready — waiting for approval...",
+								},
+							],
 							details: { phase: "waiting-for-approval", progress: 1 },
 						});
 						return draft;
@@ -892,12 +921,13 @@ export default function (pi: ExtensionAPI) {
 					onSubmit(payload) {
 						if (pendingCurate !== pc) return;
 						searchAbort.abort();
-						const filtered = payload.selectedQueryIndices.length > 0
-							? filterByQueryIndices(payload.selectedQueryIndices, pc.searchResults)
-							: collectAllResultsAndUrls(pc.searchResults);
-						const filteredInline = pc.allInlineContent.filter(c => filtered.urls.includes(c.url));
+						const filtered =
+							payload.selectedQueryIndices.length > 0
+								? filterByQueryIndices(payload.selectedQueryIndices, pc.searchResults)
+								: collectAllResultsAndUrls(pc.searchResults);
+						const filteredInline = pc.allInlineContent.filter((c) => filtered.urls.includes(c.url));
 						const base: SearchReturnOptions = {
-							queryList: filtered.results.map(r => r.query),
+							queryList: filtered.results.map((r) => r.query),
 							results: filtered.results,
 							urls: filtered.urls,
 							includeContent: pc.includeContent,
@@ -918,21 +948,30 @@ export default function (pi: ExtensionAPI) {
 						if (pendingCurate !== pc) return;
 						searchAbort.abort();
 						if (reason === "timeout") {
-							const resolvedSummary = resolveSummaryForSubmit({ selectedQueryIndices: [], summary: undefined, summaryMeta: undefined }, pc.searchResults);
+							const resolvedSummary = resolveSummaryForSubmit(
+								{
+									selectedQueryIndices: [],
+									summary: undefined,
+									summaryMeta: undefined,
+								},
+								pc.searchResults
+							);
 							const all = collectAllResultsAndUrls(pc.searchResults);
-							const filteredInline = pc.allInlineContent.filter(c => all.urls.includes(c.url));
-							pc.finish(buildSearchReturn({
-								queryList: all.results.map(r => r.query),
-								results: all.results,
-								urls: all.urls,
-								includeContent: pc.includeContent,
-								inlineContent: filteredInline.length > 0 ? filteredInline : undefined,
-								curated: true,
-								curatedFrom: pc.searchResults.size,
-								workflow: pc.workflow,
-								approvedSummary: resolvedSummary.approvedSummary,
-								summaryMeta: resolvedSummary.summaryMeta,
-							}));
+							const filteredInline = pc.allInlineContent.filter((c) => all.urls.includes(c.url));
+							pc.finish(
+								buildSearchReturn({
+									queryList: all.results.map((r) => r.query),
+									results: all.results,
+									urls: all.urls,
+									includeContent: pc.includeContent,
+									inlineContent: filteredInline.length > 0 ? filteredInline : undefined,
+									curated: true,
+									curatedFrom: pc.searchResults.size,
+									workflow: pc.workflow,
+									approvedSummary: resolvedSummary.approvedSummary,
+									summaryMeta: resolvedSummary.summaryMeta,
+								})
+							);
 						} else {
 							pc.finish(buildCurationCancelledReturn(reason));
 						}
@@ -953,11 +992,17 @@ export default function (pi: ExtensionAPI) {
 					async onAddSearch(query, queryIndex, provider) {
 						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
 						const normalizedProvider = normalizeProviderInput(provider);
-						const requestedProvider = !normalizedProvider || normalizedProvider === "auto"
-							? pc.defaultProvider
-							: normalizedProvider;
+						const requestedProvider =
+							!normalizedProvider || normalizedProvider === "auto"
+								? pc.defaultProvider
+								: normalizedProvider;
 						try {
-							const { answer, results, inlineContent, provider: actualProvider } = await search(query, {
+							const {
+								answer,
+								results,
+								inlineContent,
+								provider: actualProvider,
+							} = await search(query, {
 								provider: requestedProvider,
 								numResults: pc.numResults,
 								recencyFilter: pc.recencyFilter,
@@ -966,17 +1011,33 @@ export default function (pi: ExtensionAPI) {
 								signal: addSearchSignal,
 							});
 							if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
-							pc.searchResults.set(queryIndex, { query, answer, results, error: null, provider: actualProvider });
+							pc.searchResults.set(queryIndex, {
+								query,
+								answer,
+								results,
+								error: null,
+								provider: actualProvider,
+							});
 							if (inlineContent) pc.allInlineContent.push(...inlineContent);
 							return {
 								answer,
-								results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+								results: results.map((r) => ({
+									title: r.title,
+									url: r.url,
+									domain: extractDomain(r.url),
+								})),
 								provider: actualProvider,
 							};
 						} catch (err) {
 							const message = err instanceof Error ? err.message : String(err);
 							if (pendingCurate === pc) {
-								pc.searchResults.set(queryIndex, { query, answer: "", results: [], error: message, provider: requestedProvider });
+								pc.searchResults.set(queryIndex, {
+									query,
+									answer: "",
+									results: [],
+									error: message,
+									provider: requestedProvider,
+								});
 							}
 							throw err;
 						}
@@ -985,7 +1046,7 @@ export default function (pi: ExtensionAPI) {
 						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
 						return rewriteSearchQuery(query, pc.summaryContext, rewriteSignal);
 					},
-				},
+				}
 			);
 
 			if (pendingCurate !== pc) {
@@ -1001,7 +1062,11 @@ export default function (pi: ExtensionAPI) {
 				} else {
 					handle.pushResult(qi, {
 						answer: data.answer,
-						results: data.results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+						results: data.results.map((r) => ({
+							title: r.title,
+							url: r.url,
+							domain: extractDomain(r.url),
+						})),
 						provider: data.provider || pc.defaultProvider,
 					});
 				}
@@ -1009,7 +1074,14 @@ export default function (pi: ExtensionAPI) {
 			if (searchesComplete) handle.searchesDone();
 
 			pc.onUpdate?.({
-				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],
+				content: [
+					{
+						type: "text",
+						text: searchesComplete
+							? "Waiting for summary approval in browser..."
+							: "Searches streaming to browser...",
+					},
+				],
 				details: { phase: "curating", progress: searchesComplete ? 1 : 0.5 },
 			});
 
@@ -1088,33 +1160,51 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "web_search",
 		label: "Web Search",
-		description:
-			`Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).`,
+		description: `Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).`,
 		promptSnippet:
 			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
 		parameters: Type.Object({
-			query: Type.Optional(Type.String({ description: "Single search query. For research tasks, prefer 'queries' with multiple varied angles instead." })),
-			queries: Type.Optional(Type.Array(Type.String(), { description: "Multiple queries searched in sequence, each returning its own synthesized answer. Prefer this for research — vary phrasing, scope, and angle across 2-4 queries to maximize coverage. Good: ['React vs Vue performance benchmarks 2026', 'React vs Vue developer experience comparison', 'React ecosystem size vs Vue ecosystem']. Bad: ['React vs Vue', 'React vs Vue comparison', 'React vs Vue review'] (too similar, redundant results)." })),
+			query: Type.Optional(
+				Type.String({
+					description:
+						"Single search query. For research tasks, prefer 'queries' with multiple varied angles instead.",
+				})
+			),
+			queries: Type.Optional(
+				Type.Array(Type.String(), {
+					description:
+						"Multiple queries searched in sequence, each returning its own synthesized answer. Prefer this for research — vary phrasing, scope, and angle across 2-4 queries to maximize coverage. Good: ['React vs Vue performance benchmarks 2026', 'React vs Vue developer experience comparison', 'React ecosystem size vs Vue ecosystem']. Bad: ['React vs Vue', 'React vs Vue comparison', 'React vs Vue review'] (too similar, redundant results).",
+				})
+			),
 			numResults: Type.Optional(Type.Number({ description: "Results per query (default: 5, max: 20)" })),
 			includeContent: Type.Optional(Type.Boolean({ description: "Fetch full page content (async)" })),
 			recencyFilter: Type.Optional(
-				StringEnum(["day", "week", "month", "year"], { description: "Filter by recency" }),
+				StringEnum(["day", "week", "month", "year"], { description: "Filter by recency" })
 			),
-			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
+			domainFilter: Type.Optional(
+				Type.Array(Type.String(), {
+					description: "Limit to domains (prefix with - to exclude)",
+				})
+			),
 			provider: Type.Optional(
-				StringEnum(["auto", "perplexity", "gemini", "exa"], { description: "Search provider (default: auto)" }),
+				StringEnum(["auto", "perplexity", "gemini", "exa"], {
+					description: "Search provider (default: auto)",
+				})
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review"], {
-					description: "Search workflow mode: none = no curator, summary-review = open curator with auto summary draft (default)",
-				}),
+					description:
+						"Search workflow mode: none = no curator, summary-review = open curator with auto summary draft (default)",
+				})
 			),
 		}),
 
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
 			const rawQueryList: unknown[] = Array.isArray(params.queries)
 				? params.queries
-				: (params.query !== undefined ? [params.query] : []);
+				: params.query !== undefined
+					? [params.query]
+					: [];
 			const queryList = normalizeQueryList(rawQueryList);
 			const configWorkflow = loadConfigForExtensionInit().workflow;
 			const workflow = resolveWorkflow(params.workflow ?? configWorkflow, ctx?.hasUI !== false);
@@ -1122,14 +1212,24 @@ export default function (pi: ExtensionAPI) {
 
 			if (queryList.length === 0) {
 				return {
-					content: [{ type: "text", text: "Error: No query provided. Use 'query' or 'queries' parameter." }],
+					content: [
+						{
+							type: "text",
+							text: "Error: No query provided. Use 'query' or 'queries' parameter.",
+						},
+					],
 					details: { error: "No query provided" },
 				};
 			}
 
 			if (shouldCurate && !ctx) {
 				return {
-					content: [{ type: "text", text: "Error: Curation requires an active extension context." }],
+					content: [
+						{
+							type: "text",
+							text: "Error: Curation requires an active extension context.",
+						},
+					],
 					details: { error: "Missing extension context" },
 				};
 			}
@@ -1145,9 +1245,7 @@ export default function (pi: ExtensionAPI) {
 				const searchResults = new Map<number, QueryResultData>();
 				const allInlineContent: ExtractedContent[] = [];
 				const searchAbort = new AbortController();
-				const searchSignal = signal
-					? AbortSignal.any([signal, searchAbort.signal])
-					: searchAbort.signal;
+				const searchSignal = signal ? AbortSignal.any([signal, searchAbort.signal]) : searchAbort.signal;
 				let cancelled = false;
 
 				const bootstrap = await loadCuratorBootstrap(params.provider);
@@ -1212,8 +1310,17 @@ export default function (pi: ExtensionAPI) {
 				for (let qi = 0; qi < queryList.length; qi++) {
 					if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
 					onUpdate?.({
-						content: [{ type: "text", text: `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...` }],
-						details: { phase: "searching", progress: qi / queryList.length, currentQuery: queryList[qi] },
+						content: [
+							{
+								type: "text",
+								text: `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...`,
+							},
+						],
+						details: {
+							phase: "searching",
+							progress: qi / queryList.length,
+							currentQuery: queryList[qi],
+						},
 					});
 					const requestedProvider = pc.defaultProvider;
 					try {
@@ -1226,19 +1333,35 @@ export default function (pi: ExtensionAPI) {
 							signal: searchSignal,
 						});
 						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
-						searchResults.set(qi, { query: queryList[qi], answer, results, error: null, provider });
+						searchResults.set(qi, {
+							query: queryList[qi],
+							answer,
+							results,
+							error: null,
+							provider,
+						});
 						if (inlineContent) allInlineContent.push(...inlineContent);
 						if (activeCurator) {
 							activeCurator.pushResult(qi, {
 								answer,
-								results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+								results: results.map((r) => ({
+									title: r.title,
+									url: r.url,
+									domain: extractDomain(r.url),
+								})),
 								provider,
 							});
 						}
 					} catch (err) {
 						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
 						const message = err instanceof Error ? err.message : String(err);
-						searchResults.set(qi, { query: queryList[qi], answer: "", results: [], error: message, provider: requestedProvider });
+						searchResults.set(qi, {
+							query: queryList[qi],
+							answer: "",
+							results: [],
+							error: message,
+							provider: requestedProvider,
+						});
 						if (activeCurator) {
 							activeCurator.pushError(qi, message, requestedProvider);
 						}
@@ -1254,7 +1377,12 @@ export default function (pi: ExtensionAPI) {
 				if (activeCurator && !cancelled) {
 					activeCurator.searchesDone();
 					pc.onUpdate?.({
-						content: [{ type: "text", text: "All searches complete — waiting for summary approval in browser..." }],
+						content: [
+							{
+								type: "text",
+								text: "All searches complete — waiting for summary approval in browser...",
+							},
+						],
 						details: { phase: "curating", progress: 1 },
 					});
 				}
@@ -1271,8 +1399,17 @@ export default function (pi: ExtensionAPI) {
 				const query = queryList[i];
 
 				onUpdate?.({
-					content: [{ type: "text", text: `Searching ${i + 1}/${queryList.length}: "${query}"...` }],
-					details: { phase: "search", progress: i / queryList.length, currentQuery: query },
+					content: [
+						{
+							type: "text",
+							text: `Searching ${i + 1}/${queryList.length}: "${query}"...`,
+						},
+					],
+					details: {
+						phase: "search",
+						progress: i / queryList.length,
+						currentQuery: query,
+					},
 				});
 
 				try {
@@ -1294,10 +1431,17 @@ export default function (pi: ExtensionAPI) {
 					if (inlineContent) allInlineContent.push(...inlineContent);
 				} catch (err) {
 					const message = err instanceof Error ? err.message : String(err);
-					const requestedProvider = typeof resolvedProvider === "string" && resolvedProvider !== "auto"
-						? resolvedProvider
-						: undefined;
-					searchResults.push({ query, answer: "", results: [], error: message, provider: requestedProvider });
+					const requestedProvider =
+						typeof resolvedProvider === "string" && resolvedProvider !== "auto"
+							? resolvedProvider
+							: undefined;
+					searchResults.push({
+						query,
+						answer: "",
+						results: [],
+						error: message,
+						provider: requestedProvider,
+					});
 				}
 			}
 
@@ -1314,7 +1458,9 @@ export default function (pi: ExtensionAPI) {
 			const input = args as { query?: unknown; queries?: unknown };
 			const rawQueryList: unknown[] = Array.isArray(input.queries)
 				? input.queries
-				: (input.query !== undefined ? [input.query] : []);
+				: input.query !== undefined
+					? [input.query]
+					: [];
 			const queryList = normalizeQueryList(rawQueryList);
 			if (queryList.length === 0) {
 				return new Text(theme.fg("toolTitle", theme.bold("search ")) + theme.fg("error", "(no query)"), 0, 0);
@@ -1322,9 +1468,15 @@ export default function (pi: ExtensionAPI) {
 			if (queryList.length === 1) {
 				const q = queryList[0];
 				const display = q.length > 60 ? q.slice(0, 57) + "..." : q;
-				return new Text(theme.fg("toolTitle", theme.bold("search ")) + theme.fg("accent", `"${display}"`), 0, 0);
+				return new Text(
+					theme.fg("toolTitle", theme.bold("search ")) + theme.fg("accent", `"${display}"`),
+					0,
+					0
+				);
 			}
-			const lines = [theme.fg("toolTitle", theme.bold("search ")) + theme.fg("accent", `${queryList.length} queries`)];
+			const lines = [
+				theme.fg("toolTitle", theme.bold("search ")) + theme.fg("accent", `${queryList.length} queries`),
+			];
 			for (const q of queryList.slice(0, 5)) {
 				const display = q.length > 50 ? q.slice(0, 47) + "..." : q;
 				lines.push(theme.fg("muted", `  "${display}"`));
@@ -1376,13 +1528,15 @@ export default function (pi: ExtensionAPI) {
 				}
 				if (details?.phase === "searching") {
 					const progress = details?.progress ?? 0;
-					const bar = "\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
+					const bar =
+						"\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
 					const query = details?.currentQuery || "";
 					const display = query.length > 40 ? query.slice(0, 37) + "..." : query;
 					return new Text(theme.fg("accent", `[${bar}] ${display}`), 0, 0);
 				}
 				const progress = details?.progress ?? 0;
-				const bar = "\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
+				const bar =
+					"\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
 				return new Text(theme.fg("accent", `[${bar}] ${details?.phase || "searching"}`), 0, 0);
 			}
 
@@ -1391,7 +1545,8 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			let statusLine: string;
-			const queryInfo = details?.queryCount === 1 ? "" : `${details?.successfulQueries}/${details?.queryCount} queries, `;
+			const queryInfo =
+				details?.queryCount === 1 ? "" : `${details?.successfulQueries}/${details?.queryCount} queries, `;
 			statusLine = theme.fg("success", `${queryInfo}${details?.totalResults ?? 0} sources`);
 			if (details?.curated && details?.curatedFrom) {
 				statusLine += theme.fg("muted", ` (${details.queryCount}/${details.curatedFrom} queries curated)`);
@@ -1430,7 +1585,12 @@ export default function (pi: ExtensionAPI) {
 				const kept = queryDetails.length;
 				const from = details?.curatedFrom ?? kept;
 				lines.push("");
-				lines.push(theme.fg("accent", `\u2500\u2500 Curated Results (${kept} of ${from} queries kept) ` + "\u2500".repeat(24)));
+				lines.push(
+					theme.fg(
+						"accent",
+						`\u2500\u2500 Curated Results (${kept} of ${from} queries kept) ` + "\u2500".repeat(24)
+					)
+				);
 
 				for (const cq of queryDetails) {
 					lines.push("");
@@ -1496,17 +1656,21 @@ export default function (pi: ExtensionAPI) {
 					for (const cq of details.curatedQueries.slice(0, 3)) {
 						const dq = cq.query.length > 55 ? cq.query.slice(0, 52) + "..." : cq.query;
 						const srcCount = cq.sources?.length ?? 0;
-						const suffix = cq.error ? theme.fg("error", " (error)") : theme.fg("dim", ` · ${srcCount} sources`);
+						const suffix = cq.error
+							? theme.fg("error", " (error)")
+							: theme.fg("dim", ` · ${srcCount} sources`);
 						box.addChild(new Text(theme.fg("accent", `  "${dq}"`) + suffix, 0, 0));
 						collapsedLines++;
 					}
 					if (details.curatedQueries.length > 3) {
-						box.addChild(new Text(theme.fg("dim", `  ... and ${details.curatedQueries.length - 3} more`), 0, 0));
+						box.addChild(
+							new Text(theme.fg("dim", `  ... and ${details.curatedQueries.length - 3} more`), 0, 0)
+						);
 						collapsedLines++;
 					}
 				} else {
 					const textContent = result.content.find((c) => c.type === "text")?.text || "";
-					const firstContentLine = textContent.split("\n").find(l => {
+					const firstContentLine = textContent.split("\n").find((l) => {
 						const t = l.trim();
 						return t && !t.startsWith("[") && !t.startsWith("#") && !t.startsWith("---");
 					});
@@ -1519,7 +1683,13 @@ export default function (pi: ExtensionAPI) {
 				}
 				const moreLines = Math.max(0, totalLines - collapsedLines);
 				if (moreLines > 0) {
-					box.addChild(new Text(theme.fg("muted", `\n... (${moreLines} more lines, ${totalLines} total, ctrl+o to expand)`), 0, 0));
+					box.addChild(
+						new Text(
+							theme.fg("muted", `\n... (${moreLines} more lines, ${totalLines} total, ctrl+o to expand)`),
+							0,
+							0
+						)
+					);
 				}
 				return box;
 			}
@@ -1531,16 +1701,21 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "code_search",
 		label: "Code Search",
-		description: "Search for code examples, documentation, and API references. Returns relevant code snippets and docs from GitHub, Stack Overflow, and official documentation. Use for any programming question — API usage, library examples, debugging help.",
+		description:
+			"Search for code examples, documentation, and API references. Returns relevant code snippets and docs from GitHub, Stack Overflow, and official documentation. Use for any programming question — API usage, library examples, debugging help.",
 		promptSnippet:
 			"Use for programming/API/library questions to retrieve concrete examples and docs before implementing or debugging code.",
 		parameters: Type.Object({
-			query: Type.String({ description: "Programming question, API, library, or debugging topic to search for" }),
-			maxTokens: Type.Optional(Type.Integer({
-				minimum: 1000,
-				maximum: 50000,
-				description: "Maximum tokens of code/documentation context to return (default: 5000)",
-			})),
+			query: Type.String({
+				description: "Programming question, API, library, or debugging topic to search for",
+			}),
+			maxTokens: Type.Optional(
+				Type.Integer({
+					minimum: 1000,
+					maximum: 50000,
+					description: "Maximum tokens of code/documentation context to return (default: 5000)",
+				})
+			),
 		}),
 
 		async execute(toolCallId, params, signal) {
@@ -1549,19 +1724,22 @@ export default function (pi: ExtensionAPI) {
 
 		renderCall(args, theme) {
 			const { query } = args as { query?: string };
-			const display = !query
-				? "(no query)"
-				: query.length > 70 ? query.slice(0, 67) + "..." : query;
+			const display = !query ? "(no query)" : query.length > 70 ? query.slice(0, 67) + "..." : query;
 			return new Text(theme.fg("toolTitle", theme.bold("code_search ")) + theme.fg("accent", display), 0, 0);
 		},
 
 		renderResult(result, { expanded }, theme) {
-			const details = result.details as { query?: string; maxTokens?: number; error?: string };
+			const details = result.details as {
+				query?: string;
+				maxTokens?: number;
+				error?: string;
+			};
 			if (details?.error) {
 				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
 			}
 
-			const summary = theme.fg("success", "code context returned") +
+			const summary =
+				theme.fg("success", "code context returned") +
 				theme.fg("muted", ` (${details?.maxTokens ?? 5000} tokens max)`);
 			if (!expanded) return new Text(summary, 0, 0);
 
@@ -1574,29 +1752,44 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "fetch_content",
 		label: "Fetch Content",
-		description: "Fetch URL(s) and extract readable content as markdown. Supports YouTube video transcripts (with thumbnail), GitHub repository contents, and local video files (with frame thumbnail). Video frames can be extracted via timestamp/range or sampled across the entire video with frames alone. Falls back to Gemini for pages that block bots or fail Readability extraction. For YouTube and video files: ALWAYS pass the user's specific question via the prompt parameter — this directs the AI to focus on that aspect of the video, producing much better results than a generic extraction. Content is always stored and can be retrieved with get_search_content.",
+		description:
+			"Fetch URL(s) and extract readable content as markdown. Supports YouTube video transcripts (with thumbnail), GitHub repository contents, and local video files (with frame thumbnail). Video frames can be extracted via timestamp/range or sampled across the entire video with frames alone. Falls back to Gemini for pages that block bots or fail Readability extraction. For YouTube and video files: ALWAYS pass the user's specific question via the prompt parameter — this directs the AI to focus on that aspect of the video, producing much better results than a generic extraction. Content is always stored and can be retrieved with get_search_content.",
 		promptSnippet:
 			"Use to extract readable content from URL(s), YouTube, GitHub repos, or local videos. For video questions, pass the user's exact question in prompt.",
 		parameters: Type.Object({
 			url: Type.Optional(Type.String({ description: "Single URL to fetch" })),
 			urls: Type.Optional(Type.Array(Type.String(), { description: "Multiple URLs (parallel)" })),
-			forceClone: Type.Optional(Type.Boolean({
-				description: "Force cloning large GitHub repositories that exceed the size threshold",
-			})),
-			prompt: Type.Optional(Type.String({
-				description: "Question or instruction for video analysis (YouTube and video files). Pass the user's specific question here — e.g. 'describe the book shown at the advice for beginners section'. Without this, a generic transcript extraction is used which may miss what the user is asking about.",
-			})),
-			timestamp: Type.Optional(Type.String({
-				description: "Extract video frame(s) at a timestamp or time range. Single: '1:23:45', '23:45', or '85' (seconds). Range: '23:41-25:00' extracts evenly-spaced frames across that span (default 6). Use frames with ranges to control density; single+frames uses a fixed 5s interval. YouTube requires yt-dlp + ffmpeg; local videos require ffmpeg. Use a range when you know the approximate area but not the exact moment — you'll get a contact sheet to visually identify the right frame.",
-			})),
-			frames: Type.Optional(Type.Integer({
-				minimum: 1,
-				maximum: 12,
-				description: "Number of frames to extract. Use with timestamp range for custom density, with single timestamp to get N frames at 5s intervals, or alone to sample across the entire video. Requires yt-dlp + ffmpeg for YouTube, ffmpeg for local video.",
-			})),
-			model: Type.Optional(Type.String({
-				description: "Override the Gemini model for video/YouTube analysis (e.g. 'gemini-2.5-flash', 'gemini-3-flash-preview'). Defaults to config or gemini-3-flash-preview.",
-			})),
+			forceClone: Type.Optional(
+				Type.Boolean({
+					description: "Force cloning large GitHub repositories that exceed the size threshold",
+				})
+			),
+			prompt: Type.Optional(
+				Type.String({
+					description:
+						"Question or instruction for video analysis (YouTube and video files). Pass the user's specific question here — e.g. 'describe the book shown at the advice for beginners section'. Without this, a generic transcript extraction is used which may miss what the user is asking about.",
+				})
+			),
+			timestamp: Type.Optional(
+				Type.String({
+					description:
+						"Extract video frame(s) at a timestamp or time range. Single: '1:23:45', '23:45', or '85' (seconds). Range: '23:41-25:00' extracts evenly-spaced frames across that span (default 6). Use frames with ranges to control density; single+frames uses a fixed 5s interval. YouTube requires yt-dlp + ffmpeg; local videos require ffmpeg. Use a range when you know the approximate area but not the exact moment — you'll get a contact sheet to visually identify the right frame.",
+				})
+			),
+			frames: Type.Optional(
+				Type.Integer({
+					minimum: 1,
+					maximum: 12,
+					description:
+						"Number of frames to extract. Use with timestamp range for custom density, with single timestamp to get N frames at 5s intervals, or alone to sample across the entire video. Requires yt-dlp + ffmpeg for YouTube, ffmpeg for local video.",
+				})
+			),
+			model: Type.Optional(
+				Type.String({
+					description:
+						"Override the Gemini model for video/YouTube analysis (e.g. 'gemini-2.5-flash', 'gemini-3-flash-preview'). Defaults to config or gemini-3-flash-preview.",
+				})
+			),
 		}),
 
 		async execute(_toolCallId, params, signal, onUpdate) {
@@ -1640,7 +1833,16 @@ export default function (pi: ExtensionAPI) {
 				if (result.error) {
 					return {
 						content: [{ type: "text", text: `Error: ${result.error}` }],
-						details: { urls: urlList, urlCount: 1, successful: 0, error: result.error, responseId, prompt: params.prompt, timestamp: params.timestamp, frames: params.frames },
+						details: {
+							urls: urlList,
+							urlCount: 1,
+							successful: 0,
+							error: result.error,
+							responseId,
+							prompt: params.prompt,
+							timestamp: params.timestamp,
+							frames: params.frames,
+						},
 					};
 				}
 
@@ -1651,18 +1853,28 @@ export default function (pi: ExtensionAPI) {
 					: result.content;
 
 				if (truncated) {
-					output += `\n\n---\nShowing ${MAX_INLINE_CONTENT} of ${fullLength} chars. ` +
+					output +=
+						`\n\n---\nShowing ${MAX_INLINE_CONTENT} of ${fullLength} chars. ` +
 						`Use get_search_content({ responseId: "${responseId}", urlIndex: 0 }) for full content.`;
 				}
 
-				const content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> = [];
+				const content: Array<{
+					type: string;
+					text?: string;
+					data?: string;
+					mimeType?: string;
+				}> = [];
 				if (result.frames?.length) {
 					for (const frame of result.frames) {
 						content.push({ type: "image", data: frame.data, mimeType: frame.mimeType });
 						content.push({ type: "text", text: `Frame at ${frame.timestamp}` });
 					}
 				} else if (result.thumbnail) {
-					content.push({ type: "image", data: result.thumbnail.data, mimeType: result.thumbnail.mimeType });
+					content.push({
+						type: "image",
+						data: result.thumbnail.data,
+						mimeType: result.thumbnail.mimeType,
+					});
 				}
 				content.push({ type: "text", text: output });
 
@@ -1700,12 +1912,25 @@ export default function (pi: ExtensionAPI) {
 
 			return {
 				content: [{ type: "text", text: output }],
-				details: { urls: urlList, urlCount: urlList.length, successful, totalChars, responseId },
+				details: {
+					urls: urlList,
+					urlCount: urlList.length,
+					successful,
+					totalChars,
+					responseId,
+				},
 			};
 		},
 
 		renderCall(args, theme) {
-			const { url, urls, prompt, timestamp, frames, model } = args as { url?: string; urls?: string[]; prompt?: string; timestamp?: string; frames?: number; model?: string };
+			const { url, urls, prompt, timestamp, frames, model } = args as {
+				url?: string;
+				urls?: string[];
+				prompt?: string;
+				timestamp?: string;
+				frames?: number;
+				model?: string;
+			};
 			const urlList = urls ?? (url ? [url] : []);
 			if (urlList.length === 0) {
 				return new Text(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("error", "(no URL)"), 0, 0);
@@ -1761,7 +1986,8 @@ export default function (pi: ExtensionAPI) {
 
 			if (isPartial) {
 				const progress = details?.progress ?? 0;
-				const bar = "\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
+				const bar =
+					"\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
 				return new Text(theme.fg("accent", `[${bar}] ${details?.phase || "fetching"}`), 0, 0);
 			}
 
@@ -1772,12 +1998,14 @@ export default function (pi: ExtensionAPI) {
 			if (details?.urlCount === 1) {
 				const title = details?.title || "Untitled";
 				const imgCount = details?.imageCount ?? (details?.hasImage ? 1 : 0);
-				const imageBadge = imgCount > 1
-					? theme.fg("accent", ` [${imgCount} images]`)
-					: imgCount === 1
-						? theme.fg("accent", " [image]")
-						: "";
-				let statusLine = theme.fg("success", title) + theme.fg("muted", ` (${details?.totalChars ?? 0} chars)`) + imageBadge;
+				const imageBadge =
+					imgCount > 1
+						? theme.fg("accent", ` [${imgCount} images]`)
+						: imgCount === 1
+							? theme.fg("accent", " [image]")
+							: "";
+				let statusLine =
+					theme.fg("success", title) + theme.fg("muted", ` (${details?.totalChars ?? 0} chars)`) + imageBadge;
 				if (details?.truncated) {
 					statusLine += theme.fg("warning", " [truncated]");
 				}
@@ -1806,7 +2034,9 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			const countColor = (details?.successful ?? 0) > 0 ? "success" : "error";
-			const statusLine = theme.fg(countColor, `${details?.successful}/${details?.urlCount} URLs`) + theme.fg("muted", " (content stored)");
+			const statusLine =
+				theme.fg(countColor, `${details?.successful}/${details?.urlCount} URLs`) +
+				theme.fg("muted", " (content stored)");
 			if (!expanded) {
 				return new Text(statusLine, 0, 0);
 			}
@@ -1823,7 +2053,9 @@ export default function (pi: ExtensionAPI) {
 		promptSnippet:
 			"Use after web_search/fetch_content when full stored content is needed via responseId plus query/url selectors.",
 		parameters: Type.Object({
-			responseId: Type.String({ description: "The responseId from web_search or fetch_content" }),
+			responseId: Type.String({
+				description: "The responseId from web_search or fetch_content",
+			}),
 			query: Type.Optional(Type.String({ description: "Get content for this query (web_search)" })),
 			queryIndex: Type.Optional(Type.Number({ description: "Get content for query at index" })),
 			url: Type.Optional(Type.String({ description: "Get content for this URL" })),
@@ -1834,7 +2066,12 @@ export default function (pi: ExtensionAPI) {
 			const data = getResult(params.responseId);
 			if (!data) {
 				return {
-					content: [{ type: "text", text: `Error: No stored results for "${params.responseId}"` }],
+					content: [
+						{
+							type: "text",
+							text: `Error: No stored results for "${params.responseId}"`,
+						},
+					],
 					details: { error: "Not found", responseId: params.responseId },
 				};
 			}
@@ -1847,7 +2084,12 @@ export default function (pi: ExtensionAPI) {
 					if (!queryData) {
 						const available = data.queries.map((q) => `"${q.query}"`).join(", ");
 						return {
-							content: [{ type: "text", text: `Query "${params.query}" not found. Available: ${available}` }],
+							content: [
+								{
+									type: "text",
+									text: `Query "${params.query}" not found. Available: ${available}`,
+								},
+							],
 							details: { error: "Query not found" },
 						};
 					}
@@ -1855,21 +2097,36 @@ export default function (pi: ExtensionAPI) {
 					queryData = data.queries[params.queryIndex];
 					if (!queryData) {
 						return {
-							content: [{ type: "text", text: `Index ${params.queryIndex} out of range (0-${data.queries.length - 1})` }],
+							content: [
+								{
+									type: "text",
+									text: `Index ${params.queryIndex} out of range (0-${data.queries.length - 1})`,
+								},
+							],
 							details: { error: "Index out of range" },
 						};
 					}
 				} else {
 					const available = data.queries.map((q, i) => `${i}: "${q.query}"`).join(", ");
 					return {
-						content: [{ type: "text", text: `Specify query or queryIndex. Available: ${available}` }],
+						content: [
+							{
+								type: "text",
+								text: `Specify query or queryIndex. Available: ${available}`,
+							},
+						],
 						details: { error: "No query specified" },
 					};
 				}
 
 				if (queryData.error) {
 					return {
-						content: [{ type: "text", text: `Error for "${queryData.query}": ${queryData.error}` }],
+						content: [
+							{
+								type: "text",
+								text: `Error for "${queryData.query}": ${queryData.error}`,
+							},
+						],
 						details: { error: queryData.error, query: queryData.query },
 					};
 				}
@@ -1896,14 +2153,24 @@ export default function (pi: ExtensionAPI) {
 					urlData = data.urls[params.urlIndex];
 					if (!urlData) {
 						return {
-							content: [{ type: "text", text: `Index ${params.urlIndex} out of range (0-${data.urls.length - 1})` }],
+							content: [
+								{
+									type: "text",
+									text: `Index ${params.urlIndex} out of range (0-${data.urls.length - 1})`,
+								},
+							],
 							details: { error: "Index out of range" },
 						};
 					}
 				} else {
 					const available = data.urls.map((u, i) => `${i}: ${u.url}`).join("\n  ");
 					return {
-						content: [{ type: "text", text: `Specify url or urlIndex. Available:\n  ${available}` }],
+						content: [
+							{
+								type: "text",
+								text: `Specify url or urlIndex. Available:\n  ${available}`,
+							},
+						],
 						details: { error: "No URL specified" },
 					};
 				}
@@ -1917,7 +2184,11 @@ export default function (pi: ExtensionAPI) {
 
 				return {
 					content: [{ type: "text", text: `# ${urlData.title}\n\n${urlData.content}` }],
-					details: { url: urlData.url, title: urlData.title, contentLength: urlData.content.length },
+					details: {
+						url: urlData.url,
+						title: urlData.title,
+						contentLength: urlData.content.length,
+					},
 				};
 			}
 
@@ -1940,7 +2211,12 @@ export default function (pi: ExtensionAPI) {
 			else if (queryIndex !== undefined) target = `queryIndex=${queryIndex}`;
 			else if (url) target = url.length > 30 ? url.slice(0, 27) + "..." : url;
 			else if (urlIndex !== undefined) target = `urlIndex=${urlIndex}`;
-			return new Text(theme.fg("toolTitle", theme.bold("get_content ")) + theme.fg("accent", target || responseId.slice(0, 8)), 0, 0);
+			return new Text(
+				theme.fg("toolTitle", theme.bold("get_content ")) +
+					theme.fg("accent", target || responseId.slice(0, 8)),
+				0,
+				0
+			);
 		},
 
 		renderResult(result, { expanded }, theme) {
@@ -1959,9 +2235,12 @@ export default function (pi: ExtensionAPI) {
 
 			let statusLine: string;
 			if (details?.query) {
-				statusLine = theme.fg("success", `"${details.query}"`) + theme.fg("muted", ` (${details.resultCount} results)`);
+				statusLine =
+					theme.fg("success", `"${details.query}"`) + theme.fg("muted", ` (${details.resultCount} results)`);
 			} else {
-				statusLine = theme.fg("success", details?.title || "Content") + theme.fg("muted", ` (${details?.contentLength ?? 0} chars)`);
+				statusLine =
+					theme.fg("success", details?.title || "Content") +
+					theme.fg("muted", ` (${details?.contentLength ?? 0} chars)`);
 			}
 
 			if (!expanded) {
@@ -1981,9 +2260,7 @@ export default function (pi: ExtensionAPI) {
 			const sessionToken = randomUUID();
 
 			const raw = args.trim();
-			const queries = raw.length > 0
-				? normalizeQueryList(raw.split(","))
-				: [];
+			const queries = raw.length > 0 ? normalizeQueryList(raw.split(",")) : [];
 
 			let bootstrap: CuratorBootstrap;
 			try {
@@ -2011,12 +2288,15 @@ export default function (pi: ExtensionAPI) {
 			let commandHandle: CuratorServerHandle | null = null;
 
 			function sendFollowUpFromReturn(payload: ReturnType<typeof buildSearchReturn>) {
-				pi.sendMessage({
-					customType: "web-search-results",
-					content: payload.content,
-					display: "tool",
-					details: payload.details,
-				}, { triggerTurn: true, deliverAs: "followUp" });
+				pi.sendMessage(
+					{
+						customType: "web-search-results",
+						content: payload.content,
+						display: "tool",
+						details: payload.details,
+					},
+					{ triggerTurn: true, deliverAs: "followUp" }
+				);
 			}
 
 			try {
@@ -2041,18 +2321,19 @@ export default function (pi: ExtensionAPI) {
 								summaryContext,
 								summarizeSignal,
 								model,
-								feedback,
+								feedback
 							);
 						},
 						onSubmit(payload) {
 							if (commandHandle && activeCurator !== commandHandle) return;
 							aborted = true;
 							searchAbort.abort();
-							const filtered = payload.selectedQueryIndices.length > 0
-								? filterByQueryIndices(payload.selectedQueryIndices, collected)
-								: collectAllResultsAndUrls(collected);
+							const filtered =
+								payload.selectedQueryIndices.length > 0
+									? filterByQueryIndices(payload.selectedQueryIndices, collected)
+									: collectAllResultsAndUrls(collected);
 							const base: SearchReturnOptions = {
-								queryList: filtered.results.map(r => r.query),
+								queryList: filtered.results.map((r) => r.query),
 								results: filtered.results,
 								urls: filtered.urls,
 								includeContent: false,
@@ -2074,18 +2355,27 @@ export default function (pi: ExtensionAPI) {
 							searchAbort.abort();
 							if (reason === "timeout") {
 								const all = collectAllResultsAndUrls(collected);
-								const resolvedSummary = resolveSummaryForSubmit({ selectedQueryIndices: [], summary: undefined, summaryMeta: undefined }, collected);
-								sendFollowUpFromReturn(buildSearchReturn({
-									queryList: all.results.map(r => r.query),
-									results: all.results,
-									urls: all.urls,
-									includeContent: false,
-									curated: true,
-									curatedFrom: collected.size,
-									workflow: "summary-review",
-									approvedSummary: resolvedSummary.approvedSummary,
-									summaryMeta: resolvedSummary.summaryMeta,
-								}));
+								const resolvedSummary = resolveSummaryForSubmit(
+									{
+										selectedQueryIndices: [],
+										summary: undefined,
+										summaryMeta: undefined,
+									},
+									collected
+								);
+								sendFollowUpFromReturn(
+									buildSearchReturn({
+										queryList: all.results.map((r) => r.query),
+										results: all.results,
+										urls: all.urls,
+										includeContent: false,
+										curated: true,
+										curatedFrom: collected.size,
+										workflow: "summary-review",
+										approvedSummary: resolvedSummary.approvedSummary,
+										summaryMeta: resolvedSummary.summaryMeta,
+									})
+								);
 							}
 							closeCurator();
 						},
@@ -2106,27 +2396,48 @@ export default function (pi: ExtensionAPI) {
 								throw new Error("Curator session is no longer active.");
 							}
 							const normalizedProvider = normalizeProviderInput(provider);
-							const requestedProvider = !normalizedProvider || normalizedProvider === "auto"
-								? currentProvider
-								: normalizedProvider;
+							const requestedProvider =
+								!normalizedProvider || normalizedProvider === "auto"
+									? currentProvider
+									: normalizedProvider;
 							try {
-								const { answer, results, provider: actualProvider } = await search(query, {
+								const {
+									answer,
+									results,
+									provider: actualProvider,
+								} = await search(query, {
 									provider: requestedProvider,
 									signal: searchAbort.signal,
 								});
 								if (commandHandle && activeCurator !== commandHandle) {
 									throw new Error("Curator session is no longer active.");
 								}
-								collected.set(queryIndex, { query, answer, results, error: null, provider: actualProvider });
+								collected.set(queryIndex, {
+									query,
+									answer,
+									results,
+									error: null,
+									provider: actualProvider,
+								});
 								return {
 									answer,
-									results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+									results: results.map((r) => ({
+										title: r.title,
+										url: r.url,
+										domain: extractDomain(r.url),
+									})),
 									provider: actualProvider,
 								};
 							} catch (err) {
 								const message = err instanceof Error ? err.message : String(err);
 								if (!commandHandle || activeCurator === commandHandle) {
-									collected.set(queryIndex, { query, answer: "", results: [], error: message, provider: requestedProvider });
+									collected.set(queryIndex, {
+										query,
+										answer: "",
+										results: [],
+										error: message,
+										provider: requestedProvider,
+									});
 								}
 								throw err;
 							}
@@ -2137,7 +2448,7 @@ export default function (pi: ExtensionAPI) {
 							}
 							return rewriteSearchQuery(query, summaryContext, rewriteSignal);
 						},
-					},
+					}
 				);
 
 				commandHandle = handle;
@@ -2176,15 +2487,31 @@ export default function (pi: ExtensionAPI) {
 								if (aborted || activeCurator !== handle) break;
 								handle.pushResult(qi, {
 									answer,
-									results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+									results: results.map((r) => ({
+										title: r.title,
+										url: r.url,
+										domain: extractDomain(r.url),
+									})),
 									provider,
 								});
-								collected.set(qi, { query: queries[qi], answer, results, error: null, provider });
+								collected.set(qi, {
+									query: queries[qi],
+									answer,
+									results,
+									error: null,
+									provider,
+								});
 							} catch (err) {
 								if (aborted || activeCurator !== handle) break;
 								const message = err instanceof Error ? err.message : String(err);
 								handle.pushError(qi, message, requestedProvider);
-								collected.set(qi, { query: queries[qi], answer: "", results: [], error: message, provider: requestedProvider });
+								collected.set(qi, {
+									query: queries[qi],
+									answer: "",
+									results: [],
+									error: message,
+									provider: requestedProvider,
+								});
 							}
 						}
 						if (!aborted && activeCurator === handle) handle.searchesDone();
@@ -2228,15 +2555,19 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
-			const label = newWorkflow === "none"
-				? "Curator disabled — web_search will return raw results"
-				: "Curator enabled — web_search will open curator and auto-generate a summary draft";
-			pi.sendMessage({
-				customType: "curator-config",
-				content: [{ type: "text", text: label }],
-				display: "tool",
-				details: { workflow: newWorkflow },
-			}, { triggerTurn: false, deliverAs: "followUp" });
+			const label =
+				newWorkflow === "none"
+					? "Curator disabled — web_search will return raw results"
+					: "Curator enabled — web_search will open curator and auto-generate a summary draft";
+			pi.sendMessage(
+				{
+					customType: "curator-config",
+					content: [{ type: "text", text: label }],
+					display: "tool",
+					details: { workflow: newWorkflow },
+				},
+				{ triggerTurn: false, deliverAs: "followUp" }
+			);
 		},
 	});
 
@@ -2244,23 +2575,39 @@ export default function (pi: ExtensionAPI) {
 		description: "Show the active Google account for Gemini Web",
 		handler: async () => {
 			if (!isBrowserCookieAccessAllowed()) {
-				pi.sendMessage({
-					customType: "google-account",
-					content: [{ type: "text", text: "Gemini Web browser cookie access is disabled. Set allowBrowserCookies: true in ~/.pi/web-search.json to enable it." }],
-					display: "tool",
-					details: { available: false, cookieAccessAllowed: false },
-				}, { triggerTurn: true, deliverAs: "followUp" });
+				pi.sendMessage(
+					{
+						customType: "google-account",
+						content: [
+							{
+								type: "text",
+								text: "Gemini Web browser cookie access is disabled. Set allowBrowserCookies: true in ~/.pi/web-search.json to enable it.",
+							},
+						],
+						display: "tool",
+						details: { available: false, cookieAccessAllowed: false },
+					},
+					{ triggerTurn: true, deliverAs: "followUp" }
+				);
 				return;
 			}
 
 			const cookies = await isGeminiWebAvailable();
 			if (!cookies) {
-				pi.sendMessage({
-					customType: "google-account",
-					content: [{ type: "text", text: "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser." }],
-					display: "tool",
-					details: { available: false, cookieAccessAllowed: true },
-				}, { triggerTurn: true, deliverAs: "followUp" });
+				pi.sendMessage(
+					{
+						customType: "google-account",
+						content: [
+							{
+								type: "text",
+								text: "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser.",
+							},
+						],
+						display: "tool",
+						details: { available: false, cookieAccessAllowed: true },
+					},
+					{ triggerTurn: true, deliverAs: "followUp" }
+				);
 				return;
 			}
 
@@ -2269,12 +2616,15 @@ export default function (pi: ExtensionAPI) {
 				? `Active Google account: ${email}`
 				: "Gemini Web is available, but the active Google account could not be determined.";
 
-			pi.sendMessage({
-				customType: "google-account",
-				content: [{ type: "text", text }],
-				display: "tool",
-				details: { available: true, email: email ?? null },
-			}, { triggerTurn: true, deliverAs: "followUp" });
+			pi.sendMessage(
+				{
+					customType: "google-account",
+					content: [{ type: "text", text }],
+					display: "tool",
+					details: { available: true, email: email ?? null },
+				},
+				{ triggerTurn: true, deliverAs: "followUp" }
+			);
 		},
 	});
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,248 +1,267 @@
 {
-  "name": "pi-web-access",
-  "version": "0.10.7",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "pi-web-access",
-      "version": "0.10.7",
-      "license": "MIT",
-      "dependencies": {
-        "@mozilla/readability": "^0.5.0",
-        "linkedom": "^0.16.0",
-        "p-limit": "^6.1.0",
-        "turndown": "^7.2.0",
-        "unpdf": "^1.6.2"
-      }
-    },
-    "node_modules/@mixmark-io/domino": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
-      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@mozilla/readability": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.5.0.tgz",
-      "integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
-    },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "license": "MIT"
-    },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/html-escaper": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
-      "license": "MIT"
-    },
-    "node_modules/htmlparser2": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.1.0",
-        "entities": "^4.5.0"
-      }
-    },
-    "node_modules/linkedom": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.11.tgz",
-      "integrity": "sha512-WgaTVbj7itjyXTsCvgerpneERXShcnNJF5VIV+/4SLtyRLN+HppPre/WDHRofAr2IpEuujSNgJbCBd5lMl6lRw==",
-      "license": "ISC",
-      "dependencies": {
-        "css-select": "^5.1.0",
-        "cssom": "^0.5.0",
-        "html-escaper": "^3.0.3",
-        "htmlparser2": "^9.1.0",
-        "uhyphen": "^0.2.0"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
-      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/turndown": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
-      "integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mixmark-io/domino": "^2.2.0"
-      }
-    },
-    "node_modules/uhyphen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
-      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
-      "license": "ISC"
-    },
-    "node_modules/unpdf": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
-      "integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@napi-rs/canvas": "^0.1.69"
-      },
-      "peerDependenciesMeta": {
-        "@napi-rs/canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    }
-  }
+	"name": "pi-web-access",
+	"version": "0.10.7",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "pi-web-access",
+			"version": "0.10.7",
+			"license": "MIT",
+			"dependencies": {
+				"@mozilla/readability": "^0.5.0",
+				"linkedom": "^0.16.0",
+				"p-limit": "^6.1.0",
+				"turndown": "^7.2.0",
+				"unpdf": "^1.6.2"
+			},
+			"devDependencies": {
+				"prettier": "^3.8.3"
+			}
+		},
+		"node_modules/@mixmark-io/domino": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/@mozilla/readability": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.5.0.tgz",
+			"integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"license": "ISC"
+		},
+		"node_modules/css-select": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cssom": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+			"license": "MIT"
+		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+			"integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+			"license": "MIT"
+		},
+		"node_modules/htmlparser2": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+			"integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.1.0",
+				"entities": "^4.5.0"
+			}
+		},
+		"node_modules/linkedom": {
+			"version": "0.16.11",
+			"resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.11.tgz",
+			"integrity": "sha512-WgaTVbj7itjyXTsCvgerpneERXShcnNJF5VIV+/4SLtyRLN+HppPre/WDHRofAr2IpEuujSNgJbCBd5lMl6lRw==",
+			"license": "ISC",
+			"dependencies": {
+				"css-select": "^5.1.0",
+				"cssom": "^0.5.0",
+				"html-escaper": "^3.0.3",
+				"htmlparser2": "^9.1.0",
+				"uhyphen": "^0.2.0"
+			}
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+			"integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/turndown": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
+			"integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@mixmark-io/domino": "^2.2.0"
+			}
+		},
+		"node_modules/uhyphen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+			"integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+			"license": "ISC"
+		},
+		"node_modules/unpdf": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
+			"integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@napi-rs/canvas": "^0.1.69"
+			},
+			"peerDependenciesMeta": {
+				"@napi-rs/canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+			"integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,45 +1,50 @@
 {
-  "name": "pi-web-access",
-  "version": "0.10.7",
-  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent",
-  "type": "module",
-  "scripts": {
-    "test": "node --test"
-  },
-  "keywords": [
-    "pi-package",
-    "pi",
-    "pi-coding-agent",
-    "extension",
-    "web-search",
-    "perplexity",
-    "fetch",
-    "scraping"
-  ],
-  "author": "Nico Bailon",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nicobailon/pi-web-access.git"
-  },
-  "bugs": {
-    "url": "https://github.com/nicobailon/pi-web-access/issues"
-  },
-  "homepage": "https://github.com/nicobailon/pi-web-access#readme",
-  "dependencies": {
-    "@mozilla/readability": "^0.5.0",
-    "linkedom": "^0.16.0",
-    "p-limit": "^6.1.0",
-    "turndown": "^7.2.0",
-    "unpdf": "^1.6.2"
-  },
-  "pi": {
-    "extensions": [
-      "./index.ts"
-    ],
-    "skills": [
-      "./skills"
-    ],
-    "video": "https://github.com/nicobailon/pi-web-access/raw/refs/heads/main/pi-web-fetch-demo.mp4"
-  }
+	"name": "pi-web-access",
+	"version": "0.10.7",
+	"description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent",
+	"type": "module",
+	"scripts": {
+		"format": "prettier --write '*.ts' '*.json' 'test/**/*.mjs'",
+		"format:check": "prettier --check '*.ts' '*.json' 'test/**/*.mjs'",
+		"test": "node --test"
+	},
+	"keywords": [
+		"pi-package",
+		"pi",
+		"pi-coding-agent",
+		"extension",
+		"web-search",
+		"perplexity",
+		"fetch",
+		"scraping"
+	],
+	"author": "Nico Bailon",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/nicobailon/pi-web-access.git"
+	},
+	"bugs": {
+		"url": "https://github.com/nicobailon/pi-web-access/issues"
+	},
+	"homepage": "https://github.com/nicobailon/pi-web-access#readme",
+	"dependencies": {
+		"@mozilla/readability": "^0.5.0",
+		"linkedom": "^0.16.0",
+		"p-limit": "^6.1.0",
+		"turndown": "^7.2.0",
+		"unpdf": "^1.6.2"
+	},
+	"pi": {
+		"extensions": [
+			"./index.ts"
+		],
+		"skills": [
+			"./skills"
+		],
+		"video": "https://github.com/nicobailon/pi-web-access/raw/refs/heads/main/pi-web-fetch-demo.mp4"
+	},
+	"devDependencies": {
+		"prettier": "^3.8.3"
+	}
 }

--- a/pdf-extract.ts
+++ b/pdf-extract.ts
@@ -1,6 +1,6 @@
 /**
  * PDF Content Extractor
- * 
+ *
  * Extracts text from PDF files and saves to markdown.
  * Uses unpdf (pdfjs-dist wrapper) for text extraction.
  */
@@ -11,16 +11,16 @@ import { join, basename } from "node:path";
 import { homedir } from "node:os";
 
 export interface PDFExtractResult {
-  title: string;
-  pages: number;
-  chars: number;
-  outputPath: string;
+	title: string;
+	pages: number;
+	chars: number;
+	outputPath: string;
 }
 
 export interface PDFExtractOptions {
-  maxPages?: number;
-  outputDir?: string;
-  filename?: string;
+	maxPages?: number;
+	outputDir?: string;
+	filename?: string;
 }
 
 const DEFAULT_MAX_PAGES = 100;
@@ -30,163 +30,154 @@ const DEFAULT_OUTPUT_DIR = join(homedir(), "Downloads");
  * Extract text from a PDF buffer and save to markdown file
  */
 export async function extractPDFToMarkdown(
-  buffer: ArrayBuffer,
-  url: string,
-  options: PDFExtractOptions = {}
+	buffer: ArrayBuffer,
+	url: string,
+	options: PDFExtractOptions = {}
 ): Promise<PDFExtractResult> {
-  const {
-    maxPages = DEFAULT_MAX_PAGES,
-    outputDir = DEFAULT_OUTPUT_DIR,
-    filename,
-  } = options;
+	const { maxPages = DEFAULT_MAX_PAGES, outputDir = DEFAULT_OUTPUT_DIR, filename } = options;
 
-  const safeMaxPages = Number.isFinite(maxPages)
-    ? Math.max(1, Math.floor(maxPages))
-    : DEFAULT_MAX_PAGES;
+	const safeMaxPages = Number.isFinite(maxPages) ? Math.max(1, Math.floor(maxPages)) : DEFAULT_MAX_PAGES;
 
-  const pdf = await getDocumentProxy(new Uint8Array(buffer));
-  const metadata = await pdf.getMetadata();
-  const metadataInfo = metadata.info && typeof metadata.info === "object"
-    ? metadata.info as Record<string, unknown>
-    : null;
+	const pdf = await getDocumentProxy(new Uint8Array(buffer));
+	const metadata = await pdf.getMetadata();
+	const metadataInfo =
+		metadata.info && typeof metadata.info === "object" ? (metadata.info as Record<string, unknown>) : null;
 
-  // Extract title from metadata or URL
-  const metaTitle = typeof metadataInfo?.Title === "string" ? metadataInfo.Title : undefined;
-  const metaAuthor = typeof metadataInfo?.Author === "string" ? metadataInfo.Author : undefined;
-  const urlTitle = extractTitleFromURL(url);
-  const title = metaTitle?.trim() || urlTitle;
+	// Extract title from metadata or URL
+	const metaTitle = typeof metadataInfo?.Title === "string" ? metadataInfo.Title : undefined;
+	const metaAuthor = typeof metadataInfo?.Author === "string" ? metadataInfo.Author : undefined;
+	const urlTitle = extractTitleFromURL(url);
+	const title = metaTitle?.trim() || urlTitle;
 
-  // Determine pages to extract
-  const pagesToExtract = Math.min(pdf.numPages, safeMaxPages);
-  const truncated = pdf.numPages > safeMaxPages;
+	// Determine pages to extract
+	const pagesToExtract = Math.min(pdf.numPages, safeMaxPages);
+	const truncated = pdf.numPages > safeMaxPages;
 
-  // Extract text page by page for better structure
-  const pages: { pageNum: number; text: string }[] = [];
-  for (let i = 1; i <= pagesToExtract; i++) {
-    const page = await pdf.getPage(i);
-    const textContent = await page.getTextContent();
-    const pageText = textContent.items
-      .map((item: unknown) => {
-        const textItem = item as { str?: string };
-        return textItem.str || "";
-      })
-      .join(" ")
-      .replace(/\s+/g, " ")
-      .trim();
-    
-    if (pageText) {
-      pages.push({ pageNum: i, text: pageText });
-    }
-  }
+	// Extract text page by page for better structure
+	const pages: { pageNum: number; text: string }[] = [];
+	for (let i = 1; i <= pagesToExtract; i++) {
+		const page = await pdf.getPage(i);
+		const textContent = await page.getTextContent();
+		const pageText = textContent.items
+			.map((item: unknown) => {
+				const textItem = item as { str?: string };
+				return textItem.str || "";
+			})
+			.join(" ")
+			.replace(/\s+/g, " ")
+			.trim();
 
-  // Build markdown content
-  const lines: string[] = [];
-  
-  // Header with metadata
-  lines.push(`# ${title}`);
-  lines.push("");
-  lines.push(`> Source: ${url}`);
-  lines.push(`> Pages: ${pdf.numPages}${truncated ? ` (extracted first ${pagesToExtract})` : ""}`);
-  if (metaAuthor) {
-    lines.push(`> Author: ${metaAuthor}`);
-  }
-  lines.push("");
-  lines.push("---");
-  lines.push("");
+		if (pageText) {
+			pages.push({ pageNum: i, text: pageText });
+		}
+	}
 
-  // Content with page markers
-  for (let i = 0; i < pages.length; i++) {
-    if (i > 0) {
-      lines.push("");
-      lines.push(`<!-- Page ${pages[i].pageNum} -->`);
-      lines.push("");
-    }
-    lines.push(pages[i].text);
-  }
+	// Build markdown content
+	const lines: string[] = [];
 
-  if (truncated) {
-    lines.push("");
-    lines.push("---");
-    lines.push("");
-    lines.push(`*[Truncated: Only first ${pagesToExtract} of ${pdf.numPages} pages extracted]*`);
-  }
+	// Header with metadata
+	lines.push(`# ${title}`);
+	lines.push("");
+	lines.push(`> Source: ${url}`);
+	lines.push(`> Pages: ${pdf.numPages}${truncated ? ` (extracted first ${pagesToExtract})` : ""}`);
+	if (metaAuthor) {
+		lines.push(`> Author: ${metaAuthor}`);
+	}
+	lines.push("");
+	lines.push("---");
+	lines.push("");
 
-  const content = lines.join("\n");
+	// Content with page markers
+	for (let i = 0; i < pages.length; i++) {
+		if (i > 0) {
+			lines.push("");
+			lines.push(`<!-- Page ${pages[i].pageNum} -->`);
+			lines.push("");
+		}
+		lines.push(pages[i].text);
+	}
 
-  // Generate output filename
-  const outputFilename = filename || sanitizeFilename(title) + ".md";
-  const outputPath = join(outputDir, outputFilename);
+	if (truncated) {
+		lines.push("");
+		lines.push("---");
+		lines.push("");
+		lines.push(`*[Truncated: Only first ${pagesToExtract} of ${pdf.numPages} pages extracted]*`);
+	}
 
-  // Ensure output directory exists
-  await mkdir(outputDir, { recursive: true });
+	const content = lines.join("\n");
 
-  // Write file
-  await writeFile(outputPath, content, "utf-8");
+	// Generate output filename
+	const outputFilename = filename || sanitizeFilename(title) + ".md";
+	const outputPath = join(outputDir, outputFilename);
 
-  return {
-    title,
-    pages: pdf.numPages,
-    chars: content.length,
-    outputPath,
-  };
+	// Ensure output directory exists
+	await mkdir(outputDir, { recursive: true });
+
+	// Write file
+	await writeFile(outputPath, content, "utf-8");
+
+	return {
+		title,
+		pages: pdf.numPages,
+		chars: content.length,
+		outputPath,
+	};
 }
 
 /**
  * Extract a reasonable title from URL
  */
 function extractTitleFromURL(url: string): string {
-  try {
-    const urlObj = new URL(url);
-    const pathname = urlObj.pathname;
-    
-    // Get filename without extension
-    let filename = basename(pathname, ".pdf");
-    
-    // Handle arxiv URLs: /pdf/1706.03762 → "arxiv-1706.03762"
-    if (urlObj.hostname.includes("arxiv.org")) {
-      const match = pathname.match(/\/(?:pdf|abs)\/(\d+\.\d+)/);
-      if (match) {
-        filename = `arxiv-${match[1]}`;
-      }
-    }
-    
-    // Clean up filename
-    filename = filename
-      .replace(/[_-]+/g, " ")
-      .replace(/\s+/g, " ")
-      .trim();
-    
-    return filename || "document";
-  } catch {
-    return "document";
-  }
+	try {
+		const urlObj = new URL(url);
+		const pathname = urlObj.pathname;
+
+		// Get filename without extension
+		let filename = basename(pathname, ".pdf");
+
+		// Handle arxiv URLs: /pdf/1706.03762 → "arxiv-1706.03762"
+		if (urlObj.hostname.includes("arxiv.org")) {
+			const match = pathname.match(/\/(?:pdf|abs)\/(\d+\.\d+)/);
+			if (match) {
+				filename = `arxiv-${match[1]}`;
+			}
+		}
+
+		// Clean up filename
+		filename = filename.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+
+		return filename || "document";
+	} catch {
+		return "document";
+	}
 }
 
 /**
  * Sanitize string for use as filename
  */
 function sanitizeFilename(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .slice(0, 100)
-    .replace(/^-|-$/g, "")
-    || "document";
+	return (
+		name
+			.toLowerCase()
+			.replace(/[^a-z0-9\s-]/g, "")
+			.replace(/\s+/g, "-")
+			.replace(/-+/g, "-")
+			.slice(0, 100)
+			.replace(/^-|-$/g, "") || "document"
+	);
 }
 
 /**
  * Check if URL or content-type indicates a PDF
  */
 export function isPDF(url: string, contentType?: string): boolean {
-  if (contentType?.includes("application/pdf")) {
-    return true;
-  }
-  try {
-    const urlObj = new URL(url);
-    return urlObj.pathname.toLowerCase().endsWith(".pdf");
-  } catch {
-    return false;
-  }
+	if (contentType?.includes("application/pdf")) {
+		return true;
+	}
+	try {
+		const urlObj = new URL(url);
+		return urlObj.pathname.toLowerCase().endsWith(".pdf");
+	} catch {
+		return false;
+	}
 }

--- a/perplexity.ts
+++ b/perplexity.ts
@@ -68,9 +68,9 @@ function getApiKey(): string {
 	if (!key) {
 		throw new Error(
 			"Perplexity API key not found. Either:\n" +
-			`  1. Create ${CONFIG_PATH} with { "perplexityApiKey": "your-key" }\n` +
-			"  2. Set PERPLEXITY_API_KEY environment variable\n" +
-			"Get a key at https://perplexity.ai/settings/api"
+				`  1. Create ${CONFIG_PATH} with { "perplexityApiKey": "your-key" }\n` +
+				"  2. Set PERPLEXITY_API_KEY environment variable\n" +
+				"Get a key at https://perplexity.ai/settings/api"
 		);
 	}
 	return key;

--- a/rsc-extract.ts
+++ b/rsc-extract.ts
@@ -1,338 +1,371 @@
 /**
  * RSC Content Extractor
- * 
+ *
  * Extracts readable content from Next.js React Server Components (RSC) flight payloads.
  * RSC pages embed content as JSON in <script>self.__next_f.push([...])</script> tags.
  */
 
 export interface RSCExtractResult {
-  title: string;
-  content: string;
+	title: string;
+	content: string;
 }
 
 export function extractRSCContent(html: string): RSCExtractResult | null {
-  if (!html.includes("self.__next_f.push")) {
-    return null;
-  }
+	if (!html.includes("self.__next_f.push")) {
+		return null;
+	}
 
-  // Parse all RSC chunks into a map
-  const chunkMap = new Map<string, string>();
-  const scriptRegex = /<script>self\.__next_f\.push\(\[1,"([\s\S]*?)"\]\)<\/script>/g;
+	// Parse all RSC chunks into a map
+	const chunkMap = new Map<string, string>();
+	const scriptRegex = /<script>self\.__next_f\.push\(\[1,"([\s\S]*?)"\]\)<\/script>/g;
 
-  for (const match of html.matchAll(scriptRegex)) {
-    let content: string;
-    try {
-      content = JSON.parse('"' + match[1] + '"');
-    } catch {
-      continue;
-    }
+	for (const match of html.matchAll(scriptRegex)) {
+		let content: string;
+		try {
+			content = JSON.parse('"' + match[1] + '"');
+		} catch {
+			continue;
+		}
 
-    // Parse each line as "id:payload"
-    // Lines are separated by \n, each line is one chunk
-    // Chunk IDs are hex strings, typically 1-4 chars (supports up to 65535 chunks)
-    for (const line of content.split("\n")) {
-      if (!line.trim()) continue;
-      
-      const colonIdx = line.indexOf(":");
-      if (colonIdx <= 0 || colonIdx > 4) continue;
-      
-      const id = line.slice(0, colonIdx);
-      if (!/^[0-9a-f]+$/i.test(id)) continue;
-      
-      const payload = line.slice(colonIdx + 1);
-      if (!payload) continue;
-      
-      const existing = chunkMap.get(id);
-      if (!existing || payload.length > existing.length) {
-        chunkMap.set(id, payload);
-      }
-    }
-  }
+		// Parse each line as "id:payload"
+		// Lines are separated by \n, each line is one chunk
+		// Chunk IDs are hex strings, typically 1-4 chars (supports up to 65535 chunks)
+		for (const line of content.split("\n")) {
+			if (!line.trim()) continue;
 
-  if (chunkMap.size === 0) return null;
+			const colonIdx = line.indexOf(":");
+			if (colonIdx <= 0 || colonIdx > 4) continue;
 
-  // Extract title
-  const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/);
-  const title = titleMatch?.[1]?.split("|")[0]?.trim() || "";
+			const id = line.slice(0, colonIdx);
+			if (!/^[0-9a-f]+$/i.test(id)) continue;
 
-  // Parse and cache parsed chunks
-  const parsedCache = new Map<string, unknown>();
-  
-  function getParsedChunk(id: string): unknown | null {
-    if (parsedCache.has(id)) return parsedCache.get(id);
-    
-    const chunk = chunkMap.get(id);
-    if (!chunk || !chunk.startsWith("[")) {
-      parsedCache.set(id, null);
-      return null;
-    }
-    
-    try {
-      const parsed = JSON.parse(chunk);
-      parsedCache.set(id, parsed);
-      return parsed;
-    } catch {
-      parsedCache.set(id, null);
-      return null;
-    }
-  }
+			const payload = line.slice(colonIdx + 1);
+			if (!payload) continue;
 
-  // Extract markdown from nodes, resolving refs on the fly
-  type Node = unknown;
-  const visitedRefs = new Set<string>();
+			const existing = chunkMap.get(id);
+			if (!existing || payload.length > existing.length) {
+				chunkMap.set(id, payload);
+			}
+		}
+	}
 
-  function extractNode(node: Node, ctx = { inTable: false, inCode: false }): string {
-    if (node === null || node === undefined) return "";
-    
-    if (typeof node === "string") {
-      // Check if it's a reference like "$L30"
-      const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
-      if (refMatch) {
-        const refId = refMatch[1];
-        if (visitedRefs.has(refId)) return ""; // Prevent cycles
-        visitedRefs.add(refId);
-        const refNode = getParsedChunk(refId);
-        const result = refNode ? extractNode(refNode, ctx) : "";
-        visitedRefs.delete(refId);
-        return result;
-      }
-      // Filter out RSC-specific artifacts, but preserve content inside code blocks
-      if (!ctx.inCode && (node === "$undefined" || node === "$" || /^\$[A-Z]/.test(node))) return "";
-      return node.trim() ? node : "";
-    }
-    
-    if (typeof node === "number") return String(node);
-    if (typeof node === "boolean") return "";
-    if (!Array.isArray(node)) return "";
+	if (chunkMap.size === 0) return null;
 
-    // RSC element: ["$", "tag", key, props]
-    if (node[0] === "$" && typeof node[1] === "string") {
-      const tag = node[1] as string;
-      const props = (node[3] || {}) as Record<string, unknown>;
+	// Extract title
+	const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/);
+	const title = titleMatch?.[1]?.split("|")[0]?.trim() || "";
 
-      // Skip non-content
-      const skipTags = ["script", "style", "svg", "path", "circle", "link", "meta", 
-                        "template", "button", "input", "nav", "footer", "aside"];
-      if (skipTags.includes(tag)) return "";
+	// Parse and cache parsed chunks
+	const parsedCache = new Map<string, unknown>();
 
-      // Component ref like $L25
-      if (tag.startsWith("$L")) {
-        const refId = tag.slice(2);
-        if (visitedRefs.has(refId)) return "";
-        
-        // Check for heading components with baseId
-        if (props.baseId && props.children) {
-          return `## ${String(props.children)}\n\n`;
-        }
-        
-        visitedRefs.add(refId);
-        const refNode = getParsedChunk(refId);
-        let result = "";
-        if (refNode) {
-          result = extractNode(refNode, ctx);
-        } else if (props.children) {
-          result = extractNode(props.children as Node, ctx);
-        }
-        visitedRefs.delete(refId);
-        return result;
-      }
+	function getParsedChunk(id: string): unknown | null {
+		if (parsedCache.has(id)) return parsedCache.get(id);
 
-      const children = props.children;
-      const content = children ? extractNode(children as Node, ctx) : "";
+		const chunk = chunkMap.get(id);
+		if (!chunk || !chunk.startsWith("[")) {
+			parsedCache.set(id, null);
+			return null;
+		}
 
-      switch (tag) {
-        case "h1": return `# ${content.trim()}\n\n`;
-        case "h2": return `## ${content.trim()}\n\n`;
-        case "h3": return `### ${content.trim()}\n\n`;
-        case "h4": return `#### ${content.trim()}\n\n`;
-        case "h5": return `##### ${content.trim()}\n\n`;
-        case "h6": return `###### ${content.trim()}\n\n`;
-        case "p": return ctx.inTable ? content : `${content.trim()}\n\n`;
-        case "code": {
-          const codeContent = children ? extractNode(children as Node, { ...ctx, inCode: true }) : "";
-          return ctx.inCode ? codeContent : `\`${codeContent}\``;
-        }
-        case "pre": {
-          const preContent = children ? extractNode(children as Node, { ...ctx, inCode: true }) : "";
-          return "```\n" + preContent + "\n```\n\n";
-        }
-        case "strong": case "b": return `**${content}**`;
-        case "em": case "i": return `*${content}*`;
-        case "li": return `- ${content.trim()}\n`;
-        case "ul": case "ol": return content + "\n";
-        case "blockquote": return `> ${content.trim()}\n\n`;
-        case "table": return extractTable(node as unknown[]) + "\n";
-        case "thead": case "tbody": case "tr": case "th": case "td":
-          return content;
-        case "div":
-          if (props.role === "alert" || props["data-slot"] === "alert") {
-            return `> ${content.trim()}\n\n`;
-          }
-          return content;
-        case "a": {
-          const href = props.href as string | undefined;
-          return href && !href.startsWith("#") ? `[${content}](${href})` : content;
-        }
-        default: return content;
-      }
-    }
+		try {
+			const parsed = JSON.parse(chunk);
+			parsedCache.set(id, parsed);
+			return parsed;
+		} catch {
+			parsedCache.set(id, null);
+			return null;
+		}
+	}
 
-    // Array of child nodes
-    return (node as Node[]).map(n => extractNode(n, ctx)).join("");
-  }
+	// Extract markdown from nodes, resolving refs on the fly
+	type Node = unknown;
+	const visitedRefs = new Set<string>();
 
-  function extractTable(tableNode: unknown[]): string {
-    const props = (tableNode[3] || {}) as Record<string, unknown>;
-    const rows: string[][] = [];
-    let headerRowCount = 0;
+	function extractNode(node: Node, ctx = { inTable: false, inCode: false }): string {
+		if (node === null || node === undefined) return "";
 
-    function walkTable(node: unknown, isHeader = false): void {
-      if (node === null || node === undefined) return;
-      
-      // Handle string refs
-      if (typeof node === "string") {
-        const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
-        if (refMatch && !visitedRefs.has(refMatch[1])) {
-          visitedRefs.add(refMatch[1]);
-          const refNode = getParsedChunk(refMatch[1]);
-          if (refNode) walkTable(refNode, isHeader);
-          visitedRefs.delete(refMatch[1]);
-        }
-        return;
-      }
-      
-      if (!Array.isArray(node)) return;
-      
-      if (node[0] === "$") {
-        const tag = node[1] as string;
-        const nodeProps = (node[3] || {}) as Record<string, unknown>;
-        
-        // Handle component refs
-        if (tag.startsWith("$L")) {
-          const refId = tag.slice(2);
-          if (!visitedRefs.has(refId)) {
-            visitedRefs.add(refId);
-            const refNode = getParsedChunk(refId);
-            if (refNode) walkTable(refNode, isHeader);
-            visitedRefs.delete(refId);
-          }
-          return;
-        }
-        
-        if (tag === "thead") walkTable(nodeProps.children, true);
-        else if (tag === "tbody") walkTable(nodeProps.children, false);
-        else if (tag === "tr") {
-          const cells: string[] = [];
-          walkCells(nodeProps.children, cells);
-          if (cells.length > 0) {
-            rows.push(cells);
-            if (isHeader) headerRowCount++;
-          }
-        } else walkTable(nodeProps.children, isHeader);
-      } else {
-        for (const child of node) walkTable(child, isHeader);
-      }
-    }
+		if (typeof node === "string") {
+			// Check if it's a reference like "$L30"
+			const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
+			if (refMatch) {
+				const refId = refMatch[1];
+				if (visitedRefs.has(refId)) return ""; // Prevent cycles
+				visitedRefs.add(refId);
+				const refNode = getParsedChunk(refId);
+				const result = refNode ? extractNode(refNode, ctx) : "";
+				visitedRefs.delete(refId);
+				return result;
+			}
+			// Filter out RSC-specific artifacts, but preserve content inside code blocks
+			if (!ctx.inCode && (node === "$undefined" || node === "$" || /^\$[A-Z]/.test(node))) return "";
+			return node.trim() ? node : "";
+		}
 
-    function walkCells(node: unknown, cells: string[]): void {
-      if (node === null || node === undefined) return;
-      
-      // Handle string refs
-      if (typeof node === "string") {
-        const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
-        if (refMatch && !visitedRefs.has(refMatch[1])) {
-          visitedRefs.add(refMatch[1]);
-          const refNode = getParsedChunk(refMatch[1]);
-          if (refNode) walkCells(refNode, cells);
-          visitedRefs.delete(refMatch[1]);
-        }
-        return;
-      }
-      
-      if (!Array.isArray(node)) return;
-      
-      if (node[0] === "$" && (node[1] === "td" || node[1] === "th")) {
-        const cellProps = (node[3] || {}) as Record<string, unknown>;
-        const text = extractNode(cellProps.children, { inTable: true, inCode: false })
-          .trim()
-          .replace(/\n/g, " ")
-          .replace(/\\/g, "\\\\")  // Escape backslashes first
-          .replace(/\|/g, "\\|");  // Then escape pipes
-        cells.push(text);
-      } else if (node[0] === "$" && typeof node[1] === "string" && (node[1] as string).startsWith("$L")) {
-        // Component ref for a cell
-        const refId = (node[1] as string).slice(2);
-        if (!visitedRefs.has(refId)) {
-          visitedRefs.add(refId);
-          const refNode = getParsedChunk(refId);
-          if (refNode) walkCells(refNode, cells);
-          visitedRefs.delete(refId);
-        }
-      } else {
-        for (const child of node) walkCells(child, cells);
-      }
-    }
+		if (typeof node === "number") return String(node);
+		if (typeof node === "boolean") return "";
+		if (!Array.isArray(node)) return "";
 
-    walkTable(props.children);
-    if (rows.length === 0) return "";
+		// RSC element: ["$", "tag", key, props]
+		if (node[0] === "$" && typeof node[1] === "string") {
+			const tag = node[1] as string;
+			const props = (node[3] || {}) as Record<string, unknown>;
 
-    const colCount = Math.max(...rows.map(r => r.length));
-    let md = "";
-    for (let i = 0; i < rows.length; i++) {
-      const row = rows[i].concat(Array(colCount - rows[i].length).fill(""));
-      md += "| " + row.join(" | ") + " |\n";
-      if (i === headerRowCount - 1 || (headerRowCount === 0 && i === 0)) {
-        md += "| " + Array(colCount).fill("---").join(" | ") + " |\n";
-      }
-    }
-    return md;
-  }
+			// Skip non-content
+			const skipTags = [
+				"script",
+				"style",
+				"svg",
+				"path",
+				"circle",
+				"link",
+				"meta",
+				"template",
+				"button",
+				"input",
+				"nav",
+				"footer",
+				"aside",
+			];
+			if (skipTags.includes(tag)) return "";
 
-  // Process main content chunk (usually "23")
-  const mainChunk = getParsedChunk("23");
-  
-  if (mainChunk) {
-    const content = extractNode(mainChunk);
-    if (content.trim().length > 100) {
-      const cleaned = content
-        .replace(/\n{3,}/g, "\n\n")
-        .trim();
-      return { title, content: cleaned };
-    }
-  }
+			// Component ref like $L25
+			if (tag.startsWith("$L")) {
+				const refId = tag.slice(2);
+				if (visitedRefs.has(refId)) return "";
 
-  // Fallback: try other chunks
-  const contentParts: { order: number; text: string }[] = [];
+				// Check for heading components with baseId
+				if (props.baseId && props.children) {
+					return `## ${String(props.children)}\n\n`;
+				}
 
-  for (const [id] of chunkMap) {
-    if (id === "23") continue;
-    const parsed = getParsedChunk(id);
-    if (!parsed) continue;
+				visitedRefs.add(refId);
+				const refNode = getParsedChunk(refId);
+				let result = "";
+				if (refNode) {
+					result = extractNode(refNode, ctx);
+				} else if (props.children) {
+					result = extractNode(props.children as Node, ctx);
+				}
+				visitedRefs.delete(refId);
+				return result;
+			}
 
-    visitedRefs.clear();
-    const text = extractNode(parsed);
+			const children = props.children;
+			const content = children ? extractNode(children as Node, ctx) : "";
 
-    if (text.trim().length > 50 && 
-        !text.includes("page was not found") && 
-        !text.includes("404")) {
-      contentParts.push({ order: parseInt(id, 16), text: text.trim() });
-    }
-  }
+			switch (tag) {
+				case "h1":
+					return `# ${content.trim()}\n\n`;
+				case "h2":
+					return `## ${content.trim()}\n\n`;
+				case "h3":
+					return `### ${content.trim()}\n\n`;
+				case "h4":
+					return `#### ${content.trim()}\n\n`;
+				case "h5":
+					return `##### ${content.trim()}\n\n`;
+				case "h6":
+					return `###### ${content.trim()}\n\n`;
+				case "p":
+					return ctx.inTable ? content : `${content.trim()}\n\n`;
+				case "code": {
+					const codeContent = children ? extractNode(children as Node, { ...ctx, inCode: true }) : "";
+					return ctx.inCode ? codeContent : `\`${codeContent}\``;
+				}
+				case "pre": {
+					const preContent = children ? extractNode(children as Node, { ...ctx, inCode: true }) : "";
+					return "```\n" + preContent + "\n```\n\n";
+				}
+				case "strong":
+				case "b":
+					return `**${content}**`;
+				case "em":
+				case "i":
+					return `*${content}*`;
+				case "li":
+					return `- ${content.trim()}\n`;
+				case "ul":
+				case "ol":
+					return content + "\n";
+				case "blockquote":
+					return `> ${content.trim()}\n\n`;
+				case "table":
+					return extractTable(node as unknown[]) + "\n";
+				case "thead":
+				case "tbody":
+				case "tr":
+				case "th":
+				case "td":
+					return content;
+				case "div":
+					if (props.role === "alert" || props["data-slot"] === "alert") {
+						return `> ${content.trim()}\n\n`;
+					}
+					return content;
+				case "a": {
+					const href = props.href as string | undefined;
+					return href && !href.startsWith("#") ? `[${content}](${href})` : content;
+				}
+				default:
+					return content;
+			}
+		}
 
-  if (contentParts.length === 0) return null;
+		// Array of child nodes
+		return (node as Node[]).map((n) => extractNode(n, ctx)).join("");
+	}
 
-  contentParts.sort((a, b) => a.order - b.order);
-  
-  const seen = new Set<string>();
-  const uniqueParts: string[] = [];
-  for (const part of contentParts) {
-    const key = part.text.slice(0, 150);
-    if (!seen.has(key)) {
-      seen.add(key);
-      uniqueParts.push(part.text);
-    }
-  }
+	function extractTable(tableNode: unknown[]): string {
+		const props = (tableNode[3] || {}) as Record<string, unknown>;
+		const rows: string[][] = [];
+		let headerRowCount = 0;
 
-  const content = uniqueParts.join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
-  return content.length > 100 ? { title, content } : null;
+		function walkTable(node: unknown, isHeader = false): void {
+			if (node === null || node === undefined) return;
+
+			// Handle string refs
+			if (typeof node === "string") {
+				const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
+				if (refMatch && !visitedRefs.has(refMatch[1])) {
+					visitedRefs.add(refMatch[1]);
+					const refNode = getParsedChunk(refMatch[1]);
+					if (refNode) walkTable(refNode, isHeader);
+					visitedRefs.delete(refMatch[1]);
+				}
+				return;
+			}
+
+			if (!Array.isArray(node)) return;
+
+			if (node[0] === "$") {
+				const tag = node[1] as string;
+				const nodeProps = (node[3] || {}) as Record<string, unknown>;
+
+				// Handle component refs
+				if (tag.startsWith("$L")) {
+					const refId = tag.slice(2);
+					if (!visitedRefs.has(refId)) {
+						visitedRefs.add(refId);
+						const refNode = getParsedChunk(refId);
+						if (refNode) walkTable(refNode, isHeader);
+						visitedRefs.delete(refId);
+					}
+					return;
+				}
+
+				if (tag === "thead") walkTable(nodeProps.children, true);
+				else if (tag === "tbody") walkTable(nodeProps.children, false);
+				else if (tag === "tr") {
+					const cells: string[] = [];
+					walkCells(nodeProps.children, cells);
+					if (cells.length > 0) {
+						rows.push(cells);
+						if (isHeader) headerRowCount++;
+					}
+				} else walkTable(nodeProps.children, isHeader);
+			} else {
+				for (const child of node) walkTable(child, isHeader);
+			}
+		}
+
+		function walkCells(node: unknown, cells: string[]): void {
+			if (node === null || node === undefined) return;
+
+			// Handle string refs
+			if (typeof node === "string") {
+				const refMatch = node.match(/^\$L([0-9a-f]+)$/i);
+				if (refMatch && !visitedRefs.has(refMatch[1])) {
+					visitedRefs.add(refMatch[1]);
+					const refNode = getParsedChunk(refMatch[1]);
+					if (refNode) walkCells(refNode, cells);
+					visitedRefs.delete(refMatch[1]);
+				}
+				return;
+			}
+
+			if (!Array.isArray(node)) return;
+
+			if (node[0] === "$" && (node[1] === "td" || node[1] === "th")) {
+				const cellProps = (node[3] || {}) as Record<string, unknown>;
+				const text = extractNode(cellProps.children, { inTable: true, inCode: false })
+					.trim()
+					.replace(/\n/g, " ")
+					.replace(/\\/g, "\\\\") // Escape backslashes first
+					.replace(/\|/g, "\\|"); // Then escape pipes
+				cells.push(text);
+			} else if (node[0] === "$" && typeof node[1] === "string" && (node[1] as string).startsWith("$L")) {
+				// Component ref for a cell
+				const refId = (node[1] as string).slice(2);
+				if (!visitedRefs.has(refId)) {
+					visitedRefs.add(refId);
+					const refNode = getParsedChunk(refId);
+					if (refNode) walkCells(refNode, cells);
+					visitedRefs.delete(refId);
+				}
+			} else {
+				for (const child of node) walkCells(child, cells);
+			}
+		}
+
+		walkTable(props.children);
+		if (rows.length === 0) return "";
+
+		const colCount = Math.max(...rows.map((r) => r.length));
+		let md = "";
+		for (let i = 0; i < rows.length; i++) {
+			const row = rows[i].concat(Array(colCount - rows[i].length).fill(""));
+			md += "| " + row.join(" | ") + " |\n";
+			if (i === headerRowCount - 1 || (headerRowCount === 0 && i === 0)) {
+				md += "| " + Array(colCount).fill("---").join(" | ") + " |\n";
+			}
+		}
+		return md;
+	}
+
+	// Process main content chunk (usually "23")
+	const mainChunk = getParsedChunk("23");
+
+	if (mainChunk) {
+		const content = extractNode(mainChunk);
+		if (content.trim().length > 100) {
+			const cleaned = content.replace(/\n{3,}/g, "\n\n").trim();
+			return { title, content: cleaned };
+		}
+	}
+
+	// Fallback: try other chunks
+	const contentParts: { order: number; text: string }[] = [];
+
+	for (const [id] of chunkMap) {
+		if (id === "23") continue;
+		const parsed = getParsedChunk(id);
+		if (!parsed) continue;
+
+		visitedRefs.clear();
+		const text = extractNode(parsed);
+
+		if (text.trim().length > 50 && !text.includes("page was not found") && !text.includes("404")) {
+			contentParts.push({ order: parseInt(id, 16), text: text.trim() });
+		}
+	}
+
+	if (contentParts.length === 0) return null;
+
+	contentParts.sort((a, b) => a.order - b.order);
+
+	const seen = new Set<string>();
+	const uniqueParts: string[] = [];
+	for (const part of contentParts) {
+		const key = part.text.slice(0, 150);
+		if (!seen.has(key)) {
+			seen.add(key);
+			uniqueParts.push(part.text);
+		}
+	}
+
+	const content = uniqueParts
+		.join("\n\n")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
+	return content.length > 100 ? { title, content } : null;
 }

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -58,7 +58,7 @@ export function buildSummaryPrompt(results: QueryResultData[], feedback?: string
 		"- Include key findings and caveats.",
 		"- Do not invent sources or claims.",
 		"- If evidence is weak or conflicting, say so explicitly.",
-		"- End with a short \"Sources\" section listing the most relevant URLs.",
+		'- End with a short "Sources" section listing the most relevant URLs.',
 	];
 
 	if (feedback) {
@@ -106,10 +106,7 @@ function buildDeterministicSummaryLines(results: QueryResultData[]): string[] {
 		];
 	}
 
-	const lines: string[] = [
-		"Summary based on the currently selected search results.",
-		"",
-	];
+	const lines: string[] = ["Summary based on the currently selected search results.", ""];
 
 	const sourceUrls: string[] = [];
 	let successful = 0;
@@ -127,7 +124,9 @@ function buildDeterministicSummaryLines(results: QueryResultData[]): string[] {
 		if (preview.length > 0) {
 			lines.push(`- ${result.query}: ${preview}`);
 		} else {
-			lines.push(`- ${result.query}: returned ${result.results.length} source${result.results.length === 1 ? "" : "s"} without answer text.`);
+			lines.push(
+				`- ${result.query}: returned ${result.results.length} source${result.results.length === 1 ? "" : "s"} without answer text.`
+			);
 		}
 
 		for (const source of result.results) {
@@ -158,11 +157,15 @@ function buildDeterministicSummaryLines(results: QueryResultData[]): string[] {
 	return lines;
 }
 
-export function buildDeterministicSummary(results: QueryResultData[]): { summary: string; meta: SummaryMeta } {
+export function buildDeterministicSummary(results: QueryResultData[]): {
+	summary: string;
+	meta: SummaryMeta;
+} {
 	const summary = buildDeterministicSummaryLines(results).join("\n").trim();
-	const nonEmptySummary = summary.length > 0
-		? summary
-		: "No completed search results were available when the curator session finished.\n\nSources\n- None";
+	const nonEmptySummary =
+		summary.length > 0
+			? summary
+			: "No completed search results were available when the curator session finished.\n\nSources\n- None";
 
 	return {
 		summary: nonEmptySummary,
@@ -179,7 +182,7 @@ export function buildDeterministicSummary(results: QueryResultData[]): { summary
 
 async function resolveSummaryModel(
 	ctx: SummaryGenerationContext,
-	modelOverride?: string,
+	modelOverride?: string
 ): Promise<{ model: Model; apiKey: string; headers?: Record<string, string> }> {
 	const normalizedOverride = typeof modelOverride === "string" ? modelOverride.trim() : "";
 	if (normalizedOverride.length > 0) {
@@ -207,7 +210,9 @@ async function resolveSummaryModel(
 		if (auth.ok && auth.apiKey) return { model, apiKey: auth.apiKey, headers: auth.headers };
 	}
 
-	throw new Error(`No API key available for summary models: ${PREFERRED_SUMMARY_MODELS.map(c => `${c.provider}/${c.id}`).join(", ")}`);
+	throw new Error(
+		`No API key available for summary models: ${PREFERRED_SUMMARY_MODELS.map((c) => `${c.provider}/${c.id}`).join(", ")}`
+	);
 }
 
 function getTextFromContentPart(part: unknown): string {
@@ -229,7 +234,7 @@ export async function generateSummaryDraft(
 	ctx: SummaryGenerationContext,
 	signal?: AbortSignal,
 	modelOverride?: string,
-	feedback?: string,
+	feedback?: string
 ): Promise<{ summary: string; meta: SummaryMeta }> {
 	if (!ctx || !ctx.modelRegistry) {
 		throw new Error("Summary generation context unavailable");
@@ -252,13 +257,13 @@ export async function generateSummaryDraft(
 
 	const contentParts = Array.isArray(response.content) ? response.content : [];
 	const summary = contentParts
-		.map(part => getTextFromContentPart(part))
-		.filter(text => text.trim().length > 0)
+		.map((part) => getTextFromContentPart(part))
+		.filter((text) => text.trim().length > 0)
 		.join("\n")
 		.trim();
 
 	if (summary.length === 0) {
-		const partTypes = contentParts.map(part => getContentPartType(part));
+		const partTypes = contentParts.map((part) => getContentPartType(part));
 		const typesLabel = partTypes.length > 0 ? partTypes.join(", ") : "none";
 		throw new Error(`Summary model returned empty response (content parts: ${typesLabel})`);
 	}

--- a/test/pdf-extract.test.mjs
+++ b/test/pdf-extract.test.mjs
@@ -5,23 +5,23 @@ import { test } from "node:test";
 const extractorUrl = new URL("../pdf-extract.ts", import.meta.url).href;
 
 test("extractPDFToMarkdown works on Node 22 without native Promise.try", () => {
-  const child = spawnSync(process.execPath, ["--input-type=module"], {
-    input: buildChildScript(extractorUrl),
-    encoding: "utf8",
-    maxBuffer: 2 * 1024 * 1024,
-  });
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
 
-  assert.equal(
-    child.status,
-    0,
-    "PDF extraction failed in a child process. stderr summary:\n" + errorSummary(child.stderr),
-  );
+	assert.equal(
+		child.status,
+		0,
+		"PDF extraction failed in a child process. stderr summary:\n" + errorSummary(child.stderr)
+	);
 
-  assert.match(child.stdout, /Hello PDF/);
+	assert.match(child.stdout, /Hello PDF/);
 });
 
 function buildChildScript(moduleUrl) {
-  return `
+	return `
     import { mkdtemp, readFile } from "node:fs/promises";
     import { tmpdir } from "node:os";
     import { join } from "node:path";
@@ -85,11 +85,11 @@ function buildChildScript(moduleUrl) {
 }
 
 function errorSummary(value, size = 1200) {
-  const marker = "TypeError: Promise.try is not a function";
-  const index = value.indexOf(marker);
-  if (index >= 0) {
-    return value.slice(index, index + size);
-  }
+	const marker = "TypeError: Promise.try is not a function";
+	const index = value.indexOf(marker);
+	if (index >= 0) {
+		return value.slice(index, index + size);
+	}
 
-  return value.length > size ? value.slice(-size) : value;
+	return value.length > size ? value.slice(-size) : value;
 }

--- a/video-extract.ts
+++ b/video-extract.ts
@@ -83,7 +83,9 @@ function loadVideoConfig(): VideoConfig {
 	const rawText = readFileSync(CONFIG_PATH, "utf-8");
 	let raw: { video?: { enabled?: boolean; preferredModel?: string; maxSizeMB?: number } };
 	try {
-		raw = JSON.parse(rawText) as { video?: { enabled?: boolean; preferredModel?: string; maxSizeMB?: number } };
+		raw = JSON.parse(rawText) as {
+			video?: { enabled?: boolean; preferredModel?: string; maxSizeMB?: number };
+		};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
@@ -102,7 +104,8 @@ export function isVideoFile(input: string): VideoFileInfo | null {
 	const config = loadVideoConfig();
 	if (!config.enabled) return null;
 
-	const isFilePath = input.startsWith("/") || input.startsWith("./") || input.startsWith("../") || input.startsWith("file://");
+	const isFilePath =
+		input.startsWith("/") || input.startsWith("./") || input.startsWith("../") || input.startsWith("file://");
 	if (!isFilePath) return null;
 
 	let filePath = input;
@@ -145,7 +148,7 @@ function resolveFilePath(filePath: string): string | null {
 
 	try {
 		const normalizedBase = normalizeSpaces(base);
-		const match = readdirSync(dir).find(f => normalizeSpaces(f) === normalizedBase);
+		const match = readdirSync(dir).find((f) => normalizeSpaces(f) === normalizedBase);
 		return match ? join(dir, match) : null;
 	} catch {
 		return null;
@@ -159,7 +162,7 @@ function normalizeSpaces(s: string): string {
 export async function extractVideo(
 	info: VideoFileInfo,
 	signal?: AbortSignal,
-	options?: ExtractOptions,
+	options?: ExtractOptions
 ): Promise<ExtractedContent | null> {
 	const config = loadVideoConfig();
 	const effectivePrompt = options?.prompt ?? DEFAULT_VIDEO_PROMPT;
@@ -167,8 +170,9 @@ export async function extractVideo(
 	const displayName = basename(info.absolutePath);
 	const activityId = activityMonitor.logStart({ type: "fetch", url: `video:${displayName}` });
 
-	const result = await tryVideoGeminiApi(info, effectivePrompt, effectiveModel, signal)
-		?? await tryVideoGeminiWeb(info, effectivePrompt, effectiveModel, signal);
+	const result =
+		(await tryVideoGeminiApi(info, effectivePrompt, effectiveModel, signal)) ??
+		(await tryVideoGeminiWeb(info, effectivePrompt, effectiveModel, signal));
 
 	if (result) {
 		const thumbnail = await extractVideoFrame(info.absolutePath);
@@ -197,10 +201,23 @@ function mapFfprobeError(err: unknown): string {
 
 export async function extractVideoFrame(filePath: string, seconds: number = 1): Promise<FrameResult> {
 	try {
-		const buffer = execFileSync("ffmpeg", [
-			"-ss", String(seconds), "-i", filePath,
-			"-frames:v", "1", "-f", "image2pipe", "-vcodec", "mjpeg", "pipe:1",
-		], { maxBuffer: 5 * 1024 * 1024, timeout: 10000, stdio: ["pipe", "pipe", "pipe"] });
+		const buffer = execFileSync(
+			"ffmpeg",
+			[
+				"-ss",
+				String(seconds),
+				"-i",
+				filePath,
+				"-frames:v",
+				"1",
+				"-f",
+				"image2pipe",
+				"-vcodec",
+				"mjpeg",
+				"pipe:1",
+			],
+			{ maxBuffer: 5 * 1024 * 1024, timeout: 10000, stdio: ["pipe", "pipe", "pipe"] }
+		);
 		if (buffer.length === 0) return { error: "ffmpeg failed: empty output" };
 		return { data: buffer.toString("base64"), mimeType: "image/jpeg" };
 	} catch (err) {
@@ -210,12 +227,15 @@ export async function extractVideoFrame(filePath: string, seconds: number = 1): 
 
 export async function getLocalVideoDuration(filePath: string): Promise<number | { error: string }> {
 	try {
-		const output = execFileSync("ffprobe", [
-			"-v", "quiet",
-			"-show_entries", "format=duration",
-			"-of", "csv=p=0",
-			filePath,
-		], { timeout: 10000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+		const output = execFileSync(
+			"ffprobe",
+			["-v", "quiet", "-show_entries", "format=duration", "-of", "csv=p=0", filePath],
+			{
+				timeout: 10000,
+				encoding: "utf-8",
+				stdio: ["pipe", "pipe", "pipe"],
+			}
+		).trim();
 		const duration = Number.parseFloat(output);
 		if (!Number.isFinite(duration)) return { error: "ffprobe failed: invalid duration output" };
 		return duration;
@@ -228,7 +248,7 @@ async function tryVideoGeminiWeb(
 	info: VideoFileInfo,
 	prompt: string,
 	model: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	try {
 		const cookies = await isGeminiWebAvailable();
@@ -258,7 +278,7 @@ async function tryVideoGeminiApi(
 	info: VideoFileInfo,
 	prompt: string,
 	model: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	const apiKey = getApiKey();
 	if (!apiKey) return null;
@@ -295,7 +315,7 @@ async function tryVideoGeminiApi(
 async function uploadToFilesApi(
 	info: VideoFileInfo,
 	apiKey: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<{ name: string; uri: string }> {
 	const displayName = basename(info.absolutePath);
 
@@ -338,7 +358,7 @@ async function uploadToFilesApi(
 		throw new Error(`File upload failed: ${uploadRes.status} (${text.slice(0, 200)})`);
 	}
 
-	const result = await uploadRes.json() as { file: { name: string; uri: string } };
+	const result = (await uploadRes.json()) as { file: { name: string; uri: string } };
 	return result.file;
 }
 
@@ -346,7 +366,7 @@ async function pollFileState(
 	fileName: string,
 	apiKey: string,
 	signal?: AbortSignal,
-	timeoutMs: number = 120000,
+	timeoutMs: number = 120000
 ): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 
@@ -356,11 +376,11 @@ async function pollFileState(
 		const res = await fetch(`${API_BASE}/${fileName}?key=${apiKey}`, { signal });
 		if (!res.ok) throw new Error(`File state check failed: ${res.status}`);
 
-		const data = await res.json() as { state: string };
+		const data = (await res.json()) as { state: string };
 		if (data.state === "ACTIVE") return;
 		if (data.state === "FAILED") throw new Error("File processing failed");
 
-		await new Promise(r => setTimeout(r, 5000));
+		await new Promise((r) => setTimeout(r, 5000));
 	}
 
 	throw new Error("File processing timed out");

--- a/youtube-extract.ts
+++ b/youtube-extract.ts
@@ -75,8 +75,7 @@ export function isYouTubeURL(url: string): { isYouTube: boolean; videoId: string
 		if (parsed.pathname === "/playlist") {
 			return { isYouTube: false, videoId: null };
 		}
-	} catch {
-	}
+	} catch {}
 
 	const match = url.match(YOUTUBE_REGEX);
 	if (!match) return { isYouTube: false, videoId: null };
@@ -91,21 +90,23 @@ export async function extractYouTube(
 	url: string,
 	signal?: AbortSignal,
 	prompt?: string,
-	model?: string,
+	model?: string
 ): Promise<ExtractedContent | null> {
 	const config = loadYouTubeConfig();
 	const { videoId } = isYouTubeURL(url);
-	const canonicalUrl = videoId
-		? `https://www.youtube.com/watch?v=${videoId}`
-		: url;
+	const canonicalUrl = videoId ? `https://www.youtube.com/watch?v=${videoId}` : url;
 	const effectivePrompt = prompt ?? YOUTUBE_PROMPT;
 	const effectiveModel = model ?? config.preferredModel;
 
-	const activityId = activityMonitor.logStart({ type: "fetch", url: `youtube.com/${videoId ?? "video"}` });
+	const activityId = activityMonitor.logStart({
+		type: "fetch",
+		url: `youtube.com/${videoId ?? "video"}`,
+	});
 
-	const result = await tryGeminiWeb(canonicalUrl, effectivePrompt, effectiveModel, signal)
-		?? await tryGeminiApi(canonicalUrl, effectivePrompt, effectiveModel, signal)
-		?? await tryPerplexity(url, effectivePrompt, signal);
+	const result =
+		(await tryGeminiWeb(canonicalUrl, effectivePrompt, effectiveModel, signal)) ??
+		(await tryGeminiApi(canonicalUrl, effectivePrompt, effectiveModel, signal)) ??
+		(await tryPerplexity(url, effectivePrompt, signal));
 
 	if (result) {
 		result.url = url;
@@ -144,10 +145,15 @@ function mapYtDlpError(err: unknown): string {
 
 export async function getYouTubeStreamInfo(videoId: string): Promise<StreamResult> {
 	try {
-		const output = execFileSync("yt-dlp", [
-			"--print", "duration",
-			"-g", `https://www.youtube.com/watch?v=${videoId}`,
-		], { timeout: 15000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+		const output = execFileSync(
+			"yt-dlp",
+			["--print", "duration", "-g", `https://www.youtube.com/watch?v=${videoId}`],
+			{
+				timeout: 15000,
+				encoding: "utf-8",
+				stdio: ["pipe", "pipe", "pipe"],
+			}
+		).trim();
 		const lines = output.split(/\r?\n/);
 		const rawDuration = lines[0]?.trim();
 		const streamUrl = lines[1]?.trim();
@@ -162,10 +168,23 @@ export async function getYouTubeStreamInfo(videoId: string): Promise<StreamResul
 
 async function extractFrameFromStream(streamUrl: string, seconds: number): Promise<FrameResult> {
 	try {
-		const buffer = execFileSync("ffmpeg", [
-			"-ss", String(seconds), "-i", streamUrl,
-			"-frames:v", "1", "-f", "image2pipe", "-vcodec", "mjpeg", "pipe:1",
-		], { maxBuffer: 5 * 1024 * 1024, timeout: 30000, stdio: ["pipe", "pipe", "pipe"] });
+		const buffer = execFileSync(
+			"ffmpeg",
+			[
+				"-ss",
+				String(seconds),
+				"-i",
+				streamUrl,
+				"-frames:v",
+				"1",
+				"-f",
+				"image2pipe",
+				"-vcodec",
+				"mjpeg",
+				"pipe:1",
+			],
+			{ maxBuffer: 5 * 1024 * 1024, timeout: 30000, stdio: ["pipe", "pipe", "pipe"] }
+		);
 		if (buffer.length === 0) return { error: "ffmpeg failed: empty output" };
 		return { data: buffer.toString("base64"), mimeType: "image/jpeg" };
 	} catch (err) {
@@ -176,9 +195,9 @@ async function extractFrameFromStream(streamUrl: string, seconds: number): Promi
 export async function extractYouTubeFrame(
 	videoId: string,
 	seconds: number,
-	streamInfo?: StreamInfo,
+	streamInfo?: StreamInfo
 ): Promise<FrameResult> {
-	const info = streamInfo ?? await getYouTubeStreamInfo(videoId);
+	const info = streamInfo ?? (await getYouTubeStreamInfo(videoId));
 	if ("error" in info) return info;
 	return extractFrameFromStream(info.streamUrl, seconds);
 }
@@ -186,18 +205,24 @@ export async function extractYouTubeFrame(
 export async function extractYouTubeFrames(
 	videoId: string,
 	timestamps: number[],
-	streamInfo?: StreamInfo,
+	streamInfo?: StreamInfo
 ): Promise<{ frames: VideoFrame[]; duration: number | null; error: string | null }> {
-	const info = streamInfo ?? await getYouTubeStreamInfo(videoId);
+	const info = streamInfo ?? (await getYouTubeStreamInfo(videoId));
 	if ("error" in info) return { frames: [], duration: null, error: info.error };
-	const results = await Promise.all(timestamps.map(async (t) => {
-		const frame = await extractFrameFromStream(info.streamUrl, t);
-		if ("error" in frame) return { error: frame.error };
-		return { ...frame, timestamp: formatSeconds(t) };
-	}));
+	const results = await Promise.all(
+		timestamps.map(async (t) => {
+			const frame = await extractFrameFromStream(info.streamUrl, t);
+			if ("error" in frame) return { error: frame.error };
+			return { ...frame, timestamp: formatSeconds(t) };
+		})
+	);
 	const frames = results.filter((f): f is VideoFrame => "data" in f);
 	const errorResult = results.find((f): f is { error: string } => "error" in f);
-	return { frames, duration: info.duration, error: frames.length === 0 && errorResult ? errorResult.error : null };
+	return {
+		frames,
+		duration: info.duration,
+		error: frames.length === 0 && errorResult ? errorResult.error : null,
+	};
 }
 
 export async function fetchYouTubeThumbnail(videoId: string): Promise<{ data: string; mimeType: string } | null> {
@@ -218,7 +243,7 @@ async function tryGeminiWeb(
 	url: string,
 	prompt: string,
 	model: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	try {
 		const cookies = await isGeminiWebAvailable();
@@ -249,7 +274,7 @@ async function tryGeminiApi(
 	url: string,
 	prompt: string,
 	model: string,
-	signal?: AbortSignal,
+	signal?: AbortSignal
 ): Promise<ExtractedContent | null> {
 	try {
 		if (!isGeminiApiAvailable()) return null;
@@ -274,22 +299,16 @@ async function tryGeminiApi(
 	}
 }
 
-async function tryPerplexity(
-	url: string,
-	prompt: string,
-	signal?: AbortSignal,
-): Promise<ExtractedContent | null> {
+async function tryPerplexity(url: string, prompt: string, signal?: AbortSignal): Promise<ExtractedContent | null> {
 	try {
 		if (signal?.aborted) return null;
 
-		const perplexityQuery = prompt === YOUTUBE_PROMPT
-			? `Summarize this YouTube video in detail: ${url}`
-			: `${prompt} YouTube video: ${url}`;
+		const perplexityQuery =
+			prompt === YOUTUBE_PROMPT
+				? `Summarize this YouTube video in detail: ${url}`
+				: `${prompt} YouTube video: ${url}`;
 
-		const { answer } = await searchWithPerplexity(
-			perplexityQuery,
-			{ signal },
-		);
+		const { answer } = await searchWithPerplexity(perplexityQuery, { signal });
 
 		if (!answer) return null;
 


### PR DESCRIPTION
## Summary

Adds a `.prettierrc` config matching the repo's existing style (tabs, semicolons, double quotes, trailing commas) and applies it across all TypeScript and test files.

### Changes

- Add `.prettierrc` with consistent formatting rules
- Add `prettier` as a dev dependency
- Add `format` and `format:check` scripts to `package.json`
- Format all TypeScript and test files to match

### Why this helps

I have a few bug fixes and quality-of-life improvements I'd like to contribute upstream. Having deterministic formatting will make those PRs much cleaner to review — the diff will show only the actual logic changes, not whitespace noise.

Happy to rebase my other changes on top of this once it lands. No rush — just setting up a cleaner baseline for future contributions.
