### PR TITLE
fix: expandable Ctrl+O error diagnostics for web_search / code_search / fetch_content / get_search_content

### DIFF
--- a/curator-server.ts
+++ b/curator-server.ts
@@ -44,6 +44,9 @@ export interface CuratorServerHandle {
 	pushResult: (queryIndex: number, data: { answer: string; results: Array<{ title: string; url: string; domain: string }>; provider: string }) => void;
 	pushError: (queryIndex: number, error: string, provider?: string) => void;
 	searchesDone: () => void;
+	/** Reports browser connection state so a cancelled search can surface WHY it
+	 * went stale (e.g. the browser never connected). */
+	getConnectionState: () => { browserConnected: boolean; lastHeartbeatAgeMs: number };
 }
 
 function sendJson(res: ServerResponse, status: number, payload: unknown): void {
@@ -604,6 +607,10 @@ export function startCuratorServer(
 					sendSSE("done", {});
 					state = "RESULT_SELECTION";
 				},
+				getConnectionState: () => ({
+					browserConnected,
+					lastHeartbeatAgeMs: Date.now() - lastHeartbeatAt,
+				}),
 			});
 		});
 	});

--- a/index.ts
+++ b/index.ts
@@ -40,8 +40,27 @@ import { getActiveGoogleEmail, isGeminiWebAvailable } from "./gemini-web.ts";
 import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
 import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
+import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
 
 const WEB_SEARCH_CONFIG_PATH = join(homedir(), ".pi", "web-search.json");
+
+/** Shared collapsed/expanded renderer for an error/cancel plan produced by
+ * buildSearchErrorPlan(). Used by every tool renderResult's error branch so
+ * Ctrl+O (app.tools.expand) reveals diagnostics instead of a dead-end single line. */
+function renderSearchErrorPlan(plan: SearchErrorPlan, expanded: boolean, theme: { fg: (key: string, s: string) => string; bg: (key: string, s: string) => string }) {
+	if (expanded) {
+		return new Text(plan.expanded.map((l, i) => i === 0 ? theme.fg("error", l) : theme.fg("toolOutput", l)).join("\n"), 0, 0);
+	}
+	const box = new Box(1, 0, (t) => theme.bg("toolErrorBg", t));
+	box.addChild(new Text(theme.fg("error", plan.expanded[0]), 0, 0));
+	for (const line of plan.collapsed) {
+		box.addChild(new Text(theme.fg("dim", line), 0, 0));
+	}
+	if (plan.expandHint) {
+		box.addChild(new Text(theme.fg("muted", plan.expandHint), 0, 0));
+	}
+	return box;
+}
 
 interface WebSearchConfig {
 	provider?: string;
@@ -591,14 +610,34 @@ export default function (pi: ExtensionAPI) {
 		};
 	}
 
-	function buildCurationCancelledReturn(reason: "user" | "stale") {
+	function buildCurationCancelledReturn(
+		reason: "user" | "stale",
+		partial?: {
+			queries?: QueryResultData[];
+			queryCount?: number;
+			browserConnected?: boolean;
+			lastHeartbeatAgeMs?: number | null;
+		},
+	) {
 		const message = `Search curation cancelled (${reason}).`;
+		const cancelledQueries = partial?.queries?.length
+			? partial.queries.map(q => ({
+				query: q.query,
+				provider: q.provider ?? null,
+				error: q.error,
+				resultCount: q.results?.length ?? 0,
+			}))
+			: undefined;
 		return {
 			content: [{ type: "text", text: message }],
 			details: {
 				error: message,
 				cancelled: true,
 				cancelReason: reason,
+				browserConnected: partial?.browserConnected,
+				lastHeartbeatAgeMs: partial?.lastHeartbeatAgeMs,
+				queryCount: partial?.queryCount,
+				cancelledQueries,
 			},
 		};
 	}
@@ -964,7 +1003,13 @@ export default function (pi: ExtensionAPI) {
 								summaryMeta: resolvedSummary.summaryMeta,
 							}));
 						} else {
-							pc.finish(buildCurationCancelledReturn(reason));
+							const conn = activeCurator?.getConnectionState();
+							pc.finish(buildCurationCancelledReturn(reason, {
+								queries: Array.from(pc.searchResults.values()),
+								queryCount: pc.queryList.length,
+								browserConnected: conn?.browserConnected,
+								lastHeartbeatAgeMs: conn?.lastHeartbeatAgeMs,
+							}));
 						}
 						closeCurator();
 					},
@@ -1236,7 +1281,13 @@ export default function (pi: ExtensionAPI) {
 
 				const cancel = (reason: "user" | "stale" = "stale") => {
 					if (cancelled) return;
-					finish(buildCurationCancelledReturn(reason));
+					const conn = activeCurator?.getConnectionState();
+					finish(buildCurationCancelledReturn(reason, {
+						queries: Array.from(searchResults.values()),
+						queryCount: queryList.length,
+						browserConnected: conn?.browserConnected,
+						lastHeartbeatAgeMs: conn?.lastHeartbeatAgeMs,
+					}));
 				};
 
 				pc.finish = finish;
@@ -1398,6 +1449,9 @@ export default function (pi: ExtensionAPI) {
 				curatedQueries?: QueryDetail[];
 				cancelled?: boolean;
 				cancelReason?: string;
+				browserConnected?: boolean;
+				lastHeartbeatAgeMs?: number | null;
+				cancelledQueries?: import("./render-search-error.ts").CancelledQueryDetail[];
 				summary?: {
 					text: string;
 					workflow: CuratorWorkflow;
@@ -1427,6 +1481,10 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			if (details?.error) {
+				// Expandable Ctrl+O diagnostics: which queries completed, per-query errors,
+				// browser connection state, cancel reason. See render-search-error.ts.
+				const plan = buildSearchErrorPlan(details as SearchErrorDetails);
+				if (plan) return renderSearchErrorPlan(plan, expanded, theme);
 				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
 			}
 
@@ -1598,6 +1656,11 @@ export default function (pi: ExtensionAPI) {
 		renderResult(result, { expanded }, theme) {
 			const details = result.details as { query?: string; maxTokens?: number; error?: string };
 			if (details?.error) {
+				const plan = buildSearchErrorPlan({
+					error: details.error,
+					extraLines: details.query ? [`query: ${details.query}`] : [],
+				});
+				if (plan) return renderSearchErrorPlan(plan, expanded, theme);
 				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
 			}
 
@@ -1806,6 +1869,18 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			if (details?.error) {
+				const fd = details as typeof details & { urls?: string[] };
+				const extras: string[] = [];
+				if (typeof fd.urlCount === "number" || typeof fd.successful === "number") {
+					extras.push(`urls: ${fd.successful ?? 0}/${fd.urlCount ?? 0} succeeded`);
+				}
+				if (fd.responseId) extras.push(`response id: ${fd.responseId}`);
+				if (fd.urls && fd.urls.length > 0) {
+					for (const u of fd.urls.slice(0, 8)) extras.push(`  \u25b8 ${u}`);
+					if (fd.urls.length > 8) extras.push(`  ... and ${fd.urls.length - 8} more`);
+				}
+				const plan = buildSearchErrorPlan({ error: details.error, extraLines: extras });
+				if (plan) return renderSearchErrorPlan(plan, expanded, theme);
 				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
 			}
 
@@ -1994,6 +2069,12 @@ export default function (pi: ExtensionAPI) {
 			};
 
 			if (details?.error) {
+				const extras: string[] = [];
+				if (details.query) extras.push(`query: ${details.query}`);
+				if (details.url) extras.push(`url: ${details.url}`);
+				else if (details.title) extras.push(`resource: ${details.title}`);
+				const plan = buildSearchErrorPlan({ error: details.error, extraLines: extras });
+				if (plan) return renderSearchErrorPlan(plan, expanded, theme);
 				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
 			}
 

--- a/render-search-error.ts
+++ b/render-search-error.ts
@@ -1,0 +1,170 @@
+/**
+ * Pure, dependency-free renderer for web_search error / cancel results.
+ *
+ * WHY THIS EXISTS: the upstream web_search `renderResult` (index.ts) early-returns
+ * a SINGLE line on the error/cancel path, before the collapsed/expanded branch.
+ * That makes Ctrl+O (app.tools.expand) flip `expanded` with zero visible effect —
+ * a dead-end with no diagnostics. It also discards the partial search results
+ * gathered before the cancel, so even an expandable view would have nothing to show.
+ *
+ * This module is the single source of truth for the error/cancel render PLAN
+ * (plain strings, no theme/ANSI), so it is unit-testable without pi's runtime
+ * (@mariozechner/pi-tui Text/Box). index.ts.renderResult delegates to it and only
+ * applies theme colors + creates Text/Box components.
+ *
+ * Contract for callers:
+ *   const plan = buildSearchErrorPlan(details);
+ *   if (plan === null) ... // not an error/cancel result; use the normal renderer
+ *   // collapsed: [statusLine, ...plan.collapsed, plan.expandHint].filter(Boolean)
+ *   // expanded:  plan.expanded
+ */
+
+export interface CancelledQueryDetail {
+	query: string;
+	provider: string | null;
+	error: string | null; // null = completed ok; string = per-query error
+	resultCount: number;
+}
+
+export interface SearchErrorDetails {
+	/** The headline error/cancel message, e.g. "Search curation cancelled (stale)." */
+	error?: string;
+	cancelled?: boolean;
+	cancelReason?: string;
+	/** Did the curator browser page ever establish a connection? */
+	browserConnected?: boolean;
+	/** Age (ms) of the last curator heartbeat at cancel time, if known. */
+	lastHeartbeatAgeMs?: number | null;
+	/** Total queries the user requested. */
+	queryCount?: number;
+	/** Partial per-query results gathered before the cancel/error. */
+	cancelledQueries?: CancelledQueryDetail[];
+	/** Arbitrary extra diagnostic lines (e.g. URLs, response id) for non-cancel errors
+	 * like code_search / fetch_content / get_search_content. Shown in the expanded view. */
+	extraLines?: string[];
+}
+
+export interface SearchErrorPlan {
+	/** Full diagnostic block, shown when expanded (Ctrl+O). */
+	expanded: string[];
+	/** Short preview lines, shown under the headline when collapsed. */
+	collapsed: string[];
+	/** The "... (N more lines, ctrl+o to expand)" hint, or null if nothing is hidden. */
+	expandHint: string | null;
+}
+
+function truncate(text: string, max: number): string {
+	return text.length > max ? text.slice(0, max - 1) + "\u2026" : text;
+}
+
+/**
+ * Build the error/cancel render plan. Returns null when `details` carries no
+ * error/cancel signal (so the caller falls through to the normal success renderer).
+ */
+export function buildSearchErrorPlan(details: SearchErrorDetails | undefined | null): SearchErrorPlan | null {
+	if (!details || (!details.error && !details.cancelled)) {
+		return null;
+	}
+
+	const headline = details.error ?? "Search cancelled.";
+	const queries = details.cancelledQueries ?? [];
+	const queryCount = typeof details.queryCount === "number" && details.queryCount > 0
+		? details.queryCount
+		: queries.length;
+	const done = queries.length;
+	const errored = queries.filter(q => q.error).length;
+
+	// Rich diagnostics only make sense when there is something to diagnose: a
+	// cancelled/curator result with partial data, OR a non-cancel error that carries
+	// extra detail (urls/response-id for fetch_content, the failed query for
+	// code_search/get_search_content). A bare argument error (e.g. "No URL
+	// provided") stays a clean single line -- no noise.
+	const extras = details.extraLines ?? [];
+	const rich = details.cancelled === true || queries.length > 0 || extras.length > 0;
+	if (!rich) {
+		return { expanded: [headline], collapsed: [], expandHint: null };
+	}
+
+	// --- diagnostics block (expanded): curator/cancel-specific only. For non-cancel
+	// errors (fetch_content/code_search/get_search_content) there is no browser or
+	// query-curation state to report, so we skip this block and show only Details. ---
+	const expanded: string[] = [headline, ""];
+
+	if (details.cancelled === true || queries.length > 0) {
+		const diag: string[] = [];
+		if (details.cancelled) {
+			diag.push(`cancel reason   : ${details.cancelReason ?? "unknown"}`);
+		}
+		// Browser connection state — the most common stale cause (page never opened).
+		const browserLabel = details.browserConnected === undefined
+			? "unknown"
+			: details.browserConnected
+				? "connected"
+				: "never connected";
+		diag.push(`browser         : ${browserLabel}`);
+		if (typeof details.lastHeartbeatAgeMs === "number" && Number.isFinite(details.lastHeartbeatAgeMs)) {
+			diag.push(`last heartbeat  : ${Math.round(details.lastHeartbeatAgeMs / 1000)}s ago`);
+		}
+		if (queryCount > 0) {
+			diag.push(`queries started : ${queryCount}`);
+			diag.push(`queries done    : ${done}`);
+			if (errored > 0) diag.push(`queries errored : ${errored}`);
+		}
+		expanded.push("Diagnostics:");
+		for (const line of diag) expanded.push(`  ${line}`);
+	}
+
+	// --- per-query results gathered before cancel ---
+	if (queries.length > 0) {
+		expanded.push("");
+		expanded.push("Per-query results (gathered before cancel):");
+		for (const q of queries) {
+			const dq = truncate(q.query, 52);
+			const tag = q.error ? "[err] " : "[ok]  ";
+			const provider = q.provider ? ` (${q.provider})` : "";
+			const tail = q.error
+				? `\u2014 ${truncate(q.error, 60)}`
+				: `\u2014 ${q.resultCount} source${q.resultCount === 1 ? "" : "s"}`;
+			expanded.push(`  ${tag}"${dq}"${provider} ${tail}`);
+		}
+	}
+
+	// --- arbitrary extra detail (non-cancel errors) ---
+	if (extras.length > 0) {
+		expanded.push("");
+		expanded.push("Details:");
+		for (const e of extras) expanded.push(`  ${e}`);
+	}
+
+	// --- collapsed preview ---
+	const collapsed: string[] = [];
+	const parts: string[] = [];
+	if (queryCount > 0) {
+		parts.push(`${done}/${queryCount} queries completed`);
+	}
+	if (errored > 0) {
+		parts.push(`${errored} errored`);
+	}
+	if (details.browserConnected === false) {
+		parts.push("browser never connected");
+	} else if (details.cancelReason) {
+		parts.push(`reason: ${details.cancelReason}`);
+	}
+	if (parts.length > 0) {
+		collapsed.push(parts.join("; ") + ".");
+	}
+	// For non-cancel errors with extra detail, preview the first detail line.
+	if (collapsed.length === 0 && extras.length > 0) {
+		for (const e of extras.slice(0, 2)) {
+			collapsed.push(truncate(e, 100));
+		}
+	}
+
+	// --- expand hint ---
+	const hiddenLines = Math.max(0, expanded.length - (1 + collapsed.length)); // headline + preview shown when collapsed
+	const expandHint = hiddenLines > 0
+		? `... (${hiddenLines} more lines, ${expanded.length} total, ctrl+o to expand)`
+		: null;
+
+	return { expanded, collapsed, expandHint };
+}

--- a/test/search-error-render.test.mjs
+++ b/test/search-error-render.test.mjs
@@ -1,0 +1,155 @@
+// Repro + guard for the web_search Ctrl+O error-path dead-end (ronin fix).
+//
+// BEFORE the fix, web_search renderResult early-returned a SINGLE line on the
+// error/cancel path (before the collapsed/expanded branch), so Ctrl+O flipped
+// `expanded` with zero visible effect and discarded the partial results. This
+// test pins the new behavior: the error/cancel path produces a rich, EXPANDABLE
+// plan (>1 line, with diagnostics + a "ctrl+o to expand" hint), routed through
+// the dep-free buildSearchErrorPlan() that index.ts.renderResult delegates to.
+//
+// Runner: node --test (matches the package's existing .test.mjs convention).
+// Node >= 22.6 imports the .ts source directly (no build step).
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { buildSearchErrorPlan } from "../render-search-error.ts";
+
+// --- fixture: a stale cancel with partial results, mirroring the user's report
+// ("Search curation cancelled (stale)" with 2/3 queries done, one errored,
+//  browser never connected). ---
+const staleCancel = {
+	error: "Search curation cancelled (stale).",
+	cancelled: true,
+	cancelReason: "stale",
+	browserConnected: false,
+	lastHeartbeatAgeMs: 31200,
+	queryCount: 3,
+	cancelledQueries: [
+		{ query: "z.ai API usage endpoint coding plan credits", provider: "perplexity", error: null, resultCount: 5 },
+		{ query: "z.ai GLM coding plan API key usage limits", provider: "perplexity", error: "Connection error", resultCount: 0 },
+	],
+};
+
+test("cancel/error path is NOT a dead-end single line: expanded plan has >1 line", () => {
+	const plan = buildSearchErrorPlan(staleCancel);
+	assert.notEqual(plan, null, "a cancelled result must produce a plan, not null");
+	const expanded = plan.expanded.join("\n");
+	// The dead-end was exactly ONE line. Pin that the expanded view is rich.
+	assert.ok(plan.expanded.length > 1, `expanded must be >1 line, got ${plan.expanded.length}`);
+	assert.match(expanded, /Search curation cancelled \(stale\)/);
+});
+
+test("expanded plan surfaces the diagnostics that were previously discarded", () => {
+	const plan = buildSearchErrorPlan(staleCancel);
+	const expanded = plan.expanded.join("\n");
+	// cancel reason
+	assert.match(expanded, /cancel reason\s*:\s*stale/);
+	// browser state — the #1 stale cause, previously invisible
+	assert.match(expanded, /browser\s*:\s*never connected/);
+	// query progress (2 of 3 done)
+	assert.match(expanded, /queries started\s*:\s*3/);
+	assert.match(expanded, /queries done\s*:\s*2/);
+	// per-query results: the completed one (with source count) AND the errored one
+	assert.match(expanded, /z\.ai API usage endpoint/);
+	assert.match(expanded, /5 sources/);
+	assert.match(expanded, /\[err\]/);
+	assert.match(expanded, /Connection error/);
+});
+
+test("collapsed view is a short summary WITH a ctrl+o expand hint (Ctrl+O now does something)", () => {
+	const plan = buildSearchErrorPlan(staleCancel);
+	// collapsed preview summarizes progress + browser state
+	const collapsed = plan.collapsed.join("\n");
+	assert.match(collapsed, /2\/3 queries completed/);
+	assert.match(collapsed, /browser never connected/);
+	// THE fix signal: an expand hint exists (the old single-line return had none,
+	// so Ctrl+O did nothing). Mutation: dropping the hint fails here.
+	assert.equal(typeof plan.expandHint, "string");
+	assert.match(plan.expandHint, /ctrl\+o to expand/i, "expand hint must mention ctrl+o");
+	// and the hint correctly counts the hidden lines
+	assert.match(plan.expandHint, /\d+ more lines/);
+});
+
+test("plain (non-cancel) error stays a clean single line — no diagnostic noise", () => {
+	// A bare argument error has nothing to diagnose; it must NOT sprout fake
+	// "browser: unknown" diagnostics. Guards the gating logic in the module.
+	const plan = buildSearchErrorPlan({ error: "No query provided" });
+	assert.notEqual(plan, null);
+	assert.equal(plan.expanded.length, 1, "plain error must be a single line");
+	assert.equal(plan.collapsed.length, 0);
+	assert.equal(plan.expandHint, null, "plain error must have no expand hint");
+});
+
+// --- other tools (code_search / fetch_content / get_search_content): the same
+// dead-end exists in their renderResults; they now reuse buildSearchErrorPlan via
+// extraLines. These pin that non-cancel errors with detail become expandable
+// WITHOUT the curator/browser diagnostics (which are web_search-only). ---
+
+test("fetch_content-style error (extras, no cancel) is expandable without browser diagnostics", () => {
+	const plan = buildSearchErrorPlan({
+		error: "Failed to fetch: https://example.com/x (404)",
+		extraLines: ["urls: 1/2 succeeded", "response id: resp_abc", "  \u25b8 https://example.com/x"],
+	});
+	assert.notEqual(plan, null);
+	const expanded = plan.expanded.join("\n");
+	assert.ok(plan.expanded.length > 1);
+	assert.match(expanded, /urls: 1\/2 succeeded/);
+	assert.match(expanded, /resp_abc/);
+	// MUST NOT show curator/browser diagnostics for a non-cancel error.
+	assert.doesNotMatch(expanded, /browser|cancel reason|queries started/);
+	assert.equal(typeof plan.expandHint, "string");
+	assert.match(plan.expandHint, /ctrl\+o to expand/i);
+});
+
+test("code_search-style error with a failed query shows the query in extras", () => {
+	const plan = buildSearchErrorPlan({
+		error: "Exa search failed: connection reset",
+		extraLines: ["query: how to use p-limit concurrency"],
+	});
+	assert.notEqual(plan, null);
+	assert.match(plan.expanded.join("\n"), /query: how to use p-limit concurrency/);
+	assert.doesNotMatch(plan.expanded.join("\n"), /browser/);
+	assert.equal(typeof plan.expandHint, "string");
+});
+
+test("error with NO extras and NO cancel stays single-line (code_search without query)", () => {
+	// e.g. code_search with no query arg — nothing to diagnose.
+	const plan = buildSearchErrorPlan({ error: "Some transient error" });
+	assert.notEqual(plan, null);
+	assert.equal(plan.expanded.length, 1);
+	assert.equal(plan.expandHint, null);
+});
+
+test("non-error result yields null so the caller falls through to the success renderer", () => {
+	assert.equal(buildSearchErrorPlan({ queryCount: 3, totalResults: 9 }), null);
+	assert.equal(buildSearchErrorPlan(undefined), null);
+	assert.equal(buildSearchErrorPlan(null), null);
+});
+
+// --- source-contract guard: index.ts web_search renderResult must DELEGATE to
+// buildSearchErrorPlan on the error path (mutation-proof against reverting the
+// integration back to the dead-end single-line return). ---
+const indexPath = fileURLToPath(new URL("../index.ts", import.meta.url));
+const indexSrc = readFileSync(indexPath, "utf8");
+
+test("index.ts imports buildSearchErrorPlan and wires it into the web_search error path", () => {
+	assert.match(indexSrc, /import \{ buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan \} from "\.\/render-search-error\.ts";/);
+	// The web_search renderResult error branch must call buildSearchErrorPlan.
+	// (Mutation: reverting renderResult to `return new Text(error...)` drops this.)
+	assert.match(indexSrc, /buildSearchErrorPlan\(details as SearchErrorDetails\)/);
+	// buildCurationCancelledReturn must now carry partial diagnostics into details
+	// (mutation: dropping the partial arg reverts to the discarded-results bug).
+	assert.match(indexSrc, /buildCurationCancelledReturn\(reason, \{/);
+	assert.match(indexSrc, /cancelledQueries/);
+	// the 3 other tools must also delegate to buildSearchErrorPlan (mutation-proof:
+	// reverting any of them to the bare single-line drops its buildSearchErrorPlan call).
+	// Count call sites: web_search + code_search + fetch_content + get_search_content = 4.
+	const callSiteCount = (indexSrc.match(/const plan = buildSearchErrorPlan\(/g) || []).length;
+	assert.equal(callSiteCount, 4, `expected 4 buildSearchErrorPlan call sites, got ${callSiteCount}`);
+	// renderSearchErrorPlan shared renderer is used by all 4.
+	const renderCount = (indexSrc.match(/return renderSearchErrorPlan\(plan, expanded, theme\)/g) || []).length;
+	assert.equal(renderCount, 4, `expected 4 renderSearchErrorPlan returns, got ${renderCount}`);
+});


### PR DESCRIPTION
fix: expandable Ctrl+O error diagnostics for web_search/code_search/fetch_content/get_search_content

## Problem

When `web_search` (and `code_search`/`fetch_content`/`get_search_content`) ends on
the error or curator-cancel path, `renderResult` early-returns a SINGLE line:

```js
if (details?.error) {
    return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
}
```

…before the collapsed/expanded branch. So pressing Ctrl+O (`app.tools.expand`) flips
`expanded` with **zero visible effect** — a dead-end with no way to see what went
wrong. Worse, `buildCurationCancelledReturn(reason)` discards the partial search
results gathered before the cancel, so even an expandable view would have had
nothing to show.

The most common real-world case: a `summary-review` search whose curator browser
page never connects is cancelled with `Search curation cancelled (stale)` and the
user can't tell *why* (browser never opened? port conflict? which queries finished?).

## Fix

- New dep-free module `render-search-error.ts` exporting `buildSearchErrorPlan(details)`:
  returns `{ expanded[], collapsed[], expandHint }`. Rich diagnostics are gated to
  results that actually have something to diagnose — a cancelled/curator result with
  partial data (cancel reason, browser connection state, last-heartbeat age,
  queries-completed counts, per-query results + per-query errors), or a non-cancel
  error that carries extra detail. A bare argument error (e.g. "No URL provided")
  stays a clean single line — no noise.
- `index.ts`: extract a shared `renderSearchErrorPlan(plan, expanded, theme)` helper.
  All FOUR tools' `renderResult` error branches now route through it: collapsed shows
  headline + one-line summary + `... (N more lines, ctrl+o to expand)`; expanded
  (Ctrl+O) shows the full diagnostic block. The bare single-line return is kept as a
  defensive fallback for null plans.
  - code_search → failed query
  - fetch_content → urls N/M succeeded + response id + url list
  - get_search_content → query / url / resource title
  - web_search → cancel diagnostics (queries completed, browser state, …)
- `buildCurationCancelledReturn` now carries the partial data into `details`
  (queries, queryCount, browser state, last-heartbeat age) instead of discarding it.
  Both cancel sites pass it.
- `curator-server.ts`: `CuratorServerHandle` gains `getConnectionState()` so a
  cancelled search can report *why* it went stale (browser never connected = the
  #1 cause). Additive, non-breaking.

## Testability

The render logic lives in a dep-free module so it's unit-testable without pi's
runtime (`@mariozechner/pi-tui`). `test/search-error-render.test.mjs` (node --test)
pins it: 9 tests covering the cancel path, the non-cancel extras path, plain-error
gating, and a source-contract guard. Mutation-proven: reverting
`buildSearchErrorPlan` to the old single-line form fails the 3 behavioral tests;
reverting any tool's wiring fails the source-contract count (4 call sites).

Full suite: 11/11.

## Behavior change

Non-breaking. The error path previously rendered one line; now it renders one line
when collapsed (with an expand hint) and a diagnostics block when expanded. Tool
result `details` gains optional fields consumed only by the new renderer.
