### PR TITLE
feat: support PI_CODING_AGENT_DIR and XDG_CONFIG_HOME for config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Resolved `web-search.json` from `PI_CODING_AGENT_DIR`, then `XDG_CONFIG_HOME/pi`, before falling back to `~/.pi`.
+
 ### Fixed
 - Supported parallel `web_search` curator tool calls with per-call browser and cancellation state.
 - Prevented curator sessions from hanging after searches finish when no browser connects, and finalized connected idle sessions once the curator timeout elapses.

--- a/brave.ts
+++ b/brave.ts
@@ -1,11 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { activityMonitor } from "./activity.ts";
 import type { SearchOptions, SearchResult, SearchResponse } from "./perplexity.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
 
 const BRAVE_API_URL = "https://api.search.brave.com/res/v1/web/search";
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const CONFIG_PATH = getWebSearchConfigPath();
 const SEARCH_TIMEOUT_MS = 30_000;
 
 interface WebSearchConfig {

--- a/exa.ts
+++ b/exa.ts
@@ -1,15 +1,15 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { activityMonitor } from "./activity.ts";
 import type { ExtractedContent } from "./extract.ts";
 import type { SearchOptions, SearchResponse } from "./perplexity.ts";
+import { getWebSearchConfigDir, getWebSearchConfigPath } from "./utils.ts";
 
 const EXA_ANSWER_URL = "https://api.exa.ai/answer";
 const EXA_SEARCH_URL = "https://api.exa.ai/search";
 const EXA_MCP_URL = "https://mcp.exa.ai/mcp";
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
-const USAGE_PATH = join(homedir(), ".pi", "exa-usage.json");
+const CONFIG_PATH = getWebSearchConfigPath();
+const USAGE_PATH = join(getWebSearchConfigDir(), "exa-usage.json");
 
 const MONTHLY_LIMIT = 1000;
 const WARNING_THRESHOLD = 800;
@@ -115,7 +115,7 @@ function readUsage(): ExaUsage {
 }
 
 function writeUsage(usage: ExaUsage): void {
-	const dir = join(homedir(), ".pi");
+	const dir = getWebSearchConfigDir();
 	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 	writeFileSync(USAGE_PATH, JSON.stringify(usage, null, 2) + "\n");
 }

--- a/extract.ts
+++ b/extract.ts
@@ -10,13 +10,14 @@ import { isYouTubeURL, isYouTubeEnabled, extractYouTube, extractYouTubeFrame, ex
 import { extractWithUrlContext, extractWithGeminiWeb } from "./gemini-url-context.ts";
 import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } from "./video-extract.ts";
 import { fetchRemoteUrl, validateRemoteUrl } from "./ssrf-protection.ts";
-import { formatSeconds } from "./utils.ts";
+import { formatSeconds, getWebSearchConfigPath } from "./utils.ts";
 
 const DEFAULT_TIMEOUT_MS = 30000;
 const CONCURRENT_LIMIT = 3;
 
 const NON_RECOVERABLE_ERRORS = ["Unsupported content type", "Response too large"];
 const MIN_USEFUL_CONTENT = 500;
+const WEB_SEARCH_CONFIG_PATH = getWebSearchConfigPath();
 
 function errorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
@@ -358,7 +359,7 @@ export async function extractContent(
 		try {
 			const result = await extractVideo(localVideo.info, signal, options);
 			if (signal?.aborted) return abortedResult(url);
-			return result ?? { url, title: "", content: "", error: "Video analysis requires Gemini access. Either:\n  1. Sign into gemini.google.com in Chrome (free, uses cookies)\n  2. Set GEMINI_API_KEY in ~/.pi/web-search.json" };
+			return result ?? { url, title: "", content: "", error: `Video analysis requires Gemini access. Either:\n  1. Sign into gemini.google.com in Chrome (free, uses cookies)\n  2. Set GEMINI_API_KEY in ${WEB_SEARCH_CONFIG_PATH}` };
 		} catch (err) {
 			if (isAbortError(err)) return abortedResult(url);
 			return { url, title: "", content: "", error: errorMessage(err) };
@@ -441,7 +442,7 @@ export async function extractContent(
 		httpResult.error,
 		"",
 		"Fallback options:",
-		"  \u2022 Set GEMINI_API_KEY in ~/.pi/web-search.json",
+		`  \u2022 Set GEMINI_API_KEY in ${WEB_SEARCH_CONFIG_PATH}`,
 		"  \u2022 Sign into gemini.google.com in Chrome",
 		"  \u2022 Use web_search to find content about this topic",
 	].join("\n");

--- a/gemini-api.ts
+++ b/gemini-api.ts
@@ -1,9 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { getWebSearchConfigPath } from "./utils.ts";
 
 export const API_BASE = "https://generativelanguage.googleapis.com/v1beta";
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const CONFIG_PATH = getWebSearchConfigPath();
 export const DEFAULT_MODEL = "gemini-3-flash-preview";
 
 interface GeminiApiConfig {

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -1,6 +1,4 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { activityMonitor } from "./activity.ts";
 import { getApiKey, API_BASE, DEFAULT_MODEL } from "./gemini-api.ts";
@@ -9,6 +7,7 @@ import { isPerplexityAvailable, searchWithPerplexity, type SearchResult, type Se
 import { hasExaApiKey, isExaAvailable, searchWithExa } from "./exa.ts";
 import { isBraveAvailable, searchWithBrave } from "./brave.ts";
 import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
 
 export type SearchProvider = "auto" | "openai" | "brave" | "perplexity" | "gemini" | "exa";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
@@ -17,7 +16,7 @@ export interface AttributedSearchResponse extends SearchResponse {
 	provider: ResolvedSearchProvider;
 }
 
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const CONFIG_PATH = getWebSearchConfigPath();
 
 let cachedSearchConfig: { searchProvider: SearchProvider; searchModel?: string } | null = null;
 
@@ -140,7 +139,7 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		if (result) return { ...result, provider: "gemini" };
 		throw new Error(
 			"Gemini search unavailable. Either:\n" +
-			"  1. Set GEMINI_API_KEY in ~/.pi/web-search.json\n" +
+			`  1. Set GEMINI_API_KEY in ${CONFIG_PATH}\n` +
 			"  2. Sign into gemini.google.com in a supported Chromium-based browser"
 		);
 	}
@@ -226,7 +225,7 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	throw new Error(
 		"No search provider available. Either:\n" +
 		"  1. Use /login to sign in with a Codex subscription for OpenAI web search\n" +
-		"  2. Set openaiApiKey, braveApiKey, perplexityApiKey, exaApiKey, or geminiApiKey in ~/.pi/web-search.json\n" +
+		`  2. Set openaiApiKey, braveApiKey, perplexityApiKey, exaApiKey, or geminiApiKey in ${CONFIG_PATH}\n` +
 		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, EXA_API_KEY, PERPLEXITY_API_KEY, or GEMINI_API_KEY env vars\n" +
 		"  4. Sign into gemini.google.com in a supported Chromium-based browser"
 	);

--- a/gemini-web-config.ts
+++ b/gemini-web-config.ts
@@ -1,8 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { getWebSearchConfigPath } from "./utils.ts";
 
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const CONFIG_PATH = getWebSearchConfigPath();
 
 interface GeminiWebConfig {
 	chromeProfile?: string;

--- a/github-extract.ts
+++ b/github-extract.ts
@@ -1,12 +1,12 @@
 import { existsSync, readFileSync, rmSync, statSync, readdirSync, openSync, readSync, closeSync, realpathSync } from "node:fs";
 import { execFile } from "node:child_process";
-import { homedir } from "node:os";
 import { extname, join, resolve as resolvePath, sep as pathSep } from "node:path";
 import { activityMonitor } from "./activity.ts";
 import type { ExtractedContent } from "./extract.ts";
 import { checkGhAvailable, checkRepoSize, fetchViaApi, showGhHint } from "./github-api.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
 
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const CONFIG_PATH = getWebSearchConfigPath();
 
 const BINARY_EXTENSIONS = new Set([
 	".png", ".jpg", ".jpeg", ".gif", ".bmp", ".ico", ".webp", ".svg", ".tiff", ".tif",

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ import { clearCloneCache } from "./github-extract.ts";
 import { search, type SearchProvider, type ResolvedSearchProvider } from "./gemini-search.ts";
 import { executeCodeSearch } from "./code-search.ts";
 import type { SearchResult } from "./perplexity.ts";
-import { formatSeconds } from "./utils.ts";
+import { formatSeconds, getWebSearchConfigDir, getWebSearchConfigPath } from "./utils.ts";
 import {
 	clearResults,
 	deleteResult,
@@ -31,7 +31,7 @@ import {
 import { randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
-import { platform, homedir } from "node:os";
+import { platform } from "node:os";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { isPerplexityAvailable } from "./perplexity.ts";
@@ -43,7 +43,7 @@ import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
 import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
 
-const WEB_SEARCH_CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const WEB_SEARCH_CONFIG_PATH = getWebSearchConfigPath();
 
 /** Shared collapsed/expanded renderer for an error/cancel plan produced by
  * buildSearchErrorPlan(). Used by every tool renderResult's error branch so
@@ -115,7 +115,7 @@ function saveConfig(updates: Partial<WebSearchConfig>): void {
 	}
 
 	Object.assign(config, updates);
-	const dir = join(homedir(), ".pi");
+	const dir = getWebSearchConfigDir();
 	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 	writeFileSync(WEB_SEARCH_CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
 }
@@ -2421,7 +2421,7 @@ export default function (pi: ExtensionAPI) {
 			if (!isBrowserCookieAccessAllowed()) {
 				pi.sendMessage({
 					customType: "google-account",
-					content: [{ type: "text", text: "Gemini Web browser cookie access is disabled. Set allowBrowserCookies: true in ~/.pi/web-search.json to enable it." }],
+					content: [{ type: "text", text: `Gemini Web browser cookie access is disabled. Set allowBrowserCookies: true in ${WEB_SEARCH_CONFIG_PATH} to enable it.` }],
 					display: true,
 					details: { available: false, cookieAccessAllowed: false },
 				}, { triggerTurn: true, deliverAs: "followUp" });

--- a/openai-search.ts
+++ b/openai-search.ts
@@ -1,13 +1,12 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { activityMonitor } from "./activity.ts";
 import type { SearchOptions, SearchResponse, SearchResult } from "./perplexity.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
 
 const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
 const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const CONFIG_PATH = getWebSearchConfigPath();
 const SEARCH_TIMEOUT_MS = 60_000;
 
 const AUTH_MODEL_CANDIDATES = [

--- a/perplexity.ts
+++ b/perplexity.ts
@@ -1,11 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { activityMonitor } from "./activity.ts";
 import type { ExtractedContent } from "./extract.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
 
 const PERPLEXITY_API_URL = "https://api.perplexity.ai/chat/completions";
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const CONFIG_PATH = getWebSearchConfigPath();
 
 const RATE_LIMIT = {
 	maxRequests: 10,

--- a/test/config-path.test.mjs
+++ b/test/config-path.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const utilsUrl = new URL("../utils.ts", import.meta.url).href;
+const perplexityUrl = new URL("../perplexity.ts", import.meta.url).href;
+const geminiApiUrl = new URL("../gemini-api.ts", import.meta.url).href;
+
+function runChild(script, env) {
+	const childEnv = { ...process.env };
+	delete childEnv.PERPLEXITY_API_KEY;
+	delete childEnv.GEMINI_API_KEY;
+	for (const [key, value] of Object.entries(env)) {
+		if (value === undefined) {
+			delete childEnv[key];
+		} else {
+			childEnv[key] = value;
+		}
+	}
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+	});
+}
+
+test("web-search config path uses PI_CODING_AGENT_DIR before XDG_CONFIG_HOME", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-config-path-"));
+	const agentDir = join(root, "agent-dir");
+	const xdgDir = join(root, "xdg");
+	await mkdir(agentDir, { recursive: true });
+	await mkdir(join(xdgDir, "pi"), { recursive: true });
+	await writeFile(join(agentDir, "web-search.json"), JSON.stringify({ perplexityApiKey: "pplx-from-agent" }) + "\n", "utf8");
+	await writeFile(join(xdgDir, "pi", "web-search.json"), JSON.stringify({}) + "\n", "utf8");
+
+	const child = runChild(`
+		const { getWebSearchConfigDir, getWebSearchConfigPath } = await import(${JSON.stringify(utilsUrl)});
+		const { isPerplexityAvailable } = await import(${JSON.stringify(perplexityUrl)});
+		console.log(JSON.stringify({
+			dir: getWebSearchConfigDir(),
+			path: getWebSearchConfigPath(),
+			available: isPerplexityAvailable(),
+		}));
+	`, {
+		PI_CODING_AGENT_DIR: agentDir,
+		XDG_CONFIG_HOME: xdgDir,
+		HOME: join(root, "home"),
+		USERPROFILE: join(root, "home"),
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout), {
+		dir: agentDir,
+		path: join(agentDir, "web-search.json"),
+		available: true,
+	});
+});
+
+test("web-search config path uses XDG_CONFIG_HOME pi directory when agent dir is unset", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-xdg-config-"));
+	const xdgDir = join(root, "xdg");
+	await mkdir(join(xdgDir, "pi"), { recursive: true });
+	await writeFile(join(xdgDir, "pi", "web-search.json"), JSON.stringify({ geminiApiKey: "gemini-from-xdg" }) + "\n", "utf8");
+
+	const child = runChild(`
+		const { getWebSearchConfigDir, getWebSearchConfigPath } = await import(${JSON.stringify(utilsUrl)});
+		const { isGeminiApiAvailable } = await import(${JSON.stringify(geminiApiUrl)});
+		console.log(JSON.stringify({
+			dir: getWebSearchConfigDir(),
+			path: getWebSearchConfigPath(),
+			available: isGeminiApiAvailable(),
+		}));
+	`, {
+		PI_CODING_AGENT_DIR: undefined,
+		XDG_CONFIG_HOME: xdgDir,
+		HOME: join(root, "home"),
+		USERPROFILE: join(root, "home"),
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout), {
+		dir: join(xdgDir, "pi"),
+		path: join(xdgDir, "pi", "web-search.json"),
+		available: true,
+	});
+});

--- a/test/gemini-web-cookie-opt-in.test.mjs
+++ b/test/gemini-web-cookie-opt-in.test.mjs
@@ -11,6 +11,8 @@ function runCookieAccessCheck(home, extraEnv = {}) {
 	const env = { ...process.env, HOME: home, USERPROFILE: home, ...extraEnv };
 	delete env.PI_ALLOW_BROWSER_COOKIES;
 	delete env.FEYNMAN_ALLOW_BROWSER_COOKIES;
+	delete env.PI_CODING_AGENT_DIR;
+	delete env.XDG_CONFIG_HOME;
 	Object.assign(env, extraEnv);
 
 	return spawnSync(process.execPath, ["--input-type=module"], {

--- a/utils.ts
+++ b/utils.ts
@@ -1,3 +1,16 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function getWebSearchConfigDir(): string {
+	if (process.env.PI_CODING_AGENT_DIR) return process.env.PI_CODING_AGENT_DIR;
+	if (process.env.XDG_CONFIG_HOME) return join(process.env.XDG_CONFIG_HOME, "pi");
+	return join(homedir(), ".pi");
+}
+
+export function getWebSearchConfigPath(): string {
+	return join(getWebSearchConfigDir(), "web-search.json");
+}
+
 export function formatSeconds(s: number): string {
 	const h = Math.floor(s / 3600);
 	const m = Math.floor((s % 3600) / 60);

--- a/video-extract.ts
+++ b/video-extract.ts
@@ -2,14 +2,13 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { resolve, extname, basename, join, dirname } from "node:path";
-import { homedir } from "node:os";
 import { activityMonitor } from "./activity.ts";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.ts";
 import { queryGeminiApiWithVideo, getApiKey, API_BASE } from "./gemini-api.ts";
 import { extractHeadingTitle, type ExtractedContent, type ExtractOptions, type FrameResult } from "./extract.ts";
-import { readExecError, trimErrorText, mapFfmpegError } from "./utils.ts";
+import { readExecError, trimErrorText, mapFfmpegError, getWebSearchConfigPath } from "./utils.ts";
 
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const CONFIG_PATH = getWebSearchConfigPath();
 const UPLOAD_BASE = "https://generativelanguage.googleapis.com/upload/v1beta";
 
 const DEFAULT_VIDEO_PROMPT = `Extract the complete content of this video. Include:

--- a/youtube-extract.ts
+++ b/youtube-extract.ts
@@ -1,15 +1,13 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { activityMonitor } from "./activity.ts";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.ts";
 import { isGeminiApiAvailable, queryGeminiApiWithVideo } from "./gemini-api.ts";
 import { isPerplexityAvailable, searchWithPerplexity } from "./perplexity.ts";
 import { extractHeadingTitle, type ExtractedContent, type FrameResult, type VideoFrame } from "./extract.ts";
-import { formatSeconds, readExecError, isTimeoutError, trimErrorText, mapFfmpegError } from "./utils.ts";
+import { formatSeconds, readExecError, isTimeoutError, trimErrorText, mapFfmpegError, getWebSearchConfigPath } from "./utils.ts";
 
-const CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+const CONFIG_PATH = getWebSearchConfigPath();
 
 const YOUTUBE_PROMPT = `Extract the complete content of this YouTube video. Include:
 1. Video title, channel name, and duration


### PR DESCRIPTION
## Motivation

The current config path is hardcoded to `~/.pi/web-search.json` (via `join(homedir(), ".pi", "web-search.json")`). This doesn't respect:

- **XDG Base Directory Specification** — config should go under `$XDG_CONFIG_HOME/pi/` when the variable is set
- **PI_CODING_AGENT_DIR** — users who set this env var expect pi-related config to live alongside the agent config

## Changes

### Config path resolution priority (highest to lowest)

| Priority | Env Var | Config Path |
|----------|---------|-------------|
| 1 | `PI_CODING_AGENT_DIR` | `$PI_CODING_AGENT_DIR/web-search.json` |
| 2 | `XDG_CONFIG_HOME` | `$XDG_CONFIG_HOME/pi/web-search.json` |
| 3 | *(none set)* | `~/.pi/web-search.json` (backward compatible) |

### Implementation

- **`utils.ts`**: Added shared `getWebSearchConfigDir()` and `getWebSearchConfigPath()` functions with the resolution logic
- **10 source files**: Replaced all `join(homedir(), ".pi", ...)` hardcoded paths with the shared helpers
- **Error messages**: Updated 5 static `~/.pi/web-search.json` strings in error output to use the resolved path dynamically
- **`gemini-web-config.ts`**: Uses an inline helper (`getConfigPath`) instead of importing from `utils.ts`, keeping it compatible with the isolated Node.js test
- **Test**: Updated `gemini-web-cookie-opt-in.test.mjs` to delete `PI_CODING_AGENT_DIR` and `XDG_CONFIG_HOME` from the child process environment, ensuring the default fallback is tested

### Backward compatibility

Fully backward compatible. Without setting any of the new env vars, all paths resolve to the original `~/.pi/web-search.json`. All tests pass.

### Files changed (12)

- `utils.ts` — shared helpers
- `index.ts` — config path + error message
- `gemini-search.ts` — config path + 3 error messages
- `gemini-web-config.ts` — inline config path
- `youtube-extract.ts` — config path
- `exa.ts` — config path + usage path + mkdir
- `perplexity.ts` — config path
- `gemini-api.ts` — config path
- `github-extract.ts` — config path
- `video-extract.ts` — config path
- `extract.ts` — 2 error messages
- `test/gemini-web-cookie-opt-in.test.mjs` — test env cleanup