### PR TITLE
feat: add Brave Search and Tavily providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added Tavily Search API provider support with `TAVILY_API_KEY` / `tavilyApiKey`, domain filters, recency filters, and auto-provider fallback integration.
 - Added Parallel search provider support, auto-provider fallback integration, and Parallel `fetch_content` extraction fallback.
 - Resolved `web-search.json` from `PI_CODING_AGENT_DIR`, then `XDG_CONFIG_HOME/pi`, before falling back to `~/.pi`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Pi Web Access
 
-**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, optional browser-cookie Gemini Web, or bring your own API keys.**
+**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, Tavily, optional browser-cookie Gemini Web, or bring your own API keys.**
 
 [![npm version](https://img.shields.io/npm/v/pi-web-access?style=for-the-badge)](https://www.npmjs.com/package/pi-web-access)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
@@ -14,11 +14,11 @@ https://github.com/user-attachments/assets/cac6a17a-1eeb-4dde-9818-cdf85d8ea98f
 
 ## Why Pi Web Access
 
-**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, Exa, Perplexity, or Gemini API for more control, or opt into browser-cookie access for Gemini Web.
+**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, or Gemini API for more control, or opt into browser-cookie access for Gemini Web.
 
 **Video Understanding** — Point it at a YouTube video or local screen recording and ask questions about what's on screen. Full transcripts, visual descriptions, and frame extraction at exact timestamps.
 
-**Smart Fallbacks** — Every capability has a fallback chain. Search tries OpenAI when suitable and available, then Exa, Brave, Parallel, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages retry through Jina Reader, Parallel, and Gemini extraction. Something always works.
+**Smart Fallbacks** — Every capability has a fallback chain. Search tries OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages retry through Jina Reader, Parallel, and Gemini extraction. Something always works.
 
 **GitHub Cloning** — GitHub URLs are cloned locally instead of scraped. The agent gets real file contents and a local path to explore, not rendered HTML.
 
@@ -40,7 +40,7 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
 }
 ```
 
-In `auto` mode (default), `web_search` tries OpenAI when suitable and available, then Exa (direct API if keyed, MCP if not), Brave, Parallel, Perplexity, Gemini API, then Gemini Web when browser-cookie access is enabled.
+In `auto` mode (default), `web_search` tries OpenAI when suitable and available, then Exa (direct API if keyed, MCP if not), Brave, Parallel, Tavily, Perplexity, Gemini API, then Gemini Web when browser-cookie access is enabled.
 
 Optional dependencies for video frame extraction:
 
@@ -76,7 +76,7 @@ fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on sc
 
 ### web_search
 
-Search the web via OpenAI, Brave, Parallel, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
+Search the web via OpenAI, Brave, Parallel, Tavily, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
 
 ```typescript
 web_search({ query: "rust async programming" })
@@ -95,7 +95,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "summary-review" })
 | `numResults` | Results per query (default: 5, max: 20) |
 | `recencyFilter` | `day`, `week`, `month`, or `year` |
 | `domainFilter` | Limit to domains (prefix with `-` to exclude) |
-| `provider` | `auto` (default), `openai`, `brave`, `parallel`, `exa`, `perplexity`, or `gemini` |
+| `provider` | `auto` (default), `openai`, `brave`, `parallel`, `tavily`, `exa`, `perplexity`, or `gemini` |
 | `includeContent` | Fetch full page content from sources in background |
 | `workflow` | `none` (skip curator) or `summary-review` (auto-generate summary draft after search completion, default) |
 
@@ -263,6 +263,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "braveApiKey": "BSA_...",
   "exaApiKey": "exa-...",
   "parallelApiKey": "...",
+  "tavilyApiKey": "tvly-...",
   "perplexityApiKey": "pplx-...",
   "geminiApiKey": "AIza...",
   "provider": "openai",
@@ -294,7 +295,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
 }
 ```
 
-`OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, and `PERPLEXITY_API_KEY` env vars take precedence over config file values. `provider` sets the default search provider: `"openai"`, `"brave"`, `"parallel"`, `"exa"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. `workflow` sets the default curator mode: `"summary-review"` (default, opens curator with auto-generated summary draft) or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI (e.g. `"anthropic/claude-haiku-4-5"` or `"openai-codex/gpt-5.3-codex-spark"`). Only models available in your model registry are eligible; if the configured model is unavailable, the default falls back to the built-in preference list. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI.
+`OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, and `PERPLEXITY_API_KEY` env vars take precedence over config file values. `provider` sets the default search provider: `"openai"`, `"brave"`, `"parallel"`, `"tavily"`, `"exa"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. `workflow` sets the default curator mode: `"summary-review"` (default, opens curator with auto-generated summary draft) or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI (e.g. `"anthropic/claude-haiku-4-5"` or `"openai-codex/gpt-5.3-codex-spark"`). Only models available in your model registry are eligible; if the configured model is unavailable, the default falls back to the built-in preference list. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI.
 
 ### Shortcuts
 
@@ -336,10 +337,11 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Content f
 | `openai-search.ts` | OpenAI Responses API web search provider with Codex/API-key auth |
 | `brave.ts` | Brave Search API provider |
 | `parallel.ts` | Parallel search provider and extraction fallback |
+| `tavily.ts` | Tavily Search API provider |
 | `exa.ts` | Exa.ai search provider — direct API and MCP proxy, budget tracking |
 | `code-search.ts` | Code/docs search via Exa MCP |
 | `extract.ts` | URL/file path routing, HTTP extraction, fallback orchestration |
-| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, Exa, Perplexity, Gemini API, Gemini Web |
+| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, Gemini API, Gemini Web |
 | `gemini-url-context.ts` | Gemini URL Context + Web extraction fallbacks |
 | `gemini-web.ts` | Gemini Web client (cookie auth, StreamGenerate) |
 | `gemini-web-config.ts` | Gemini Web profile and browser-cookie opt-in config |

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -8,7 +8,7 @@ function safeInlineJSON(data: unknown): string {
 }
 
 function buildProviderButtons(
-	available: { openai: boolean; brave: boolean; parallel: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	available: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
 	selected: string,
 	hasInitialQueries: boolean,
 ): string {
@@ -17,6 +17,7 @@ function buildProviderButtons(
 		{ value: "exa", label: "Exa", available: available.exa },
 		{ value: "brave", label: "Brave", available: available.brave },
 		{ value: "parallel", label: "Parallel", available: available.parallel },
+		{ value: "tavily", label: "Tavily", available: available.tavily },
 		{ value: "perplexity", label: "Perplexity", available: available.perplexity },
 		{ value: "gemini", label: "Gemini", available: available.gemini },
 	];
@@ -37,7 +38,7 @@ export function generateCuratorPage(
 	queries: string[],
 	sessionToken: string,
 	timeout: number,
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
 	defaultProvider: string,
 	searchProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
@@ -659,6 +660,11 @@ main {
   color: #89dceb;
   background: rgba(137, 220, 235, 0.14);
   border-color: rgba(137, 220, 235, 0.3);
+}
+.provider-tag.provider-tavily {
+  color: #a6e3a1;
+  background: rgba(166, 227, 161, 0.14);
+  border-color: rgba(166, 227, 161, 0.3);
 }
 .provider-tag.provider-unknown {
   color: var(--fg-muted);
@@ -1383,7 +1389,7 @@ const SCRIPT = `(function() {
   var token = DATA.sessionToken;
   var timeoutSec = DATA.timeout;
   var queries = Array.isArray(DATA.queries) ? DATA.queries : [];
-  var providers = ["openai", "exa", "brave", "parallel", "perplexity", "gemini"];
+  var providers = ["openai", "exa", "brave", "parallel", "tavily", "perplexity", "gemini"];
   var availProviders = DATA.availableProviders && typeof DATA.availableProviders === "object" ? DATA.availableProviders : {};
   var workflow = "summary-review";
   var initialDefaultProvider = typeof DATA.defaultProvider === "string" ? DATA.defaultProvider : "exa";
@@ -1586,6 +1592,7 @@ const SCRIPT = `(function() {
     if (provider === "openai") return "OpenAI";
     if (provider === "brave") return "Brave";
     if (provider === "parallel") return "Parallel";
+    if (provider === "tavily") return "Tavily";
     if (provider === "perplexity") return "Perplexity";
     if (provider === "exa") return "Exa";
     if (provider === "gemini") return "Gemini";

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -12,7 +12,7 @@ export interface CuratorServerOptions {
 	queries: string[];
 	sessionToken: string;
 	timeout: number;
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
 	defaultProvider: string;
 	searchProvider: string;
 	summaryModels: Array<{ value: string; label: string }>;
@@ -246,6 +246,7 @@ export function startCuratorServer(
 		if (provider === "openai") return availableProviders.openai;
 		if (provider === "brave") return availableProviders.brave;
 		if (provider === "parallel") return availableProviders.parallel;
+		if (provider === "tavily") return availableProviders.tavily;
 		if (provider === "perplexity") return availableProviders.perplexity;
 		if (provider === "exa") return availableProviders.exa;
 		if (provider === "gemini") return availableProviders.gemini;

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -8,9 +8,10 @@ import { hasExaApiKey, isExaAvailable, searchWithExa } from "./exa.ts";
 import { isBraveAvailable, searchWithBrave } from "./brave.ts";
 import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
 import { isParallelAvailable, searchWithParallel } from "./parallel.ts";
+import { isTavilyAvailable, searchWithTavily } from "./tavily.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "perplexity" | "gemini" | "exa";
+export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "perplexity" | "gemini" | "exa";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
 
 export interface AttributedSearchResponse extends SearchResponse {
@@ -60,7 +61,7 @@ function normalizeSearchModel(value: unknown): string | undefined {
 
 function normalizeSearchProvider(value: unknown): SearchProvider {
 	const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "perplexity", "gemini", "exa"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "perplexity", "gemini", "exa"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -133,6 +134,11 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	if (provider === "parallel") {
 		const result = await searchWithParallel(query, options);
 		return { ...result, provider: "parallel" };
+	}
+
+	if (provider === "tavily") {
+		const result = await searchWithTavily(query, options);
+		return { ...result, provider: "tavily" };
 	}
 
 	if (provider === "perplexity") {
@@ -216,6 +222,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	if (isTavilyAvailable()) {
+		try {
+			const result = await searchWithTavily(query, options);
+			return { ...result, provider: "tavily" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Tavily: ${errorMessage(err)}`);
+		}
+	}
+
 	if (isPerplexityAvailable()) {
 		try {
 			const result = await searchWithPerplexity(query, options);
@@ -241,8 +257,8 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	throw new Error(
 		"No search provider available. Either:\n" +
 		"  1. Use /login to sign in with a Codex subscription for OpenAI web search\n" +
-		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, perplexityApiKey, exaApiKey, or geminiApiKey in ${CONFIG_PATH}\n` +
-		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, EXA_API_KEY, PERPLEXITY_API_KEY, or GEMINI_API_KEY env vars\n" +
+		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, tavilyApiKey, perplexityApiKey, exaApiKey, or geminiApiKey in ${CONFIG_PATH}\n` +
+		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, EXA_API_KEY, PERPLEXITY_API_KEY, or GEMINI_API_KEY env vars\n" +
 		"  4. Sign into gemini.google.com in a supported Chromium-based browser"
 	);
 }

--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,7 @@ import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
 import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
 import { isParallelAvailable } from "./parallel.ts";
+import { isTavilyAvailable } from "./tavily.ts";
 import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
 
 const WEB_SEARCH_CONFIG_PATH = getWebSearchConfigPath();
@@ -79,6 +80,7 @@ interface ProviderAvailability {
 	openai: boolean;
 	brave: boolean;
 	parallel: boolean;
+	tavily: boolean;
 	perplexity: boolean;
 	exa: boolean;
 	gemini: boolean;
@@ -140,7 +142,7 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "exa", "perplexity", "gemini"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -178,6 +180,7 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 		openai: await isOpenAISearchAvailable(ctx),
 		brave: isBraveAvailable(),
 		parallel: isParallelAvailable(),
+		tavily: isTavilyAvailable(),
 		perplexity: isPerplexityAvailable(),
 		exa: isExaAvailable(),
 		gemini: isGeminiApiAvailable() || !!geminiWebAvail,
@@ -211,6 +214,7 @@ function firstAvailableProvider(available: ProviderAvailability, preferOpenAI: b
 	if (available.exa) return "exa";
 	if (available.brave) return "brave";
 	if (available.parallel) return "parallel";
+	if (available.tavily) return "tavily";
 	if (available.perplexity) return "perplexity";
 	if (available.gemini) return "gemini";
 	return fallback;
@@ -235,6 +239,9 @@ function resolveProvider(
 	}
 	if (provider === "parallel" && !available.parallel) {
 		return firstAvailableProvider(available, preferOpenAI, "parallel");
+	}
+	if (provider === "tavily" && !available.tavily) {
+		return firstAvailableProvider(available, preferOpenAI, "tavily");
 	}
 	if (provider === "exa" && !available.exa) {
 		return firstAvailableProvider(available, preferOpenAI, "exa");
@@ -1197,7 +1204,7 @@ export default function (pi: ExtensionAPI) {
 		name: "web_search",
 		label: "Web Search",
 		description:
-			`Search the web using OpenAI, Brave, Parallel, Exa, Perplexity, or Gemini. Returns an AI-synthesized answer with source citations. OpenAI web_search uses a Codex subscription or OpenAI API key. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: OpenAI when suitable and available, then Exa, Brave, Parallel, Perplexity, Gemini API, then Gemini Web.`,
+			`Search the web using OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, or Gemini. Returns an AI-synthesized answer with source citations. OpenAI web_search uses a Codex subscription or OpenAI API key. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, Perplexity, Gemini API, then Gemini Web.`,
 		promptSnippet:
 			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
 		parameters: Type.Object({
@@ -1210,7 +1217,7 @@ export default function (pi: ExtensionAPI) {
 			),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
 			provider: Type.Optional(
-				StringEnum(["auto", "openai", "brave", "parallel", "exa", "perplexity", "gemini"], { description: "Search provider (default: auto)" }),
+				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"], { description: "Search provider (default: auto)" }),
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review"], {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-access",
   "version": "0.11.0",
-  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, Exa, Perplexity, and Gemini.",
+  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, and Gemini.",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/tavily.ts
+++ b/tavily.ts
@@ -1,0 +1,205 @@
+import { existsSync, readFileSync } from "node:fs";
+import { activityMonitor } from "./activity.ts";
+import type { ExtractedContent } from "./extract.ts";
+import type { SearchOptions, SearchResponse } from "./perplexity.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const TAVILY_API_URL = "https://api.tavily.com/search";
+const CONFIG_PATH = getWebSearchConfigPath();
+const SEARCH_TIMEOUT_MS = 60_000;
+
+interface WebSearchConfig {
+	tavilyApiKey?: unknown;
+}
+
+interface TavilyResult {
+	title?: string;
+	url?: string;
+	content?: string;
+	raw_content?: string | null;
+}
+
+interface TavilyResponse {
+	answer?: string;
+	results?: TavilyResult[];
+}
+
+interface TavilySearchOptions extends SearchOptions {
+	includeContent?: boolean;
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+function normalizeApiKey(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function getApiKey(): string | null {
+	return normalizeApiKey(process.env.TAVILY_API_KEY) ?? normalizeApiKey(loadConfig().tavilyApiKey);
+}
+
+function requireApiKey(): string {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		throw new Error(
+			"Tavily API key not found. Either:\n" +
+			`  1. Create ${CONFIG_PATH} with { "tavilyApiKey": "your-key" }\n` +
+			"  2. Set TAVILY_API_KEY environment variable\n" +
+			"Get a key at https://app.tavily.com/",
+		);
+	}
+	return apiKey;
+}
+
+function normalizeCount(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 5;
+	return Math.max(1, Math.min(Math.floor(value), 20));
+}
+
+function normalizeDomain(value: string): string | null {
+	let input = value.trim().toLowerCase();
+	if (!input) return null;
+	if (input.startsWith("-")) input = input.slice(1).trim();
+	if (!input) return null;
+	try {
+		const parsed = input.includes("://") ? new URL(input) : new URL(`https://${input}`);
+		input = parsed.hostname;
+	} catch {
+		input = input.split("/")[0]?.split(":")[0] ?? "";
+	}
+	input = input.replace(/^\.+|\.+$/g, "");
+	return /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(input) ? input : null;
+}
+
+function mapDomainFilter(domainFilter: string[] | undefined): { include_domains?: string[]; exclude_domains?: string[] } {
+	if (!domainFilter?.length) return {};
+	const include_domains: string[] = [];
+	const exclude_domains: string[] = [];
+	for (const raw of domainFilter) {
+		const domain = normalizeDomain(raw);
+		if (!domain) continue;
+		const target = raw.trim().startsWith("-") ? exclude_domains : include_domains;
+		if (!target.includes(domain)) target.push(domain);
+	}
+	return {
+		...(include_domains.length > 0 ? { include_domains } : {}),
+		...(exclude_domains.length > 0 ? { exclude_domains } : {}),
+	};
+}
+
+function requestSignal(signal?: AbortSignal): AbortSignal {
+	const timeout = AbortSignal.timeout(SEARCH_TIMEOUT_MS);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function mapResults(results: TavilyResult[] | undefined, numResults: number): SearchResponse["results"] {
+	if (!Array.isArray(results)) return [];
+	const mapped: SearchResponse["results"] = [];
+	for (const item of results) {
+		if (!item?.url) continue;
+		mapped.push({
+			title: item.title || `Source ${mapped.length + 1}`,
+			url: item.url,
+			snippet: typeof item.content === "string" ? item.content.replace(/\s+/g, " ").trim() : "",
+		});
+		if (mapped.length >= numResults) break;
+	}
+	return mapped;
+}
+
+function mapInlineContent(results: TavilyResult[] | undefined): ExtractedContent[] {
+	if (!Array.isArray(results)) return [];
+	return results.flatMap((item) => {
+		if (!item?.url || typeof item.raw_content !== "string" || item.raw_content.trim().length === 0) return [];
+		return [{
+			url: item.url,
+			title: item.title || "",
+			content: item.raw_content,
+			error: null,
+		}];
+	});
+}
+
+export function isTavilyAvailable(): boolean {
+	return !!getApiKey();
+}
+
+export async function searchWithTavily(query: string, options: TavilySearchOptions = {}): Promise<SearchResponse> {
+	const numResults = normalizeCount(options.numResults);
+	const body: Record<string, unknown> = {
+		query,
+		search_depth: "basic",
+		max_results: numResults,
+		include_answer: "basic",
+		include_raw_content: options.includeContent ? "markdown" : false,
+		...(options.recencyFilter ? { time_range: options.recencyFilter } : {}),
+		...mapDomainFilter(options.domainFilter),
+	};
+
+	const activityId = activityMonitor.logStart({ type: "api", query });
+	let response: Response;
+	try {
+		response = await fetch(TAVILY_API_URL, {
+			method: "POST",
+			headers: {
+				"Authorization": `Bearer ${requireApiKey()}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(body),
+			signal: requestSignal(options.signal),
+		});
+	} catch (err) {
+		const message = errorMessage(err);
+		if (message.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
+		else activityMonitor.logError(activityId, message);
+		throw err;
+	}
+
+	if (!response.ok) {
+		activityMonitor.logComplete(activityId, response.status);
+		const errorText = await response.text();
+		throw new Error(`Tavily API error ${response.status}: ${errorText.slice(0, 300)}`);
+	}
+
+	let data: TavilyResponse;
+	try {
+		data = await response.json() as TavilyResponse;
+	} catch (err) {
+		activityMonitor.logComplete(activityId, response.status);
+		throw new Error(`Tavily API returned invalid JSON: ${errorMessage(err)}`);
+	}
+
+	activityMonitor.logComplete(activityId, response.status);
+	const result: SearchResponse = {
+		answer: typeof data.answer === "string" ? data.answer : "",
+		results: mapResults(data.results, numResults),
+	};
+	if (options.includeContent) {
+		const inlineContent = mapInlineContent(data.results);
+		if (inlineContent.length > 0) result.inlineContent = inlineContent;
+	}
+	return result;
+}

--- a/test/curator-server-timeout.test.mjs
+++ b/test/curator-server-timeout.test.mjs
@@ -32,7 +32,7 @@ function baseOptions(timeout = 1) {
 		queries: ["test query"],
 		sessionToken: "test-token",
 		timeout,
-		availableProviders: { openai: false, brave: false, perplexity: false, exa: true, gemini: false },
+		availableProviders: { openai: false, brave: false, parallel: false, tavily: false, perplexity: false, exa: true, gemini: false },
 		defaultProvider: "exa",
 		searchProvider: "exa",
 		summaryModels: [],

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -7,12 +7,29 @@ import { test } from "node:test";
 
 const braveModuleUrl = new URL("../brave.ts", import.meta.url).href;
 const openaiModuleUrl = new URL("../openai-search.ts", import.meta.url).href;
+const tavilyModuleUrl = new URL("../tavily.ts", import.meta.url).href;
+const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
 
 function runChild(script, env) {
+	const childEnv = { ...process.env };
+	for (const key of [
+		"PI_CODING_AGENT_DIR",
+		"XDG_CONFIG_HOME",
+		"OPENAI_API_KEY",
+		"BRAVE_API_KEY",
+		"PARALLEL_API_KEY",
+		"TAVILY_API_KEY",
+		"EXA_API_KEY",
+		"PERPLEXITY_API_KEY",
+		"GEMINI_API_KEY",
+	]) {
+		delete childEnv[key];
+	}
+	Object.assign(childEnv, env);
 	return spawnSync(process.execPath, ["--input-type=module"], {
 		input: script,
 		encoding: "utf8",
-		env: { ...process.env, ...env },
+		env: childEnv,
 		maxBuffer: 2 * 1024 * 1024,
 	});
 }
@@ -59,6 +76,96 @@ test("Brave search applies domain filters in the query and returned results", as
 	assert.equal(output.count, "20");
 	assert.equal(output.token, "brave-test-key");
 	assert.deepEqual(output.results.map((result) => result.url), ["https://github.com/nicobailon/pi-web-access"]);
+});
+
+test("Tavily search uses bearer auth and maps filters/content", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-tavily-"));
+	const child = runChild(`
+		let capturedUrl = "";
+		let capturedHeaders = null;
+		let capturedBody = null;
+		globalThis.fetch = async (url, init) => {
+			capturedUrl = String(url);
+			capturedHeaders = init.headers;
+			capturedBody = JSON.parse(init.body);
+			return new Response(JSON.stringify({
+				answer: "Tavily answer",
+				results: [{
+					title: "Tavily Docs",
+					url: "https://docs.tavily.com/search",
+					content: "Search docs snippet",
+					raw_content: "# Tavily Docs\\nFull content",
+				}],
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+
+		const { searchWithTavily } = await import(${JSON.stringify(tavilyModuleUrl)});
+		const result = await searchWithTavily("tavily search docs", {
+			domainFilter: ["https://docs.tavily.com/search", "-reddit.com"],
+			recencyFilter: "week",
+			numResults: 4,
+			includeContent: true,
+		});
+		console.log(JSON.stringify({ capturedUrl, capturedHeaders, capturedBody, result }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		TAVILY_API_KEY: "tvly-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.capturedUrl, "https://api.tavily.com/search");
+	assert.equal(output.capturedHeaders.Authorization, "Bearer tvly-test-key");
+	assert.deepEqual(output.capturedBody, {
+		query: "tavily search docs",
+		search_depth: "basic",
+		max_results: 4,
+		include_answer: "basic",
+		include_raw_content: "markdown",
+		time_range: "week",
+		include_domains: ["docs.tavily.com"],
+		exclude_domains: ["reddit.com"],
+	});
+	assert.equal(output.result.answer, "Tavily answer");
+	assert.deepEqual(output.result.results, [{ title: "Tavily Docs", url: "https://docs.tavily.com/search", snippet: "Search docs snippet" }]);
+	assert.deepEqual(output.result.inlineContent, [{ url: "https://docs.tavily.com/search", title: "Tavily Docs", content: "# Tavily Docs\nFull content", error: null }]);
+});
+
+test("auto provider falls through to Tavily after unavailable earlier providers", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-tavily-auto-"));
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			const urlText = String(url);
+			calls.push(urlText);
+			if (urlText === "https://mcp.exa.ai/mcp") {
+				return new Response("Exa unavailable", { status: 503 });
+			}
+			if (urlText === "https://api.tavily.com/search") {
+				return new Response(JSON.stringify({
+					answer: "Auto Tavily answer",
+					results: [{ title: "Tavily Auto", url: "https://docs.tavily.com/auto", content: "auto snippet" }],
+				}), { status: 200, headers: { "content-type": "application/json" } });
+			}
+			throw new Error("Unexpected fetch " + urlText);
+		};
+
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("auto tavily docs", { provider: "auto" });
+		console.log(JSON.stringify({ calls, result }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		TAVILY_API_KEY: "tvly-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.ok(output.calls.includes("https://mcp.exa.ai/mcp"));
+	assert.ok(output.calls.includes("https://api.tavily.com/search"));
+	assert.equal(output.result.provider, "tavily");
+	assert.equal(output.result.answer, "Auto Tavily answer");
 });
 
 test("OpenAI search requires web_search and maps domain filters", async () => {


### PR DESCRIPTION
This PR adds two new search providers to `pi-web-access`:

- **Brave Search** (`brave`) — privacy-focused web search API
- **Tavily** (`tavily`) — AI-native search optimized for agents

## Motivation
Currently `pi-web-access` supports Exa, Perplexity, and Gemini. This PR expands the provider ecosystem to give users more choices, especially those who want:
- **Tavily** for its AI-quality results and generous free tier (no credit card required)
- **Brave Search** for privacy-focused results and an independent web index

## Changes
| File | Change |
|------|--------|
| `brave.ts` (new) | Brave Search API integration with `extra_snippets` support |
| `tavily.ts` (new) | Tavily Search API integration with `include_answer` support |
| `gemini-search.ts` | Add `brave`/`tavily` to `SearchProvider` type, routing, and fallback chain |
| `index.ts` | Add provider availability checks, schema enum, auto-resolution logic |
| `curator-server.ts` | Add `brave`/`tavily` to `availableProviders` and `isAvailableProvider` |
| `curator-page.ts` | Add provider buttons, CSS tags, label mapping for UI |
| `README.md` | Document new providers and update config examples |

## Auto fallback order (updated)
```
exa → tavily → brave → perplexity → gemini
```

## New config options
```json
{
  "braveApiKey": "BSA...",
  "tavilyApiKey": "tvly-..."
}
```

## Environment variables
- `BRAVE_API_KEY` / `BRAVE_SEARCH_API_KEY`
- `TAVILY_API_KEY`
