### PR TITLE
Add Parallel as search provider and fetch_content fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added Parallel search provider support, auto-provider fallback integration, and Parallel `fetch_content` extraction fallback.
 - Resolved `web-search.json` from `PI_CODING_AGENT_DIR`, then `XDG_CONFIG_HOME/pi`, before falling back to `~/.pi`.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Pi Web Access
 
-**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, optional browser-cookie Gemini Web, or bring your own API keys.**
+**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, optional browser-cookie Gemini Web, or bring your own API keys.**
 
 [![npm version](https://img.shields.io/npm/v/pi-web-access?style=for-the-badge)](https://www.npmjs.com/package/pi-web-access)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
@@ -14,11 +14,11 @@ https://github.com/user-attachments/assets/cac6a17a-1eeb-4dde-9818-cdf85d8ea98f
 
 ## Why Pi Web Access
 
-**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Exa, Perplexity, or Gemini API for more control, or opt into browser-cookie access for Gemini Web.
+**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, Exa, Perplexity, or Gemini API for more control, or opt into browser-cookie access for Gemini Web.
 
 **Video Understanding** — Point it at a YouTube video or local screen recording and ask questions about what's on screen. Full transcripts, visual descriptions, and frame extraction at exact timestamps.
 
-**Smart Fallbacks** — Every capability has a fallback chain. Search tries OpenAI when suitable and available, then Exa, Brave, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages retry through Jina Reader and Gemini extraction. Something always works.
+**Smart Fallbacks** — Every capability has a fallback chain. Search tries OpenAI when suitable and available, then Exa, Brave, Parallel, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages retry through Jina Reader, Parallel, and Gemini extraction. Something always works.
 
 **GitHub Cloning** — GitHub URLs are cloned locally instead of scraped. The agent gets real file contents and a local path to explore, not rendered HTML.
 
@@ -40,7 +40,7 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
 }
 ```
 
-In `auto` mode (default), `web_search` tries OpenAI when suitable and available, then Exa (direct API if keyed, MCP if not), Brave, Perplexity, Gemini API, then Gemini Web when browser-cookie access is enabled.
+In `auto` mode (default), `web_search` tries OpenAI when suitable and available, then Exa (direct API if keyed, MCP if not), Brave, Parallel, Perplexity, Gemini API, then Gemini Web when browser-cookie access is enabled.
 
 Optional dependencies for video frame extraction:
 
@@ -76,7 +76,7 @@ fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on sc
 
 ### web_search
 
-Search the web via OpenAI, Brave, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
+Search the web via OpenAI, Brave, Parallel, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
 
 ```typescript
 web_search({ query: "rust async programming" })
@@ -95,7 +95,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "summary-review" })
 | `numResults` | Results per query (default: 5, max: 20) |
 | `recencyFilter` | `day`, `week`, `month`, or `year` |
 | `domainFilter` | Limit to domains (prefix with `-` to exclude) |
-| `provider` | `auto` (default), `openai`, `brave`, `exa`, `perplexity`, or `gemini` |
+| `provider` | `auto` (default), `openai`, `brave`, `parallel`, `exa`, `perplexity`, or `gemini` |
 | `includeContent` | Fetch full page content from sources in background |
 | `workflow` | `none` (skip curator) or `summary-review` (auto-generate summary draft after search completion, default) |
 
@@ -255,13 +255,14 @@ Toggle with **Ctrl+Shift+W** to see live request/response activity:
 
 ## Configuration
 
-All config lives in `~/.pi/web-search.json`. Every field is optional.
+Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODING_AGENT_DIR` / `XDG_CONFIG_HOME/pi` when set. Every field is optional.
 
 ```json
 {
   "openaiApiKey": "sk-...",
   "braveApiKey": "BSA_...",
   "exaApiKey": "exa-...",
+  "parallelApiKey": "...",
   "perplexityApiKey": "pplx-...",
   "geminiApiKey": "AIza...",
   "provider": "openai",
@@ -293,7 +294,7 @@ All config lives in `~/.pi/web-search.json`. Every field is optional.
 }
 ```
 
-`OPENAI_API_KEY`, `BRAVE_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, and `PERPLEXITY_API_KEY` env vars take precedence over config file values. `provider` sets the default search provider: `"openai"`, `"brave"`, `"exa"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. `workflow` sets the default curator mode: `"summary-review"` (default, opens curator with auto-generated summary draft) or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI (e.g. `"anthropic/claude-haiku-4-5"` or `"openai-codex/gpt-5.3-codex-spark"`). Only models available in your model registry are eligible; if the configured model is unavailable, the default falls back to the built-in preference list. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI.
+`OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, and `PERPLEXITY_API_KEY` env vars take precedence over config file values. `provider` sets the default search provider: `"openai"`, `"brave"`, `"parallel"`, `"exa"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. `workflow` sets the default curator mode: `"summary-review"` (default, opens curator with auto-generated summary draft) or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI (e.g. `"anthropic/claude-haiku-4-5"` or `"openai-codex/gpt-5.3-codex-spark"`). Only models available in your model registry are eligible; if the configured model is unavailable, the default falls back to the built-in preference list. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI.
 
 ### Shortcuts
 
@@ -334,10 +335,11 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Content f
 | `summary-review.ts` | Summary prompt construction, model-based draft generation, and deterministic fallback summary |
 | `openai-search.ts` | OpenAI Responses API web search provider with Codex/API-key auth |
 | `brave.ts` | Brave Search API provider |
+| `parallel.ts` | Parallel search provider and extraction fallback |
 | `exa.ts` | Exa.ai search provider — direct API and MCP proxy, budget tracking |
 | `code-search.ts` | Code/docs search via Exa MCP |
 | `extract.ts` | URL/file path routing, HTTP extraction, fallback orchestration |
-| `gemini-search.ts` | Search routing across OpenAI, Brave, Exa, Perplexity, Gemini API, Gemini Web |
+| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, Exa, Perplexity, Gemini API, Gemini Web |
 | `gemini-url-context.ts` | Gemini URL Context + Web extraction fallbacks |
 | `gemini-web.ts` | Gemini Web client (cookie auth, StreamGenerate) |
 | `gemini-web-config.ts` | Gemini Web profile and browser-cookie opt-in config |

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -8,7 +8,7 @@ function safeInlineJSON(data: unknown): string {
 }
 
 function buildProviderButtons(
-	available: { openai: boolean; brave: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	available: { openai: boolean; brave: boolean; parallel: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
 	selected: string,
 	hasInitialQueries: boolean,
 ): string {
@@ -16,6 +16,7 @@ function buildProviderButtons(
 		{ value: "openai", label: "OpenAI", available: available.openai },
 		{ value: "exa", label: "Exa", available: available.exa },
 		{ value: "brave", label: "Brave", available: available.brave },
+		{ value: "parallel", label: "Parallel", available: available.parallel },
 		{ value: "perplexity", label: "Perplexity", available: available.perplexity },
 		{ value: "gemini", label: "Gemini", available: available.gemini },
 	];
@@ -36,7 +37,7 @@ export function generateCuratorPage(
 	queries: string[],
 	sessionToken: string,
 	timeout: number,
-	availableProviders: { openai: boolean; brave: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
 	defaultProvider: string,
 	searchProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
@@ -653,6 +654,11 @@ main {
   color: #f38ba8;
   background: rgba(243, 139, 168, 0.14);
   border-color: rgba(243, 139, 168, 0.3);
+}
+.provider-tag.provider-parallel {
+  color: #89dceb;
+  background: rgba(137, 220, 235, 0.14);
+  border-color: rgba(137, 220, 235, 0.3);
 }
 .provider-tag.provider-unknown {
   color: var(--fg-muted);
@@ -1377,7 +1383,7 @@ const SCRIPT = `(function() {
   var token = DATA.sessionToken;
   var timeoutSec = DATA.timeout;
   var queries = Array.isArray(DATA.queries) ? DATA.queries : [];
-  var providers = ["openai", "exa", "brave", "perplexity", "gemini"];
+  var providers = ["openai", "exa", "brave", "parallel", "perplexity", "gemini"];
   var availProviders = DATA.availableProviders && typeof DATA.availableProviders === "object" ? DATA.availableProviders : {};
   var workflow = "summary-review";
   var initialDefaultProvider = typeof DATA.defaultProvider === "string" ? DATA.defaultProvider : "exa";
@@ -1579,6 +1585,7 @@ const SCRIPT = `(function() {
   function providerLabel(provider) {
     if (provider === "openai") return "OpenAI";
     if (provider === "brave") return "Brave";
+    if (provider === "parallel") return "Parallel";
     if (provider === "perplexity") return "Perplexity";
     if (provider === "exa") return "Exa";
     if (provider === "gemini") return "Gemini";

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -12,7 +12,7 @@ export interface CuratorServerOptions {
 	queries: string[];
 	sessionToken: string;
 	timeout: number;
-	availableProviders: { openai: boolean; brave: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
 	defaultProvider: string;
 	searchProvider: string;
 	summaryModels: Array<{ value: string; label: string }>;
@@ -245,6 +245,7 @@ export function startCuratorServer(
 	function isAvailableProvider(provider: string): boolean {
 		if (provider === "openai") return availableProviders.openai;
 		if (provider === "brave") return availableProviders.brave;
+		if (provider === "parallel") return availableProviders.parallel;
 		if (provider === "perplexity") return availableProviders.perplexity;
 		if (provider === "exa") return availableProviders.exa;
 		if (provider === "gemini") return availableProviders.gemini;

--- a/extract.ts
+++ b/extract.ts
@@ -8,6 +8,7 @@ import { extractPDFToMarkdown, isPDF } from "./pdf-extract.ts";
 import { extractGitHub } from "./github-extract.ts";
 import { isYouTubeURL, isYouTubeEnabled, extractYouTube, extractYouTubeFrame, extractYouTubeFrames, getYouTubeStreamInfo } from "./youtube-extract.ts";
 import { extractWithUrlContext, extractWithGeminiWeb } from "./gemini-url-context.ts";
+import { extractWithParallel, isParallelAvailable } from "./parallel.ts";
 import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } from "./video-extract.ts";
 import { fetchRemoteUrl, validateRemoteUrl } from "./ssrf-protection.ts";
 import { formatSeconds, getWebSearchConfigPath } from "./utils.ts";
@@ -424,6 +425,21 @@ export async function extractContent(
 	if (jinaResult) return jinaResult;
 	if (signal?.aborted) return abortedResult(url);
 
+	let parallelError: string | null = null;
+	try {
+		if (isParallelAvailable()) {
+			const parallelResult = await extractWithParallel(url, signal, options);
+			if (parallelResult) return parallelResult;
+		}
+	} catch (err) {
+		if (isAbortError(err)) return abortedResult(url);
+		parallelError = errorMessage(err);
+		if (isConfigParseError(err)) {
+			return { ...httpResult, error: parallelError };
+		}
+	}
+	if (signal?.aborted) return abortedResult(url);
+
 	let geminiResult: ExtractedContent | null = null;
 	try {
 		geminiResult = await extractWithUrlContext(url, signal)
@@ -440,8 +456,10 @@ export async function extractContent(
 
 	const guidance = [
 		httpResult.error,
+		...(parallelError ? [`Parallel fallback failed: ${parallelError}`] : []),
 		"",
 		"Fallback options:",
+		`  \u2022 Set PARALLEL_API_KEY in ${WEB_SEARCH_CONFIG_PATH}`,
 		`  \u2022 Set GEMINI_API_KEY in ${WEB_SEARCH_CONFIG_PATH}`,
 		"  \u2022 Sign into gemini.google.com in Chrome",
 		"  \u2022 Use web_search to find content about this topic",

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -7,9 +7,10 @@ import { isPerplexityAvailable, searchWithPerplexity, type SearchResult, type Se
 import { hasExaApiKey, isExaAvailable, searchWithExa } from "./exa.ts";
 import { isBraveAvailable, searchWithBrave } from "./brave.ts";
 import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
+import { isParallelAvailable, searchWithParallel } from "./parallel.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-export type SearchProvider = "auto" | "openai" | "brave" | "perplexity" | "gemini" | "exa";
+export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "perplexity" | "gemini" | "exa";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
 
 export interface AttributedSearchResponse extends SearchResponse {
@@ -59,7 +60,7 @@ function normalizeSearchModel(value: unknown): string | undefined {
 
 function normalizeSearchProvider(value: unknown): SearchProvider {
 	const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "perplexity", "gemini", "exa"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "perplexity", "gemini", "exa"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -127,6 +128,11 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	if (provider === "brave") {
 		const result = await searchWithBrave(query, options);
 		return { ...result, provider: "brave" };
+	}
+
+	if (provider === "parallel") {
+		const result = await searchWithParallel(query, options);
+		return { ...result, provider: "parallel" };
 	}
 
 	if (provider === "perplexity") {
@@ -200,6 +206,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	if (isParallelAvailable()) {
+		try {
+			const result = await searchWithParallel(query, options);
+			return { ...result, provider: "parallel" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Parallel: ${errorMessage(err)}`);
+		}
+	}
+
 	if (isPerplexityAvailable()) {
 		try {
 			const result = await searchWithPerplexity(query, options);
@@ -225,8 +241,8 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	throw new Error(
 		"No search provider available. Either:\n" +
 		"  1. Use /login to sign in with a Codex subscription for OpenAI web search\n" +
-		`  2. Set openaiApiKey, braveApiKey, perplexityApiKey, exaApiKey, or geminiApiKey in ${CONFIG_PATH}\n` +
-		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, EXA_API_KEY, PERPLEXITY_API_KEY, or GEMINI_API_KEY env vars\n" +
+		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, perplexityApiKey, exaApiKey, or geminiApiKey in ${CONFIG_PATH}\n` +
+		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, EXA_API_KEY, PERPLEXITY_API_KEY, or GEMINI_API_KEY env vars\n" +
 		"  4. Sign into gemini.google.com in a supported Chromium-based browser"
 	);
 }

--- a/index.ts
+++ b/index.ts
@@ -41,6 +41,7 @@ import { getActiveGoogleEmail, isGeminiWebAvailable } from "./gemini-web.ts";
 import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
 import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
+import { isParallelAvailable } from "./parallel.ts";
 import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
 
 const WEB_SEARCH_CONFIG_PATH = getWebSearchConfigPath();
@@ -77,6 +78,7 @@ interface WebSearchConfig {
 interface ProviderAvailability {
 	openai: boolean;
 	brave: boolean;
+	parallel: boolean;
 	perplexity: boolean;
 	exa: boolean;
 	gemini: boolean;
@@ -138,7 +140,7 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "exa", "perplexity", "gemini"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "exa", "perplexity", "gemini"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -175,6 +177,7 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 	return {
 		openai: await isOpenAISearchAvailable(ctx),
 		brave: isBraveAvailable(),
+		parallel: isParallelAvailable(),
 		perplexity: isPerplexityAvailable(),
 		exa: isExaAvailable(),
 		gemini: isGeminiApiAvailable() || !!geminiWebAvail,
@@ -207,6 +210,7 @@ function firstAvailableProvider(available: ProviderAvailability, preferOpenAI: b
 	if (preferOpenAI && available.openai) return "openai";
 	if (available.exa) return "exa";
 	if (available.brave) return "brave";
+	if (available.parallel) return "parallel";
 	if (available.perplexity) return "perplexity";
 	if (available.gemini) return "gemini";
 	return fallback;
@@ -228,6 +232,9 @@ function resolveProvider(
 	}
 	if (provider === "brave" && !available.brave) {
 		return firstAvailableProvider(available, preferOpenAI, "brave");
+	}
+	if (provider === "parallel" && !available.parallel) {
+		return firstAvailableProvider(available, preferOpenAI, "parallel");
 	}
 	if (provider === "exa" && !available.exa) {
 		return firstAvailableProvider(available, preferOpenAI, "exa");
@@ -1190,7 +1197,7 @@ export default function (pi: ExtensionAPI) {
 		name: "web_search",
 		label: "Web Search",
 		description:
-			`Search the web using OpenAI, Brave, Exa, Perplexity, or Gemini. Returns an AI-synthesized answer with source citations. OpenAI web_search uses a Codex subscription or OpenAI API key. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: OpenAI when suitable and available, then Exa, Brave, Perplexity, Gemini API, then Gemini Web.`,
+			`Search the web using OpenAI, Brave, Parallel, Exa, Perplexity, or Gemini. Returns an AI-synthesized answer with source citations. OpenAI web_search uses a Codex subscription or OpenAI API key. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: OpenAI when suitable and available, then Exa, Brave, Parallel, Perplexity, Gemini API, then Gemini Web.`,
 		promptSnippet:
 			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
 		parameters: Type.Object({
@@ -1203,7 +1210,7 @@ export default function (pi: ExtensionAPI) {
 			),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
 			provider: Type.Optional(
-				StringEnum(["auto", "openai", "brave", "exa", "perplexity", "gemini"], { description: "Search provider (default: auto)" }),
+				StringEnum(["auto", "openai", "brave", "parallel", "exa", "perplexity", "gemini"], { description: "Search provider (default: auto)" }),
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review"], {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-access",
   "version": "0.11.0",
-  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Exa, Perplexity, and Gemini.",
+  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, Exa, Perplexity, and Gemini.",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/parallel.ts
+++ b/parallel.ts
@@ -1,0 +1,360 @@
+import { existsSync, readFileSync } from "node:fs";
+import { activityMonitor } from "./activity.ts";
+import type { ExtractedContent, ExtractOptions } from "./extract.ts";
+import type { SearchOptions, SearchResponse } from "./perplexity.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const PARALLEL_SEARCH_URL = "https://api.parallel.ai/v1/search";
+const PARALLEL_EXTRACT_URL = "https://api.parallel.ai/v1/extract";
+const CONFIG_PATH = getWebSearchConfigPath();
+const MIN_PARALLEL_API_KEY_LENGTH = 8;
+const MIN_USEFUL_CONTENT = 500;
+const SEARCH_TIMEOUT_MS = 60_000;
+
+const PLACEHOLDER_API_KEY_DENYLIST = new Set([
+	"replace_with_your_parallel_api_key",
+	"parallel_api_key",
+	"your-key",
+	"your-key-here",
+	"your-api-key-here",
+	"dummy",
+	"placeholder",
+	"changeme",
+	"insert-your-key",
+	"insert-your-key-here",
+	"api-key",
+	"xxx",
+]);
+
+interface WebSearchConfig {
+	parallelApiKey?: unknown;
+}
+
+interface V1WebSearchResult {
+	url: string;
+	title?: string | null;
+	publish_date?: string | null;
+	excerpts?: string[];
+}
+
+interface V1ExtractResult {
+	url: string;
+	title?: string | null;
+	publish_date?: string | null;
+	excerpts?: string[];
+	full_content?: string | null;
+}
+
+interface ParallelSearchOptions extends SearchOptions {
+	includeContent?: boolean;
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+export function clearParallelConfigCache(): void {
+	cachedConfig = null;
+}
+
+function normalizeApiKey(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function isPlaceholderApiKey(key: string): boolean {
+	const normalized = key.trim();
+	return normalized.length < MIN_PARALLEL_API_KEY_LENGTH || PLACEHOLDER_API_KEY_DENYLIST.has(normalized.toLowerCase());
+}
+
+function resolveApiKey(): string | null {
+	const envKey = normalizeApiKey(process.env.PARALLEL_API_KEY);
+	if (envKey && !isPlaceholderApiKey(envKey)) return envKey;
+
+	const configKey = normalizeApiKey(loadConfig().parallelApiKey);
+	if (configKey && !isPlaceholderApiKey(configKey)) return configKey;
+
+	return null;
+}
+
+function getApiKey(): string {
+	const key = resolveApiKey();
+	if (!key) {
+		throw new Error(
+			"Parallel API key not found. Either:\n" +
+			`  1. Create ${CONFIG_PATH} with { "parallelApiKey": "your-key" }\n` +
+			"  2. Set PARALLEL_API_KEY environment variable\n" +
+			"Get a key at https://platform.parallel.ai",
+		);
+	}
+	return key;
+}
+
+export function hasParallelApiKey(): boolean {
+	return !!resolveApiKey();
+}
+
+export function isParallelAvailable(): boolean {
+	return hasParallelApiKey();
+}
+
+function requestSignal(signal?: AbortSignal): AbortSignal {
+	const timeout = AbortSignal.timeout(SEARCH_TIMEOUT_MS);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function activityContext(
+	url: string,
+	body: Record<string, unknown>,
+): { type: "api" | "fetch"; query?: string; url?: string } {
+	if (typeof body.objective === "string" && body.objective.trim().length > 0) {
+		return { type: "api", query: body.objective };
+	}
+
+	const searchQueries = body.search_queries;
+	if (Array.isArray(searchQueries) && typeof searchQueries[0] === "string") {
+		return { type: "api", query: searchQueries[0] };
+	}
+
+	const urls = body.urls;
+	if (Array.isArray(urls) && typeof urls[0] === "string") {
+		return { type: "fetch", url: urls[0] };
+	}
+
+	return url.includes("/search") ? { type: "api", query: "Parallel search" } : { type: "fetch", url };
+}
+
+function recencyToAfterDate(filter: string): string {
+	const now = new Date();
+	const offsets: Record<string, number> = { day: 1, week: 7, month: 30, year: 365 };
+	const days = offsets[filter] ?? 0;
+	return new Date(now.getTime() - days * 86_400_000).toISOString().slice(0, 10);
+}
+
+function normalizeDomain(value: string): string | null {
+	let input = value.trim().toLowerCase();
+	if (!input) return null;
+	if (input.startsWith("-")) input = input.slice(1).trim();
+	if (!input) return null;
+	try {
+		const parsed = input.includes("://") ? new URL(input) : new URL(`https://${input}`);
+		input = parsed.hostname;
+	} catch {
+		input = input.split("/")[0]?.split(":")[0] ?? "";
+	}
+	input = input.replace(/^\.+|\.+$/g, "");
+	return /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(input) ? input : null;
+}
+
+function mapDomainFilter(domainFilter: string[] | undefined): { include_domains?: string[]; exclude_domains?: string[] } {
+	if (!domainFilter?.length) return {};
+	const include_domains: string[] = [];
+	const exclude_domains: string[] = [];
+	for (const raw of domainFilter) {
+		const domain = normalizeDomain(raw);
+		if (!domain) continue;
+		const target = raw.trim().startsWith("-") ? exclude_domains : include_domains;
+		if (!target.includes(domain)) target.push(domain);
+	}
+	return {
+		...(include_domains.length ? { include_domains } : {}),
+		...(exclude_domains.length ? { exclude_domains } : {}),
+	};
+}
+
+function buildSearchRequestBody(query: string, options: ParallelSearchOptions = {}): Record<string, unknown> {
+	const numResults = Math.max(1, Math.min(Math.floor(options.numResults ?? 5), 20));
+	const sourcePolicy = {
+		...mapDomainFilter(options.domainFilter),
+		...(options.recencyFilter ? { after_date: recencyToAfterDate(options.recencyFilter) } : {}),
+	};
+	return {
+		objective: query,
+		search_queries: [query],
+		advanced_settings: {
+			max_results: numResults,
+			...(Object.keys(sourcePolicy).length > 0 ? { source_policy: sourcePolicy } : {}),
+		},
+	};
+}
+
+function normalizeExcerpts(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function mapSearchResults(results: V1WebSearchResult[] | undefined): SearchResponse["results"] {
+	if (!Array.isArray(results)) return [];
+	const mapped: SearchResponse["results"] = [];
+	for (let i = 0; i < results.length; i++) {
+		const item = results[i];
+		if (!item?.url) continue;
+		const excerpts = normalizeExcerpts(item.excerpts);
+		mapped.push({
+			title: item.title || `Source ${i + 1}`,
+			url: item.url,
+			snippet: excerpts.length > 0 ? excerpts[0].replace(/\s+/g, " ").trim().slice(0, 200) : "",
+		});
+	}
+	return mapped;
+}
+
+function buildAnswerFromExcerpts(results: V1WebSearchResult[] | undefined): string {
+	if (!Array.isArray(results)) return "";
+	const parts: string[] = [];
+	for (let i = 0; i < results.length; i++) {
+		const item = results[i];
+		if (!item?.url) continue;
+		const excerpts = normalizeExcerpts(item.excerpts);
+		if (excerpts.length === 0) continue;
+		parts.push(`${excerpts.join(" ")}\nSource: ${item.title || `Source ${i + 1}`} (${item.url})`);
+	}
+	return parts.join("\n\n");
+}
+
+function mapInlineContent(results: V1WebSearchResult[] | undefined): ExtractedContent[] {
+	if (!Array.isArray(results)) return [];
+	return results.flatMap((result) => {
+		if (!result?.url) return [];
+		const excerpts = normalizeExcerpts(result.excerpts);
+		if (excerpts.length === 0) return [];
+		return [{ url: result.url, title: result.title || "", content: excerpts.join("\n\n"), error: null }];
+	});
+}
+
+function resolveExtractContent(result: V1ExtractResult): string {
+	const fullContent = typeof result.full_content === "string" ? result.full_content.trim() : "";
+	return fullContent.length > 0 ? fullContent : normalizeExcerpts(result.excerpts).join("\n\n");
+}
+
+function mapExtractResult(result: V1ExtractResult | undefined | null): ExtractedContent | null {
+	if (!result?.url) return null;
+	const content = resolveExtractContent(result);
+	if (content.length < MIN_USEFUL_CONTENT) return null;
+	return {
+		url: result.url,
+		title: typeof result.title === "string" ? result.title.trim() : "",
+		content,
+		error: null,
+	};
+}
+
+function buildExtractRequestBody(url: string, options: ExtractOptions = {}, fullContent = false): Record<string, unknown> {
+	const body: Record<string, unknown> = { urls: [url] };
+	const prompt = options.prompt?.trim();
+	if (prompt) body.objective = prompt;
+	if (fullContent) body.advanced_settings = { full_content: true };
+	return body;
+}
+
+function findExtractResult(results: V1ExtractResult[] | undefined, url: string): V1ExtractResult | undefined {
+	if (!Array.isArray(results)) return undefined;
+	return results.find(item => item?.url === url) ?? results[0];
+}
+
+function hasExtractUrlError(errors: unknown, url: string): boolean {
+	if (!Array.isArray(errors)) return false;
+	return errors.some((entry) => {
+		if (typeof entry === "string") return entry === url;
+		return typeof entry === "object" && entry !== null && (entry as { url?: unknown }).url === url;
+	});
+}
+
+async function fetchAndMapExtractResult(
+	url: string,
+	body: Record<string, unknown>,
+	signal?: AbortSignal,
+): Promise<{ mapped: ExtractedContent | null; result: V1ExtractResult | undefined }> {
+	const data = await parallelFetch(PARALLEL_EXTRACT_URL, body, signal);
+	if (hasExtractUrlError(data.errors, url)) return { mapped: null, result: undefined };
+	const result = findExtractResult(data.results as V1ExtractResult[] | undefined, url);
+	return { mapped: mapExtractResult(result), result };
+}
+
+export async function searchWithParallel(query: string, options: ParallelSearchOptions = {}): Promise<SearchResponse> {
+	const data = await parallelFetch(PARALLEL_SEARCH_URL, buildSearchRequestBody(query, options), options.signal);
+	const results = data.results as V1WebSearchResult[] | undefined;
+	const response: SearchResponse = {
+		answer: buildAnswerFromExcerpts(results),
+		results: mapSearchResults(results),
+	};
+	if (options.includeContent) {
+		const inlineContent = mapInlineContent(results);
+		if (inlineContent.length > 0) response.inlineContent = inlineContent;
+	}
+	return response;
+}
+
+export async function extractWithParallel(
+	url: string,
+	signal?: AbortSignal,
+	options: ExtractOptions = {},
+): Promise<ExtractedContent | null> {
+	const initial = await fetchAndMapExtractResult(url, buildExtractRequestBody(url, options), signal);
+	if (initial.mapped) return initial.mapped;
+	if (!initial.result || resolveExtractContent(initial.result).length >= MIN_USEFUL_CONTENT) return null;
+
+	const retry = await fetchAndMapExtractResult(url, buildExtractRequestBody(url, options, true), signal);
+	return retry.mapped;
+}
+
+async function parallelFetch(
+	url: string,
+	body: Record<string, unknown>,
+	signal?: AbortSignal,
+): Promise<Record<string, unknown>> {
+	const apiKey = getApiKey();
+	const activityId = activityMonitor.logStart(activityContext(url, body));
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: "POST",
+			headers: {
+				"x-api-key": apiKey,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(body),
+			signal: requestSignal(signal),
+		});
+	} catch (err) {
+		const message = errorMessage(err);
+		if (message.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
+		else activityMonitor.logError(activityId, message);
+		throw err;
+	}
+
+	if (!response.ok) {
+		activityMonitor.logComplete(activityId, response.status);
+		const errorText = await response.text();
+		throw new Error(`Parallel API error ${response.status}: ${errorText.slice(0, 300)}`);
+	}
+
+	try {
+		const data = await response.json() as Record<string, unknown>;
+		activityMonitor.logComplete(activityId, response.status);
+		return data;
+	} catch (err) {
+		activityMonitor.logComplete(activityId, response.status);
+		throw new Error(`Parallel API returned invalid JSON: ${errorMessage(err)}`);
+	}
+}

--- a/test/parallel.test.mjs
+++ b/test/parallel.test.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const parallelModuleUrl = new URL("../parallel.ts", import.meta.url).href;
+const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
+const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
+
+async function createHome(config = {}) {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-parallel-"));
+	await mkdir(join(home, ".pi"), { recursive: true });
+	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	return home;
+}
+
+function runChild(script, env = {}) {
+	const childEnv = { ...process.env };
+	delete childEnv.PI_CODING_AGENT_DIR;
+	delete childEnv.XDG_CONFIG_HOME;
+	Object.assign(childEnv, env);
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+}
+
+test("Parallel availability reads env and config keys while rejecting placeholders", async () => {
+	const home = await createHome({ parallelApiKey: "your-key" });
+	let child = runChild(`
+		const { isParallelAvailable } = await import(${JSON.stringify(parallelModuleUrl)});
+		console.log(String(isParallelAvailable()));
+	`, { HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "" });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(child.stdout.trim(), "false");
+
+	child = runChild(`
+		const { isParallelAvailable } = await import(${JSON.stringify(parallelModuleUrl)});
+		console.log(String(isParallelAvailable()));
+	`, { HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "pk_live_parallel_test_key" });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(child.stdout.trim(), "true");
+
+	const configHome = await createHome({ parallelApiKey: "pk_live_parallel_config_key" });
+	child = runChild(`
+		const { isParallelAvailable } = await import(${JSON.stringify(parallelModuleUrl)});
+		console.log(String(isParallelAvailable()));
+	`, { HOME: configHome, USERPROFILE: configHome, PARALLEL_API_KEY: "" });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(child.stdout.trim(), "true");
+});
+
+test("explicit Parallel search routes through Parallel API and maps results", async () => {
+	const home = await createHome({ provider: "parallel" });
+	const child = runChild(`
+		let captured = null;
+		globalThis.fetch = async (url, init) => {
+			captured = { url: String(url), headers: init.headers, body: JSON.parse(init.body) };
+			return new Response(JSON.stringify({
+				results: [{ title: "Parallel Docs", url: "https://docs.parallel.ai/search", excerpts: ["Parallel search excerpt"] }],
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("parallel search docs", { provider: "parallel", includeContent: true, numResults: 3, domainFilter: ["docs.parallel.ai", "-example.com"] });
+		console.log(JSON.stringify({ captured, result }));
+	`, { HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "pk_live_parallel_test_key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.captured.url, "https://api.parallel.ai/v1/search");
+	assert.equal(output.captured.headers["x-api-key"], "pk_live_parallel_test_key");
+	assert.deepEqual(output.captured.body.advanced_settings, {
+		max_results: 3,
+		source_policy: { include_domains: ["docs.parallel.ai"], exclude_domains: ["example.com"] },
+	});
+	assert.equal(output.result.provider, "parallel");
+	assert.deepEqual(output.result.results, [{ title: "Parallel Docs", url: "https://docs.parallel.ai/search", snippet: "Parallel search excerpt" }]);
+	assert.deepEqual(output.result.inlineContent, [{ url: "https://docs.parallel.ai/search", title: "Parallel Docs", content: "Parallel search excerpt", error: null }]);
+});
+
+test("Parallel extract retries full content when excerpts are too short", async () => {
+	const home = await createHome();
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url, init) => {
+			calls.push({ url: String(url), body: JSON.parse(init.body) });
+			if (calls.length === 1) {
+				return new Response(JSON.stringify({ results: [{ url: "https://example.com", title: "Short", excerpts: ["too short"] }] }), { status: 200 });
+			}
+			return new Response(JSON.stringify({ results: [{ url: "https://example.com", title: "Full", full_content: "# Full\\n" + "x".repeat(600) }] }), { status: 200 });
+		};
+		const { extractWithParallel } = await import(${JSON.stringify(parallelModuleUrl)});
+		const result = await extractWithParallel("https://example.com");
+		console.log(JSON.stringify({ calls, result }));
+	`, { HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "pk_live_parallel_test_key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.calls.length, 2);
+	assert.deepEqual(output.calls[1].body.advanced_settings, { full_content: true });
+	assert.equal(output.result.title, "Full");
+	assert.equal(output.result.error, null);
+	assert.match(output.result.content, /^# Full/);
+});
+
+test("fetch_content continues to Gemini when Parallel extract fails", async () => {
+	const home = await createHome({ geminiApiKey: "gemini-test-key" });
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			const urlText = String(url);
+			calls.push(urlText);
+			if (urlText === "https://example.com/app") {
+				return new Response("<html><body><script></script><script></script><script></script><script></script>Loading</body></html>", { status: 200, headers: { "content-type": "text/html" } });
+			}
+			if (urlText.startsWith("https://r.jina.ai/")) {
+				return new Response("", { status: 503 });
+			}
+			if (urlText === "https://api.parallel.ai/v1/extract") {
+				return new Response("parallel exploded", { status: 500 });
+			}
+			if (urlText.includes("generativelanguage.googleapis.com")) {
+				return new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text: "# Gemini fallback\\n" + "Recovered content ".repeat(20) }] } }] }), { status: 200, headers: { "content-type": "application/json" } });
+			}
+			throw new Error("Unexpected fetch " + urlText);
+		};
+		const { extractContent } = await import(${JSON.stringify(extractModuleUrl)});
+		const result = await extractContent("https://example.com/app");
+		console.log(JSON.stringify({ calls, result }));
+	`, { HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "pk_live_parallel_test_key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.ok(output.calls.includes("https://api.parallel.ai/v1/extract"));
+	assert.ok(output.calls.some((url) => url.includes("generativelanguage.googleapis.com")));
+	assert.equal(output.result.error, null);
+	assert.match(output.result.content, /Gemini fallback/);
+});


### PR DESCRIPTION
## Summary

Adds [Parallel](https://parallel.ai) as a first-class provider in pi-web-access — product code only (no orchestration/spine artifacts).

- **`web_search`**: explicit `provider: "parallel"` plus auto-chain fallback (Exa → Parallel → Perplexity → Gemini)
- **`fetch_content`**: Parallel Extract fallback when HTTP/Readability and Jina fail (before Gemini)
- **Curator UI**: Parallel provider button, tags, and disabled-state tooltips when the API key is missing
- **REST client** (`parallel.ts`): direct API calls — no `parallel-cli` subprocess dependency

## Commits

| # | Scope | Description |
|---|-------|-------------|
| 1 | `feat` | Provider client, search routing, extract fallback, curator wiring |
| 2 | `test` | Mappers, auto-chain, rate limits, `resolveProvider` edge cases |
| 3 | `docs` | README + CHANGELOG for config and fallback ordering |

## Files changed (9)

| Area | Files |
|------|-------|
| New provider client | `parallel.ts` |
| Search routing | `gemini-search.ts`, `index.ts` |
| Extract fallback | `extract.ts` |
| Curator UI | `curator-page.ts`, `curator-server.ts` |
| Docs | `README.md`, `CHANGELOG.md` |
| Tests | `test/parallel.test.mjs` |

## Configuration

Set `parallelApiKey` in `~/.pi/web-search.json` or `PARALLEL_API_KEY` env var. Unlike Exa MCP, Parallel requires an API key.

## Test plan

- [x] `npm test` — 31/31 pass
- [x] Explicit `provider: "parallel"` with key configured returns search results
- [x] Auto-chain tries Parallel after Exa, before Perplexity
- [x] `fetch_content` tries Parallel after Jina when key present
- [x] Missing key + explicit provider → clear error (no silent fallback)
- [x] Placeholder API keys rejected; config save invalidates availability cache
- [x] Client rate limit (10 req / 60s) shared across search and extract
- [x] Exa zero-config MCP unchanged