### PR TITLE
fix: support URL-based provider IDs in summary model resolution

### DIFF
--- a/summary-review.ts
+++ b/summary-review.ts
@@ -183,7 +183,7 @@ async function resolveSummaryModel(
 ): Promise<{ model: Model; apiKey: string; headers?: Record<string, string> }> {
 	const normalizedOverride = typeof modelOverride === "string" ? modelOverride.trim() : "";
 	if (normalizedOverride.length > 0) {
-		const slashIndex = normalizedOverride.indexOf("/");
+		const slashIndex = normalizedOverride.lastIndexOf("/");
 		if (slashIndex <= 0 || slashIndex >= normalizedOverride.length - 1) {
 			throw new Error(`Invalid summary model: ${normalizedOverride}. Use provider/model-id.`);
 		}


### PR DESCRIPTION
### Problem                                                                                                                                                                                                                                                                               

The resolveSummaryModel function currently uses .indexOf('/') to separate a provider ID from a model ID. This logic fails when the provider ID contains a URL.

This specifically affects users of the pi-llama-cpp extension, which registers providers using the format llama-server=<url>. When a summary model is resolved for such a provider (e.g., llama-server=http://127.0.0.1:8080/model.gguf), the function splits the string at the first slash encountered in http://.

This results in the provider being incorrectly parsed as llama-server=http:, which does not exist in the model registry, causing summary generation to fail.

### Fix

Changed .indexOf('/') to .lastIndexOf('/') in summary-review.ts.

Since model IDs are typically filenames or simple strings, the last slash in the identifier is the only reliable separator between the provider and the model. This ensures that URL-based provider IDs are parsed correctly while maintaining compatibility with standard provider/model formatting.

### Verification

- Verified manually using the pi-llama-cpp extension with a local server.                                                                                                                                                                                                                 
- Confirmed that summary generation now works correctly when using URL-based provider IDs (e.g., llama-server=http://127.0.0.1:8080/model.gguf).                                                                                                                                          
- Confirmed that standard provider/model formatting (e.g., anthropic/claude-3) still resolves correctly.  