### PR TITLE
Fix curator timeout hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Supported parallel `web_search` curator tool calls with per-call browser and cancellation state.
+- Prevented curator sessions from hanging after searches finish when no browser connects, and finalized connected idle sessions once the curator timeout elapses.
 
 ## [0.11.0] - 2026-06-24
 

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -3360,7 +3360,10 @@ const SCRIPT = `(function() {
 
   setInterval(function() {
     if (submitted) return;
-    postJson("/heartbeat", {}).catch(function() {
+    postJson("/heartbeat", {
+      idleMs: Math.max(0, Date.now() - lastInteraction),
+      timeoutSec: timeoutSec,
+    }).catch(function() {
       // Heartbeat is best-effort.
     });
   }, 10000);

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -176,6 +176,9 @@ export function startCuratorServer(
 	} = options;
 	let browserConnected = false;
 	let lastHeartbeatAt = Date.now();
+	let stateChangedAt = Date.now();
+	let clientIdleMs: number | null = null;
+	let clientTimeoutSeconds = timeout;
 	let completed = false;
 	let watchdog: NodeJS.Timeout | null = null;
 	let state: ServerState = "SEARCHING";
@@ -197,6 +200,7 @@ export function startCuratorServer(
 		if (completed) return false;
 		completed = true;
 		state = "COMPLETED";
+		stateChangedAt = Date.now();
 		if (watchdog) {
 			clearInterval(watchdog);
 			watchdog = null;
@@ -217,6 +221,14 @@ export function startCuratorServer(
 		lastHeartbeatAt = Date.now();
 		browserConnected = true;
 	};
+
+	const getEffectiveTimeoutMs = (): number => Math.max(1000, Math.floor(clientTimeoutSeconds) * 1000);
+
+	const shouldTimeoutFromClientIdle = (): boolean => (
+		state === "RESULT_SELECTION" &&
+		clientIdleMs !== null &&
+		clientIdleMs >= getEffectiveTimeoutMs()
+	);
 
 	function validateToken(body: unknown, res: ServerResponse): boolean {
 		if (!body || typeof body !== "object") {
@@ -332,7 +344,18 @@ export function startCuratorServer(
 				if (!body) return;
 				if (!validateToken(body, res)) return;
 				touchHeartbeat();
+				const heartbeat = body as { idleMs?: unknown; timeoutSec?: unknown };
+				if (typeof heartbeat.timeoutSec === "number" && Number.isFinite(heartbeat.timeoutSec) && heartbeat.timeoutSec > 0) {
+					clientTimeoutSeconds = Math.min(600, Math.floor(heartbeat.timeoutSec));
+				}
+				if (typeof heartbeat.idleMs === "number" && Number.isFinite(heartbeat.idleMs) && heartbeat.idleMs >= 0) {
+					clientIdleMs = Math.floor(heartbeat.idleMs);
+				}
+				const timedOut = shouldTimeoutFromClientIdle();
 				sendJson(res, 200, { ok: true });
+				if (timedOut && markCompleted()) {
+					setImmediate(() => callbacks.onCancel("timeout"));
+				}
 				return;
 			}
 
@@ -578,10 +601,24 @@ export function startCuratorServer(
 			const url = `http://localhost:${addr.port}/?session=${sessionToken}`;
 
 			watchdog = setInterval(() => {
-				if (completed || !browserConnected) return;
+				if (completed) return;
+				if (!browserConnected) {
+					const noBrowserTimeoutMs = Math.max(5000, getEffectiveTimeoutMs());
+					if (state !== "RESULT_SELECTION") return;
+					if (Date.now() - stateChangedAt <= noBrowserTimeoutMs) return;
+					if (!markCompleted()) return;
+					setImmediate(() => callbacks.onCancel("timeout"));
+					return;
+				}
+				if (shouldTimeoutFromClientIdle()) {
+					if (!markCompleted()) return;
+					setImmediate(() => callbacks.onCancel("timeout"));
+					return;
+				}
 				if (Date.now() - lastHeartbeatAt <= STALE_THRESHOLD_MS) return;
+				const staleReason = state === "RESULT_SELECTION" ? "timeout" : "stale";
 				if (!markCompleted()) return;
-				setImmediate(() => callbacks.onCancel("stale"));
+				setImmediate(() => callbacks.onCancel(staleReason));
 			}, WATCHDOG_INTERVAL_MS);
 
 			resolve({
@@ -606,6 +643,7 @@ export function startCuratorServer(
 					if (completed) return;
 					sendSSE("done", {});
 					state = "RESULT_SELECTION";
+					stateChangedAt = Date.now();
 				},
 				getConnectionState: () => ({
 					browserConnected,

--- a/index.ts
+++ b/index.ts
@@ -266,6 +266,7 @@ interface PendingCurate {
 	summaryModels: Array<{ value: string; label: string }>;
 	defaultSummaryModel: string | null;
 	timeoutSeconds: number;
+	curatorUrl?: string;
 	onUpdate: ((update: { content: Array<{ type: string; text: string }>; details?: Record<string, unknown> }) => void) | undefined;
 	signal: AbortSignal | undefined;
 	abortSearches: () => void;
@@ -955,7 +956,7 @@ export default function (pi: ExtensionAPI) {
 						if (pendingCurates.get(callId) !== pc) throw new Error("Curator session is no longer active.");
 						pc.onUpdate?.({
 							content: [{ type: "text", text: "Generating summary draft..." }],
-							details: { phase: "generating-summary", progress: 0.9 },
+							details: { phase: "generating-summary", progress: 0.9, curatorUrl: pc.curatorUrl, timeoutSeconds: pc.timeoutSeconds, shortcut: curateKey },
 						});
 						const draft = await generateSummaryForSelectedIndices(
 							selectedQueryIndices,
@@ -968,7 +969,7 @@ export default function (pi: ExtensionAPI) {
 						if (pendingCurates.get(callId) !== pc) throw new Error("Curator session is no longer active.");
 						pc.onUpdate?.({
 							content: [{ type: "text", text: "Summary draft ready — waiting for approval..." }],
-							details: { phase: "waiting-for-approval", progress: 1 },
+							details: { phase: "waiting-for-approval", progress: 1, curatorUrl: pc.curatorUrl, timeoutSeconds: pc.timeoutSeconds, shortcut: curateKey },
 						});
 						return draft;
 					},
@@ -1085,6 +1086,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			activeCurators.set(callId, handle);
+			pc.curatorUrl = handle.url;
 
 			for (const [qi, data] of pc.searchResults) {
 				if (data.error) {
@@ -1101,7 +1103,13 @@ export default function (pi: ExtensionAPI) {
 
 			pc.onUpdate?.({
 				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],
-				details: { phase: "curating", progress: searchesComplete ? 1 : 0.5 },
+				details: {
+					phase: "curating",
+					progress: searchesComplete ? 1 : 0.5,
+					curatorUrl: handle.url,
+					timeoutSeconds: pc.timeoutSeconds,
+					shortcut: curateKey,
+				},
 			});
 
 			const open = platform() === "darwin" ? await getGlimpseOpen() : null;
@@ -1364,7 +1372,13 @@ export default function (pi: ExtensionAPI) {
 					curator.searchesDone();
 					pc.onUpdate?.({
 						content: [{ type: "text", text: "All searches complete — waiting for summary approval in browser..." }],
-						details: { phase: "curating", progress: 1 },
+						details: {
+							phase: "curating",
+							progress: 1,
+							curatorUrl: pc.curatorUrl,
+							timeoutSeconds: pc.timeoutSeconds,
+							shortcut: curateKey,
+						},
 					});
 				}
 
@@ -1471,6 +1485,9 @@ export default function (pi: ExtensionAPI) {
 				browserConnected?: boolean;
 				lastHeartbeatAgeMs?: number | null;
 				cancelledQueries?: import("./render-search-error.ts").CancelledQueryDetail[];
+				curatorUrl?: string;
+				timeoutSeconds?: number;
+				shortcut?: string;
 				summary?: {
 					text: string;
 					workflow: CuratorWorkflow;
@@ -1484,8 +1501,24 @@ export default function (pi: ExtensionAPI) {
 			};
 
 			if (isPartial) {
-				if (details?.phase === "curating") {
-					return new Text(theme.fg("accent", "waiting for summary approval..."), 0, 0);
+				if (details?.phase === "curating" || details?.phase === "waiting-for-approval" || details?.phase === "generating-summary") {
+					const phaseText = details?.phase === "generating-summary"
+						? "generating summary draft..."
+						: details?.phase === "waiting-for-approval"
+							? "summary draft ready; approve in browser..."
+							: "waiting for summary approval in browser...";
+					const lines = [theme.fg("accent", phaseText)];
+					if (details?.curatorUrl) {
+						lines.push(theme.fg("muted", `  ${details.curatorUrl}`));
+					}
+					const timeout = typeof details?.timeoutSeconds === "number" ? details.timeoutSeconds : undefined;
+					const shortcut = typeof details?.shortcut === "string" ? details.shortcut : curateKey;
+					if (timeout) {
+						lines.push(theme.fg("dim", `  auto-submits after ${timeout}s idle; ${shortcut} reopens`));
+					} else {
+						lines.push(theme.fg("dim", `  ${shortcut} reopens`));
+					}
+					return new Text(lines.join("\n"), 0, 0);
 				}
 				if (details?.phase === "searching") {
 					const progress = details?.progress ?? 0;

--- a/test/curator-server-timeout.test.mjs
+++ b/test/curator-server-timeout.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { access, unlink, writeFile } from "node:fs/promises";
+import { after, test } from "node:test";
+
+const curatorPageShim = new URL("../curator-page.js", import.meta.url);
+let wroteCuratorPageShim = false;
+
+const TEST_TIMEOUT_MS = 8000;
+
+async function loadServer() {
+	try {
+		await access(curatorPageShim);
+	} catch {
+		await writeFile(
+			curatorPageShim,
+			'export { generateCuratorPage } from "./curator-page.ts";\n',
+			"utf8",
+		);
+		wroteCuratorPageShim = true;
+	}
+
+	return import(`../curator-server.ts?test=${Date.now()}`);
+}
+
+after(async () => {
+	if (!wroteCuratorPageShim) return;
+	await unlink(curatorPageShim).catch(() => {});
+});
+
+function baseOptions(timeout = 1) {
+	return {
+		queries: ["test query"],
+		sessionToken: "test-token",
+		timeout,
+		availableProviders: { openai: false, brave: false, perplexity: false, exa: true, gemini: false },
+		defaultProvider: "exa",
+		searchProvider: "exa",
+		summaryModels: [],
+		defaultSummaryModel: null,
+	};
+}
+
+function baseCallbacks(resolveCancel) {
+	return {
+		onSubmit: () => {},
+		onCancel: resolveCancel,
+		onProviderChange: () => {},
+		onAddSearch: async () => ({ answer: "", results: [], provider: "exa" }),
+		onSummarize: async () => ({
+			summary: "",
+			meta: { model: null, durationMs: 0, tokenEstimate: 0, fallbackUsed: true },
+		}),
+		onRewriteQuery: async (query) => query,
+	};
+}
+
+function withTimeout(promise, label) {
+	return Promise.race([
+		promise,
+		new Promise((_, reject) => {
+			setTimeout(() => reject(new Error(`${label} timed out`)), TEST_TIMEOUT_MS);
+		}),
+	]);
+}
+
+test("curator times out when searches finish but no browser connects", async () => {
+	const { startCuratorServer } = await loadServer();
+	let resolveCancel;
+	const cancelPromise = new Promise((resolve) => { resolveCancel = resolve; });
+	const handle = await startCuratorServer(baseOptions(1), baseCallbacks(resolveCancel));
+
+	try {
+		handle.pushResult(0, { answer: "answer", results: [], provider: "exa" });
+		handle.searchesDone();
+
+		const reason = await withTimeout(cancelPromise, "no-browser timeout");
+		assert.equal(reason, "timeout");
+	} finally {
+		handle.close();
+	}
+});
+
+test("curator heartbeat timeout finalizes connected idle browser sessions", async () => {
+	const { startCuratorServer } = await loadServer();
+	let resolveCancel;
+	const cancelPromise = new Promise((resolve) => { resolveCancel = resolve; });
+	const handle = await startCuratorServer(baseOptions(20), baseCallbacks(resolveCancel));
+
+	try {
+		await fetch(handle.url);
+		handle.pushResult(0, { answer: "answer", results: [], provider: "exa" });
+		handle.searchesDone();
+
+		const response = await fetch(new URL("/heartbeat", handle.url), {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ token: "test-token", idleMs: 21000, timeoutSec: 20 }),
+		});
+		assert.equal(response.status, 200);
+
+		const reason = await withTimeout(cancelPromise, "idle heartbeat timeout");
+		assert.equal(reason, "timeout");
+	} finally {
+		handle.close();
+	}
+});


### PR DESCRIPTION
## Summary

- finalize curator sessions server-side when searches finish but no browser ever connects
- mirror the browser idle timeout through heartbeat payloads so connected pages cannot keep a tool call pending forever if they fail to submit
- show the curator URL, idle timeout, and reopen shortcut in Pi while waiting for summary approval

## Tests

- npm test

## Notes

This preserves the existing timeout fallback behavior: timeout completion routes through `onCancel("timeout")`, so callers use the deterministic summary fallback when no approved draft is available.