### PR TITLE
feat(olostep): add Olostep as optional search and content extraction provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added Olostep as a fully optional, key-gated search and content extraction provider. Set `OLOSTEP_API_KEY` or `olostepApiKey` in `~/.pi/web-search.json` to activate. When keyed, `web_search({ provider: "olostep" })` uses Olostep answers/search to return a synthesized answer with source citations. In `auto` mode, Olostep participates in the fallback chain after Tavily when a key is present. `fetch_content` uses Olostep scrape as a fallback for blocked, JS-rendered, or anti-bot pages, slotted after Jina Reader. Users without an Olostep key see no change in behavior.
+
 ## [0.13.0] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://github.com/user-attachments/assets/cac6a17a-1eeb-4dde-9818-cdf85d8ea98f
 
 **Video Understanding** — Point it at a YouTube video or local screen recording and ask questions about what's on screen. Full transcripts, visual descriptions, and frame extraction at exact timestamps.
 
-**Smart Fallbacks** — Every capability has a fallback chain. Search tries OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages retry through Jina Reader, Parallel, and Gemini extraction. Something always works.
+**Smart Fallbacks** — Every capability has a fallback chain. Search tries OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, Olostep (when keyed), Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages retry through Jina Reader, Olostep scrape (when keyed), Parallel, and Gemini extraction. Something always works.
 
 **GitHub Cloning** — GitHub URLs are cloned locally instead of scraped. The agent gets real file contents and a local path to explore, not rendered HTML.
 
@@ -35,6 +35,7 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
   "openaiApiKey": "sk-...",
   "braveApiKey": "BSA_...",
   "exaApiKey": "exa-...",
+  "olostepApiKey": "olostep-...",
   "perplexityApiKey": "pplx-...",
   "geminiApiKey": "AIza..."
 }
@@ -76,7 +77,7 @@ fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on sc
 
 ### web_search
 
-Search the web via OpenAI, Brave, Parallel, Tavily, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
+Search the web via OpenAI, Brave, Parallel, Tavily, Exa, Olostep, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
 
 ```typescript
 web_search({ query: "rust async programming" })
@@ -96,7 +97,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "auto-summary" })
 | `numResults` | Results per query (default: 5, max: 20) |
 | `recencyFilter` | `day`, `week`, `month`, or `year` |
 | `domainFilter` | Limit to domains (prefix with `-` to exclude) |
-| `provider` | `auto` (default), `openai`, `brave`, `parallel`, `tavily`, `exa`, `perplexity`, or `gemini` |
+| `provider` | `auto` (default), `openai`, `brave`, `parallel`, `tavily`, `exa`, `perplexity`, `gemini`, or `olostep` |
 | `includeContent` | Fetch full page content from sources in background |
 | `workflow` | `none` (skip curator), `summary-review` (open curator and auto-generate a summary draft, default), or `auto-summary` (generate a summary without opening the curator) |
 
@@ -177,7 +178,7 @@ When Readability fails or returns only a cookie notice, the extension retries vi
 
 ```
 web_search(query)
-  → Exa (direct API with key, MCP without) → Perplexity → Gemini API → Gemini Web (if browser cookies enabled)
+  → Exa (direct API with key, MCP without) → Olostep (if keyed) → Perplexity → Gemini API → Gemini Web (if browser cookies enabled)
 
 fetch_content(url)
   → Video file?  Gemini API (Files API) → Gemini Web (if browser cookies enabled)
@@ -249,6 +250,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "openaiApiKey": "sk-...",
   "braveApiKey": "BSA_...",
   "exaApiKey": "exa-...",
+  "olostepApiKey": "olostep-...",
   "parallelApiKey": "...",
   "tavilyApiKey": "tvly-...",
   "perplexityApiKey": "pplx-...",
@@ -290,7 +292,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
 }
 ```
 
-`OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars take precedence over config file values. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` sets the default search provider: `"openai"`, `"brave"`, `"parallel"`, `"tavily"`, `"exa"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the `web_search` tool while leaving fetch/content tools available. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected.
+`OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `OLOSTEP_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars take precedence over config file values. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` sets the default search provider: `"openai"`, `"brave"`, `"parallel"`, `"tavily"`, `"exa"`, `"olostep"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the `web_search` tool while leaving fetch/content tools available. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected.
 
 ### Shortcuts
 
@@ -335,8 +337,9 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Content f
 | `parallel.ts` | Parallel search provider and extraction fallback |
 | `tavily.ts` | Tavily Search API provider |
 | `exa.ts` | Exa.ai search provider — direct API and MCP proxy |
+| `olostep.ts` | Olostep search/answers and scrape provider — key-gated, fully optional |
 | `extract.ts` | URL/file path routing, HTTP extraction, fallback orchestration |
-| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, Gemini API, Gemini Web |
+| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, Tavily, Exa, Olostep, Perplexity, Gemini API, Gemini Web |
 | `gemini-url-context.ts` | Gemini URL Context + Web extraction fallbacks |
 | `gemini-web.ts` | Gemini Web client (cookie auth, StreamGenerate) |
 | `gemini-web-config.ts` | Gemini Web profile and browser-cookie opt-in config |

--- a/extract.ts
+++ b/extract.ts
@@ -13,6 +13,7 @@ import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } f
 import { existsSync, readFileSync } from "node:fs";
 import { fetchRemoteUrl, validateRemoteUrl, type Lookup } from "./ssrf-protection.ts";
 import { formatSeconds, getWebSearchConfigPath } from "./utils.ts";
+import { extractWithOlostep } from "./olostep.ts";
 
 const DEFAULT_TIMEOUT_MS = 30000;
 const CONCURRENT_LIMIT = 3;
@@ -460,6 +461,10 @@ export async function extractContent(
 
 	const jinaResult = await extractWithJinaReader(url, signal, options?.lookup);
 	if (jinaResult) return jinaResult;
+	if (signal?.aborted) return abortedResult(url);
+
+	const olostepResult = await extractWithOlostep(url, signal);
+	if (olostepResult) return olostepResult;
 	if (signal?.aborted) return abortedResult(url);
 
 	let parallelError: string | null = null;

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -9,9 +9,10 @@ import { isBraveAvailable, searchWithBrave } from "./brave.ts";
 import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
 import { isParallelAvailable, searchWithParallel } from "./parallel.ts";
 import { isTavilyAvailable, searchWithTavily } from "./tavily.ts";
+import { isOlostepAvailable, searchWithOlostep } from "./olostep.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "perplexity" | "gemini" | "exa";
+export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "perplexity" | "gemini" | "exa" | "olostep";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
 
 export interface AttributedSearchResponse extends SearchResponse {
@@ -61,7 +62,7 @@ function normalizeSearchModel(value: unknown): string | undefined {
 
 function normalizeSearchProvider(value: unknown): SearchProvider {
 	const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "perplexity", "gemini", "exa"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "perplexity", "gemini", "exa", "olostep"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -173,6 +174,14 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	if (provider === "olostep") {
+		const result = await searchWithOlostep(query, options);
+		if (result) return { ...result, provider: "olostep" };
+		throw new Error(
+			`Olostep search requires an API key. Set OLOSTEP_API_KEY or add olostepApiKey to ${CONFIG_PATH}.`
+		);
+	}
+
 	const fallbackErrors: string[] = [];
 
 	if (shouldTryOpenAIInAuto(options)) {
@@ -224,6 +233,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		} catch (err) {
 			if (isAbortError(err)) throw err;
 			fallbackErrors.push(`Tavily: ${errorMessage(err)}`);
+		}
+	}
+
+	if (provider !== "olostep" && isOlostepAvailable()) {
+		try {
+			const result = await searchWithOlostep(query, options);
+			if (result) return { ...result, provider: "olostep" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Olostep: ${errorMessage(err)}`);
 		}
 	}
 

--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { isPerplexityAvailable } from "./perplexity.ts";
 import { isExaAvailable } from "./exa.ts";
+import { isOlostepAvailable } from "./olostep.ts";
 import { isGeminiApiAvailable } from "./gemini-api.ts";
 import { getActiveGoogleEmail, isGeminiWebAvailable } from "./gemini-web.ts";
 import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
@@ -91,6 +92,7 @@ interface ProviderAvailability {
 	perplexity: boolean;
 	exa: boolean;
 	gemini: boolean;
+	olostep: boolean;
 }
 
 type WebSearchWorkflow = "none" | "summary-review" | "auto-summary";
@@ -150,7 +152,7 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini", "olostep"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -194,6 +196,7 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 		perplexity: isPerplexityAvailable(),
 		exa: isExaAvailable(),
 		gemini: isGeminiApiAvailable() || !!geminiWebAvail,
+		olostep: isOlostepAvailable(),
 	};
 }
 
@@ -261,6 +264,9 @@ function resolveProvider(
 	}
 	if (provider === "gemini" && !available.gemini) {
 		return firstAvailableProvider(available, preferOpenAI, "gemini");
+	}
+	if (provider === "olostep" && !available.olostep) {
+		return firstAvailableProvider(available, preferOpenAI, "olostep");
 	}
 	return provider;
 }

--- a/olostep.ts
+++ b/olostep.ts
@@ -1,0 +1,201 @@
+import { existsSync, readFileSync } from "node:fs";
+import { activityMonitor } from "./activity.ts";
+import type { ExtractedContent } from "./extract.ts";
+import type { SearchOptions, SearchResponse } from "./perplexity.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const OLOSTEP_ANSWERS_URL = "https://api.olostep.com/v1/answers";
+const OLOSTEP_SCRAPES_URL = "https://api.olostep.com/v1/scrapes";
+const CONFIG_PATH = getWebSearchConfigPath();
+
+interface WebSearchConfig {
+	olostepApiKey?: unknown;
+}
+
+interface OlostepAnswerResult {
+	url: string;
+	title: string;
+	description?: string;
+}
+
+interface OlostepAnswerResponse {
+	answer?: string;
+	results?: OlostepAnswerResult[];
+}
+
+interface OlostepScrapeResponse {
+	markdown_content?: string;
+	page_title?: string;
+	url?: string;
+	error?: string;
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+function normalizeApiKey(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function getApiKey(): string | null {
+	return normalizeApiKey(process.env.OLOSTEP_API_KEY) ?? normalizeApiKey(loadConfig().olostepApiKey);
+}
+
+function requestSignal(signal?: AbortSignal): AbortSignal {
+	const timeout = AbortSignal.timeout(30000);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function mapResults(results: OlostepAnswerResult[] | undefined): SearchResponse["results"] {
+	if (!Array.isArray(results)) return [];
+	const mapped: SearchResponse["results"] = [];
+	for (let i = 0; i < results.length; i++) {
+		const item = results[i];
+		if (!item?.url) continue;
+		mapped.push({
+			title: item.title || `Source ${i + 1}`,
+			url: item.url,
+			snippet: item.description || "",
+		});
+	}
+	return mapped;
+}
+
+export function isOlostepAvailable(): boolean {
+	return !!getApiKey();
+}
+
+export async function searchWithOlostep(query: string, options: SearchOptions = {}): Promise<SearchResponse | null> {
+	const apiKey = getApiKey();
+	if (!apiKey) return null;
+
+	const activityId = activityMonitor.logStart({ type: "api", query });
+
+	try {
+		const body: Record<string, unknown> = { query };
+		if (options.numResults && options.numResults !== 5) {
+			body.numResults = options.numResults;
+		}
+		if (options.recencyFilter) {
+			const filterMap: Record<string, string> = {
+				day: "day",
+				week: "week",
+				month: "month",
+				year: "year",
+			};
+			const mapped = filterMap[options.recencyFilter];
+			if (mapped) body.recencyFilter = mapped;
+		}
+		if (options.domainFilter?.length) {
+			const include = options.domainFilter
+				.filter(d => !d.startsWith("-") && d.trim().length > 0)
+				.map(d => d.trim());
+			const exclude = options.domainFilter
+				.filter(d => d.startsWith("-"))
+				.map(d => d.slice(1).trim())
+				.filter(Boolean);
+			if (include.length) body.domainFilter = include;
+			if (exclude.length) body.excludeDomains = exclude;
+		}
+
+		const response = await fetch(OLOSTEP_ANSWERS_URL, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(body),
+			signal: requestSignal(options.signal),
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			throw new Error(`Olostep API error ${response.status}: ${errorText.slice(0, 300)}`);
+		}
+
+		const data = await response.json() as OlostepAnswerResponse;
+		activityMonitor.logComplete(activityId, response.status);
+
+		return {
+			answer: data.answer || "",
+			results: mapResults(data.results),
+		};
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		throw err;
+	}
+}
+
+export async function extractWithOlostep(
+	url: string,
+	signal?: AbortSignal,
+): Promise<ExtractedContent | null> {
+	const apiKey = getApiKey();
+	if (!apiKey) return null;
+
+	const activityId = activityMonitor.logStart({ type: "api", query: `olostep-scrape: ${url}` });
+
+	try {
+		const response = await fetch(OLOSTEP_SCRAPES_URL, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				url,
+				formats: ["markdown"],
+			}),
+			signal: requestSignal(signal),
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			activityMonitor.logError(activityId, `Olostep scrape error ${response.status}: ${errorText.slice(0, 200)}`);
+			return null;
+		}
+
+		const data = await response.json() as OlostepScrapeResponse;
+		activityMonitor.logComplete(activityId, response.status);
+
+		const content = data.markdown_content?.trim() || "";
+		if (!content) return null;
+
+		return {
+			url: data.url || url,
+			title: data.page_title || "",
+			content,
+			error: null,
+		};
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		return null;
+	}
+}

--- a/olostep.ts
+++ b/olostep.ts
@@ -19,13 +19,19 @@ interface OlostepAnswerResult {
 }
 
 interface OlostepAnswerResponse {
-	answer?: string;
-	results?: OlostepAnswerResult[];
+	// /v1/answers nests the synthesized answer and its citations under `result`.
+	result?: {
+		json_content?: string;
+		sources?: OlostepAnswerResult[];
+	};
 }
 
 interface OlostepScrapeResponse {
-	markdown_content?: string;
-	page_title?: string;
+	// /v1/scrapes nests the page content under `result`.
+	result?: {
+		markdown_content?: string;
+		page_title?: string;
+	};
 	url?: string;
 	error?: string;
 }
@@ -89,7 +95,7 @@ export async function searchWithOlostep(query: string, options: SearchOptions = 
 	const activityId = activityMonitor.logStart({ type: "api", query });
 
 	try {
-		const body: Record<string, unknown> = { query };
+		const body: Record<string, unknown> = { task: query };
 		if (options.numResults && options.numResults !== 5) {
 			body.numResults = options.numResults;
 		}
@@ -133,9 +139,22 @@ export async function searchWithOlostep(query: string, options: SearchOptions = 
 		const data = await response.json() as OlostepAnswerResponse;
 		activityMonitor.logComplete(activityId, response.status);
 
+		const result = data.result ?? {};
+		let answer = "";
+		if (typeof result.json_content === "string" && result.json_content.length) {
+			try {
+				const parsed = JSON.parse(result.json_content) as unknown;
+				answer = typeof parsed === "string"
+					? parsed
+					: String((parsed as Record<string, unknown>)?.result ?? (parsed as Record<string, unknown>)?.answer ?? result.json_content);
+			} catch {
+				answer = result.json_content;
+			}
+		}
+
 		return {
-			answer: data.answer || "",
-			results: mapResults(data.results),
+			answer,
+			results: mapResults(result.sources),
 		};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -165,7 +184,7 @@ export async function extractWithOlostep(
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({
-				url,
+				url_to_scrape: url,
 				formats: ["markdown"],
 			}),
 			signal: requestSignal(signal),
@@ -180,12 +199,12 @@ export async function extractWithOlostep(
 		const data = await response.json() as OlostepScrapeResponse;
 		activityMonitor.logComplete(activityId, response.status);
 
-		const content = data.markdown_content?.trim() || "";
+		const content = data.result?.markdown_content?.trim() || "";
 		if (!content) return null;
 
 		return {
 			url: data.url || url,
-			title: data.page_title || "",
+			title: data.result?.page_title || "",
 			content,
 			error: null,
 		};

--- a/test/olostep.test.mjs
+++ b/test/olostep.test.mjs
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const olostepModuleUrl = new URL("../olostep.ts", import.meta.url).href;
+const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
+const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
+
+function runChild(script, env) {
+	const childEnv = { ...process.env };
+	for (const key of [
+		"PI_CODING_AGENT_DIR",
+		"XDG_CONFIG_HOME",
+		"OPENAI_API_KEY",
+		"BRAVE_API_KEY",
+		"PARALLEL_API_KEY",
+		"TAVILY_API_KEY",
+		"EXA_API_KEY",
+		"OLOSTEP_API_KEY",
+		"PERPLEXITY_API_KEY",
+		"GEMINI_API_KEY",
+	]) {
+		delete childEnv[key];
+	}
+	Object.assign(childEnv, env);
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+}
+
+test("isOlostepAvailable returns false with no key", () => {
+	const child = runChild(`
+		const { isOlostepAvailable } = await import(${JSON.stringify(olostepModuleUrl)});
+		process.stdout.write(JSON.stringify(isOlostepAvailable()));
+	`, {});
+	assert.strictEqual(child.status, 0, child.stderr);
+	assert.strictEqual(JSON.parse(child.stdout), false);
+});
+
+test("isOlostepAvailable returns true when OLOSTEP_API_KEY is set", () => {
+	const child = runChild(`
+		const { isOlostepAvailable } = await import(${JSON.stringify(olostepModuleUrl)});
+		process.stdout.write(JSON.stringify(isOlostepAvailable()));
+	`, { OLOSTEP_API_KEY: "test-key" });
+	assert.strictEqual(child.status, 0, child.stderr);
+	assert.strictEqual(JSON.parse(child.stdout), true);
+});
+
+test("searchWithOlostep returns null with no API key", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-olostep-"));
+	const child = runChild(`
+		const { searchWithOlostep } = await import(${JSON.stringify(olostepModuleUrl)});
+		const result = await searchWithOlostep("test query");
+		process.stdout.write(JSON.stringify(result));
+	`, { XDG_CONFIG_HOME: home });
+	assert.strictEqual(child.status, 0, child.stderr);
+	assert.strictEqual(JSON.parse(child.stdout), null);
+});
+
+test("searchWithOlostep sends correct request and returns shaped result", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-olostep-"));
+	const child = runChild(`
+		let capturedUrl = "";
+		let capturedHeaders = null;
+		let capturedBody = null;
+		globalThis.fetch = async (url, init) => {
+			capturedUrl = String(url);
+			capturedHeaders = Object.fromEntries(Object.entries(init.headers));
+			capturedBody = JSON.parse(init.body);
+			return new Response(JSON.stringify({
+				answer: "Olostep is a web scraping API.",
+				results: [
+					{ url: "https://olostep.com", title: "Olostep", description: "Web scraping API" },
+					{ url: "https://docs.olostep.com", title: "Olostep Docs", description: "API docs" },
+				],
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+
+		const { searchWithOlostep } = await import(${JSON.stringify(olostepModuleUrl)});
+		const result = await searchWithOlostep("what is olostep", { numResults: 3 });
+		process.stdout.write(JSON.stringify({ capturedUrl, capturedHeaders, capturedBody, result }));
+	`, { OLOSTEP_API_KEY: "test-key-123", XDG_CONFIG_HOME: home });
+
+	assert.strictEqual(child.status, 0, child.stderr);
+	const { capturedUrl, capturedHeaders, capturedBody, result } = JSON.parse(child.stdout);
+
+	assert.ok(capturedUrl.includes("olostep.com"), "should call Olostep API");
+	assert.ok(capturedHeaders["Authorization"]?.includes("test-key-123"), "should send Bearer auth");
+	assert.strictEqual(capturedBody.query, "what is olostep");
+	assert.strictEqual(capturedBody.numResults, 3);
+	assert.strictEqual(typeof result.answer, "string");
+	assert.ok(result.answer.length > 0, "answer should be non-empty");
+	assert.ok(Array.isArray(result.results), "results should be an array");
+	assert.strictEqual(result.results.length, 2);
+	assert.strictEqual(result.results[0].url, "https://olostep.com");
+	assert.strictEqual(result.results[0].title, "Olostep");
+});
+
+test("auto search fallback chain skips Olostep when no key", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-olostep-auto-"));
+	await writeFile(join(home, "web-search.json"), JSON.stringify({ provider: "auto" }));
+
+	const child = runChild(`
+		const olostepCalled = { value: false };
+		globalThis.fetch = async (url, init) => {
+			if (String(url).includes("olostep")) {
+				olostepCalled.value = true;
+			}
+			// Simulate Exa MCP unavailable, all providers fail
+			return new Response(JSON.stringify({ error: "unavailable" }), {
+				status: 503,
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const { isOlostepAvailable } = await import(${JSON.stringify(olostepModuleUrl)});
+		process.stdout.write(JSON.stringify({
+			olostepAvailable: isOlostepAvailable(),
+		}));
+	`, { XDG_CONFIG_HOME: home });
+
+	assert.strictEqual(child.status, 0, child.stderr);
+	const { olostepAvailable } = JSON.parse(child.stdout);
+	assert.strictEqual(olostepAvailable, false, "Olostep should not be available without a key");
+});
+
+test("extractWithOlostep returns null with no API key", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-olostep-ext-"));
+	const child = runChild(`
+		const { extractWithOlostep } = await import(${JSON.stringify(olostepModuleUrl)});
+		const result = await extractWithOlostep("https://example.com");
+		process.stdout.write(JSON.stringify(result));
+	`, { XDG_CONFIG_HOME: home });
+	assert.strictEqual(child.status, 0, child.stderr);
+	assert.strictEqual(JSON.parse(child.stdout), null);
+});
+
+test("extractWithOlostep returns ExtractedContent on success", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-olostep-ext-"));
+	const child = runChild(`
+		globalThis.fetch = async (url, init) => {
+			return new Response(JSON.stringify({
+				markdown_content: "# Hello from Olostep\\n\\nThis is extracted content.",
+				page_title: "Test Page",
+				url: "https://example.com",
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+
+		const { extractWithOlostep } = await import(${JSON.stringify(olostepModuleUrl)});
+		const result = await extractWithOlostep("https://example.com");
+		process.stdout.write(JSON.stringify(result));
+	`, { OLOSTEP_API_KEY: "test-key-456", XDG_CONFIG_HOME: home });
+
+	assert.strictEqual(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout);
+	assert.strictEqual(result.url, "https://example.com");
+	assert.strictEqual(result.title, "Test Page");
+	assert.ok(result.content.includes("Hello from Olostep"), "content should be markdown");
+	assert.strictEqual(result.error, null);
+});

--- a/test/olostep.test.mjs
+++ b/test/olostep.test.mjs
@@ -74,11 +74,13 @@ test("searchWithOlostep sends correct request and returns shaped result", async 
 			capturedHeaders = Object.fromEntries(Object.entries(init.headers));
 			capturedBody = JSON.parse(init.body);
 			return new Response(JSON.stringify({
-				answer: "Olostep is a web scraping API.",
-				results: [
-					{ url: "https://olostep.com", title: "Olostep", description: "Web scraping API" },
-					{ url: "https://docs.olostep.com", title: "Olostep Docs", description: "API docs" },
-				],
+				result: {
+					json_content: JSON.stringify({ result: "Olostep is a web scraping API." }),
+					sources: [
+						{ url: "https://olostep.com", title: "Olostep", description: "Web scraping API" },
+						{ url: "https://docs.olostep.com", title: "Olostep Docs", description: "API docs" },
+					],
+				},
 			}), { status: 200, headers: { "content-type": "application/json" } });
 		};
 
@@ -92,7 +94,7 @@ test("searchWithOlostep sends correct request and returns shaped result", async 
 
 	assert.ok(capturedUrl.includes("olostep.com"), "should call Olostep API");
 	assert.ok(capturedHeaders["Authorization"]?.includes("test-key-123"), "should send Bearer auth");
-	assert.strictEqual(capturedBody.query, "what is olostep");
+	assert.strictEqual(capturedBody.task, "what is olostep");
 	assert.strictEqual(capturedBody.numResults, 3);
 	assert.strictEqual(typeof result.answer, "string");
 	assert.ok(result.answer.length > 0, "answer should be non-empty");
@@ -146,8 +148,10 @@ test("extractWithOlostep returns ExtractedContent on success", async () => {
 	const child = runChild(`
 		globalThis.fetch = async (url, init) => {
 			return new Response(JSON.stringify({
-				markdown_content: "# Hello from Olostep\\n\\nThis is extracted content.",
-				page_title: "Test Page",
+				result: {
+					markdown_content: "# Hello from Olostep\\n\\nThis is extracted content.",
+					page_title: "Test Page",
+				},
 				url: "https://example.com",
 			}), { status: 200, headers: { "content-type": "application/json" } });
 		};


### PR DESCRIPTION
## What this adds

Adds Olostep as a fully optional, key-gated provider for both `web_search` and `fetch_content`. Users without an Olostep key see no change in behavior.

### Search (`web_search`)
- New `olostep.ts` provider module uses the [Olostep answers API](https://docs.olostep.com) to return a synthesized answer with source citations in the same shape as other providers
- `provider: 'olostep'` explicit routing added to `gemini-search.ts`
- In `auto` mode, Olostep joins the fallback chain after Tavily when a key is present
- Zero-config Exa default path is **unchanged** — no key means Olostep is silently skipped

### Content extraction (`fetch_content`)
- Olostep scrape (single URL to clean markdown) added as a fallback in `extract.ts` after Jina Reader, for blocked, JS-rendered, or anti-bot pages

### Configuration
Add to `~/.pi/web-search.json`:
```json
{ "olostepApiKey": "olostep-..." }
```
Or set the `OLOSTEP_API_KEY` env var (takes precedence).

### Files changed
- `olostep.ts` — new provider module (search + scrape, modeled on `exa.ts`)
- `gemini-search.ts` — `olostep` added to `SearchProvider` enum, routing, and auto fallback chain
- `extract.ts` — Olostep scrape slotted after Jina Reader in blocked-page retry path
- `index.ts` — provider availability check + guard
- `test/olostep.test.mjs` — 7 tests (all pass)
- `README.md`, `CHANGELOG.md` — updated

### Tests
```
node --test test/olostep.test.mjs
✔ isOlostepAvailable returns false with no key
✔ isOlostepAvailable returns true when OLOSTEP_API_KEY is set
✔ searchWithOlostep returns null with no API key
✔ searchWithOlostep sends correct request and returns shaped result
✔ auto search fallback chain skips Olostep when no key
✔ extractWithOlostep returns null with no API key
✔ extractWithOlostep returns ExtractedContent on success
7/7 pass
```

cc @nicobailon