### PR TITLE
Fix masked YouTube Gemini API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Aligned custom message display values and widget clearing with the current Pi extension API types.
+- Surfaced real YouTube Gemini API failures instead of replacing them with the generic Chrome/API-key guidance.
 
 ### Removed
 - Removed the committed `package-lock.json` from the extension package and ignored future lockfiles.

--- a/extract.ts
+++ b/extract.ts
@@ -396,9 +396,7 @@ export async function extractContent(
 		} catch (err) {
 			const message = errorMessage(err);
 			if (isAbortError(err)) return abortedResult(url);
-			if (isConfigParseError(err)) {
-				return { url, title: "", content: "", error: message };
-			}
+			return { url, title: "", content: "", error: message };
 		}
 		return {
 			url,

--- a/test/youtube-extract-errors.test.mjs
+++ b/test/youtube-extract-errors.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const extractorUrl = new URL("../extract.ts", import.meta.url).href;
+
+test("YouTube extraction surfaces Gemini API errors", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-youtube-errors-"));
+	const env = {
+		...process.env,
+		HOME: home,
+		USERPROFILE: home,
+		GEMINI_API_KEY: "test-gemini-key",
+		PERPLEXITY_API_KEY: "",
+	};
+	delete env.PI_ALLOW_BROWSER_COOKIES;
+	delete env.FEYNMAN_ALLOW_BROWSER_COOKIES;
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl),
+		encoding: "utf8",
+		env,
+	});
+
+	assert.equal(child.status, 0, child.stderr || child.stdout);
+	const result = JSON.parse(child.stdout);
+	assert.match(result.error, /Gemini API error 503/);
+	assert.doesNotMatch(result.error, /Sign into Google in Chrome/);
+});
+
+function buildChildScript(moduleUrl) {
+	return `
+		process.on("uncaughtException", (error) => {
+			console.error(error?.stack || error);
+			process.exit(1);
+		});
+		process.on("unhandledRejection", (error) => {
+			console.error(error?.stack || error);
+			process.exit(1);
+		});
+
+		globalThis.fetch = async (input) => {
+			const url = String(input);
+			if (url.startsWith("https://generativelanguage.googleapis.com/")) {
+				return new Response(JSON.stringify({ error: { message: "model overloaded" } }), {
+					status: 503,
+					statusText: "Service Unavailable",
+					headers: { "content-type": "application/json" },
+				});
+			}
+			throw new Error("Unexpected fetch: " + url);
+		};
+
+		const { extractContent } = await import(${JSON.stringify(moduleUrl)});
+		const result = await extractContent("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+		console.log(JSON.stringify(result));
+	`;
+}

--- a/youtube-extract.ts
+++ b/youtube-extract.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { activityMonitor } from "./activity.ts";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.ts";
 import { isGeminiApiAvailable, queryGeminiApiWithVideo } from "./gemini-api.ts";
-import { searchWithPerplexity } from "./perplexity.ts";
+import { isPerplexityAvailable, searchWithPerplexity } from "./perplexity.ts";
 import { extractHeadingTitle, type ExtractedContent, type FrameResult, type VideoFrame } from "./extract.ts";
 import { formatSeconds, readExecError, isTimeoutError, trimErrorText, mapFfmpegError } from "./utils.ts";
 
@@ -22,9 +22,17 @@ Format as markdown.`;
 const YOUTUBE_REGEX =
 	/(?:(?:www\.|m\.)?youtube\.com\/(?:watch\?.*v=|shorts\/|live\/|embed\/|v\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
 
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
 function shouldRethrow(err: unknown): boolean {
-	const message = err instanceof Error ? err.message : String(err);
-	return message.startsWith("Failed to parse ");
+	return errorMessage(err).startsWith("Failed to parse ");
+}
+
+function addAttemptError(errors: string[], label: string, err: unknown): void {
+	const message = errorMessage(err).replace(/\s+/g, " ").trim();
+	if (message) errors.push(`${label}: ${message}`);
 }
 
 interface YouTubeConfig {
@@ -102,18 +110,19 @@ export async function extractYouTube(
 	const effectiveModel = model ?? config.preferredModel;
 
 	const activityId = activityMonitor.logStart({ type: "fetch", url: `youtube.com/${videoId ?? "video"}` });
+	const attemptErrors: string[] = [];
 
-	const result = await tryGeminiWeb(canonicalUrl, effectivePrompt, effectiveModel, signal)
-		?? await tryGeminiApi(canonicalUrl, effectivePrompt, effectiveModel, signal)
-		?? await tryPerplexity(url, effectivePrompt, signal);
+	const result = await tryGeminiWeb(canonicalUrl, effectivePrompt, effectiveModel, signal, attemptErrors)
+		?? await tryGeminiApi(canonicalUrl, effectivePrompt, effectiveModel, signal, attemptErrors)
+		?? await tryPerplexity(url, effectivePrompt, signal, attemptErrors);
 
 	if (result) {
 		result.url = url;
-		if (videoId) {
+		if (!result.error && videoId) {
 			const thumb = await fetchYouTubeThumbnail(videoId);
 			if (thumb) result.thumbnail = thumb;
 		}
-		activityMonitor.logComplete(activityId, 200);
+		activityMonitor.logComplete(activityId, result.error ? 0 : 200);
 		return result;
 	}
 
@@ -122,8 +131,11 @@ export async function extractYouTube(
 		return null;
 	}
 
-	activityMonitor.logError(activityId, "all extraction paths failed");
-	return null;
+	const error = attemptErrors.length > 0
+		? ["Could not extract YouTube video content.", "", ...attemptErrors.map(message => `- ${message}`)].join("\n")
+		: "Could not extract YouTube video content. Sign into Google in Chrome for automatic access, or set GEMINI_API_KEY.";
+	activityMonitor.logError(activityId, error);
+	return { url, title: "", content: "", error };
 }
 
 type StreamInfo = { streamUrl: string; duration: number | null };
@@ -218,7 +230,8 @@ async function tryGeminiWeb(
 	url: string,
 	prompt: string,
 	model: string,
-	signal?: AbortSignal,
+	signal: AbortSignal | undefined,
+	attemptErrors: string[],
 ): Promise<ExtractedContent | null> {
 	try {
 		const cookies = await isGeminiWebAvailable();
@@ -241,6 +254,7 @@ async function tryGeminiWeb(
 		};
 	} catch (err) {
 		if (shouldRethrow(err)) throw err;
+		if (!signal?.aborted) addAttemptError(attemptErrors, "Gemini Web", err);
 		return null;
 	}
 }
@@ -249,7 +263,8 @@ async function tryGeminiApi(
 	url: string,
 	prompt: string,
 	model: string,
-	signal?: AbortSignal,
+	signal: AbortSignal | undefined,
+	attemptErrors: string[],
 ): Promise<ExtractedContent | null> {
 	try {
 		if (!isGeminiApiAvailable()) return null;
@@ -270,6 +285,7 @@ async function tryGeminiApi(
 		};
 	} catch (err) {
 		if (shouldRethrow(err)) throw err;
+		if (!signal?.aborted) addAttemptError(attemptErrors, "Gemini API", err);
 		return null;
 	}
 }
@@ -277,10 +293,11 @@ async function tryGeminiApi(
 async function tryPerplexity(
 	url: string,
 	prompt: string,
-	signal?: AbortSignal,
+	signal: AbortSignal | undefined,
+	attemptErrors: string[],
 ): Promise<ExtractedContent | null> {
 	try {
-		if (signal?.aborted) return null;
+		if (signal?.aborted || !isPerplexityAvailable()) return null;
 
 		const perplexityQuery = prompt === YOUTUBE_PROMPT
 			? `Summarize this YouTube video in detail: ${url}`
@@ -305,6 +322,7 @@ async function tryPerplexity(
 		};
 	} catch (err) {
 		if (shouldRethrow(err)) throw err;
+		if (!signal?.aborted) addAttemptError(attemptErrors, "Perplexity", err);
 		return null;
 	}
 }


### PR DESCRIPTION
YouTube extraction was swallowing Gemini API failures and falling through to the generic Chrome/API-key message, which made real 400 and 503 errors impossible to see. This keeps the useful error from the extractor and only uses the generic guidance when there really is no better failure to show.

I added a small regression test with a mocked Gemini 503 so this does not get masked again.

Fixes #96.