### PR TITLE
feat: add SearXNG search provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added SearXNG as an optional `web_search` provider via `searxngBaseUrl` / `SEARXNG_BASE_URL`, using the self-hosted JSON API and supporting result count, recency, and domain filters.
+
 ## [0.13.0] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Pi Web Access
 
-**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, Tavily, optional browser-cookie Gemini Web, or bring your own API keys.**
+**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, Tavily, SearXNG, optional browser-cookie Gemini Web, or bring your own API keys.**
 
 [![npm version](https://img.shields.io/npm/v/pi-web-access?style=for-the-badge)](https://www.npmjs.com/package/pi-web-access)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
@@ -14,11 +14,11 @@ https://github.com/user-attachments/assets/cac6a17a-1eeb-4dde-9818-cdf85d8ea98f
 
 ## Why Pi Web Access
 
-**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, or Gemini API for more control, or opt into browser-cookie access for Gemini Web.
+**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, or Gemini API for more control; point it at a self-hosted SearXNG instance for private metasearch; or opt into browser-cookie access for Gemini Web.
 
 **Video Understanding** — Point it at a YouTube video or local screen recording and ask questions about what's on screen. Full transcripts, visual descriptions, and frame extraction at exact timestamps.
 
-**Smart Fallbacks** — Every capability has a fallback chain. Search tries OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages retry through Jina Reader, Parallel, and Gemini extraction. Something always works.
+**Smart Fallbacks** — Every capability has a fallback chain. Search tries OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, SearXNG, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages retry through Jina Reader, Parallel, and Gemini extraction. Something always works.
 
 **GitHub Cloning** — GitHub URLs are cloned locally instead of scraped. The agent gets real file contents and a local path to explore, not rendered HTML.
 
@@ -40,7 +40,7 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
 }
 ```
 
-In `auto` mode (default), `web_search` tries OpenAI when suitable and available, then Exa (direct API if keyed, MCP if not), Brave, Parallel, Tavily, Perplexity, Gemini API, then Gemini Web when browser-cookie access is enabled.
+In `auto` mode (default), `web_search` tries OpenAI when suitable and available, then Exa (direct API if keyed, MCP if not), Brave, Parallel, Tavily, SearXNG, Perplexity, Gemini API, then Gemini Web when browser-cookie access is enabled.
 
 Optional dependencies for video frame extraction:
 
@@ -76,7 +76,7 @@ fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on sc
 
 ### web_search
 
-Search the web via OpenAI, Brave, Parallel, Tavily, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
+Search the web via OpenAI, Brave, Parallel, Tavily, SearXNG, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
 
 ```typescript
 web_search({ query: "rust async programming" })
@@ -96,7 +96,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "auto-summary" })
 | `numResults` | Results per query (default: 5, max: 20) |
 | `recencyFilter` | `day`, `week`, `month`, or `year` |
 | `domainFilter` | Limit to domains (prefix with `-` to exclude) |
-| `provider` | `auto` (default), `openai`, `brave`, `parallel`, `tavily`, `exa`, `perplexity`, or `gemini` |
+| `provider` | `auto` (default), `openai`, `brave`, `parallel`, `tavily`, `searxng`, `exa`, `perplexity`, or `gemini` |
 | `includeContent` | Fetch full page content from sources in background |
 | `workflow` | `none` (skip curator), `summary-review` (open curator and auto-generate a summary draft, default), or `auto-summary` (generate a summary without opening the curator) |
 
@@ -251,6 +251,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "exaApiKey": "exa-...",
   "parallelApiKey": "...",
   "tavilyApiKey": "tvly-...",
+  "searxngBaseUrl": "https://search.example.com",
   "perplexityApiKey": "pplx-...",
   "geminiApiKey": "AIza...",
   "geminiBaseUrl": "https://my-gateway.example.com/gemini",
@@ -290,7 +291,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
 }
 ```
 
-`OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars take precedence over config file values. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` sets the default search provider: `"openai"`, `"brave"`, `"parallel"`, `"tavily"`, `"exa"`, `"perplexity"`, or `"gemini"`. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the `web_search` tool while leaving fetch/content tools available. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected.
+`OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `SEARXNG_BASE_URL`, `EXA_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars take precedence over config file values. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` sets the default search provider: `"openai"`, `"brave"`, `"parallel"`, `"tavily"`, `"searxng"`, `"exa"`, `"perplexity"`, or `"gemini"`. `searxngBaseUrl` / `SEARXNG_BASE_URL` points to a self-hosted SearXNG instance and uses its JSON API (`/search?format=json&q=...`). This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the `web_search` tool while leaving fetch/content tools available. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on `web_search`, or toggled at runtime with `/curator`. `chromeProfile` overrides the Chromium profile directory used for Gemini Web cookie lookup. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. `searchModel` overrides the Gemini API model used by `web_search` without changing URL, YouTube, or video extraction defaults. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected.
 
 ### Shortcuts
 
@@ -334,9 +335,10 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Content f
 | `brave.ts` | Brave Search API provider |
 | `parallel.ts` | Parallel search provider and extraction fallback |
 | `tavily.ts` | Tavily Search API provider |
+| `searxng.ts` | SearXNG JSON API provider |
 | `exa.ts` | Exa.ai search provider — direct API and MCP proxy |
 | `extract.ts` | URL/file path routing, HTTP extraction, fallback orchestration |
-| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, Gemini API, Gemini Web |
+| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, Tavily, SearXNG, Exa, Perplexity, Gemini API, Gemini Web |
 | `gemini-url-context.ts` | Gemini URL Context + Web extraction fallbacks |
 | `gemini-web.ts` | Gemini Web client (cookie auth, StreamGenerate) |
 | `gemini-web-config.ts` | Gemini Web profile and browser-cookie opt-in config |

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -8,7 +8,7 @@ function safeInlineJSON(data: unknown): string {
 }
 
 function buildProviderButtons(
-	available: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	available: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
 	selected: string,
 	hasInitialQueries: boolean,
 ): string {
@@ -18,6 +18,7 @@ function buildProviderButtons(
 		{ value: "brave", label: "Brave", available: available.brave },
 		{ value: "parallel", label: "Parallel", available: available.parallel },
 		{ value: "tavily", label: "Tavily", available: available.tavily },
+		{ value: "searxng", label: "SearXNG", available: available.searxng },
 		{ value: "perplexity", label: "Perplexity", available: available.perplexity },
 		{ value: "gemini", label: "Gemini", available: available.gemini },
 	];
@@ -38,7 +39,7 @@ export function generateCuratorPage(
 	queries: string[],
 	sessionToken: string,
 	timeout: number,
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
 	defaultProvider: string,
 	searchProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
@@ -665,6 +666,11 @@ main {
   color: #a6e3a1;
   background: rgba(166, 227, 161, 0.14);
   border-color: rgba(166, 227, 161, 0.3);
+}
+.provider-tag.provider-searxng {
+  color: #a3e635;
+  background: rgba(163, 230, 53, 0.14);
+  border-color: rgba(163, 230, 53, 0.3);
 }
 .provider-tag.provider-unknown {
   color: var(--fg-muted);
@@ -1389,7 +1395,7 @@ const SCRIPT = `(function() {
   var token = DATA.sessionToken;
   var timeoutSec = DATA.timeout;
   var queries = Array.isArray(DATA.queries) ? DATA.queries : [];
-  var providers = ["openai", "exa", "brave", "parallel", "tavily", "perplexity", "gemini"];
+  var providers = ["openai", "exa", "brave", "parallel", "tavily", "searxng", "perplexity", "gemini"];
   var availProviders = DATA.availableProviders && typeof DATA.availableProviders === "object" ? DATA.availableProviders : {};
   var workflow = "summary-review";
   var initialDefaultProvider = typeof DATA.defaultProvider === "string" ? DATA.defaultProvider : "exa";
@@ -1593,6 +1599,7 @@ const SCRIPT = `(function() {
     if (provider === "brave") return "Brave";
     if (provider === "parallel") return "Parallel";
     if (provider === "tavily") return "Tavily";
+    if (provider === "searxng") return "SearXNG";
     if (provider === "perplexity") return "Perplexity";
     if (provider === "exa") return "Exa";
     if (provider === "gemini") return "Gemini";

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -12,7 +12,7 @@ export interface CuratorServerOptions {
 	queries: string[];
 	sessionToken: string;
 	timeout: number;
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
 	defaultProvider: string;
 	searchProvider: string;
 	summaryModels: Array<{ value: string; label: string }>;
@@ -247,6 +247,7 @@ export function startCuratorServer(
 		if (provider === "brave") return availableProviders.brave;
 		if (provider === "parallel") return availableProviders.parallel;
 		if (provider === "tavily") return availableProviders.tavily;
+		if (provider === "searxng") return availableProviders.searxng;
 		if (provider === "perplexity") return availableProviders.perplexity;
 		if (provider === "exa") return availableProviders.exa;
 		if (provider === "gemini") return availableProviders.gemini;

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -9,9 +9,10 @@ import { isBraveAvailable, searchWithBrave } from "./brave.ts";
 import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
 import { isParallelAvailable, searchWithParallel } from "./parallel.ts";
 import { isTavilyAvailable, searchWithTavily } from "./tavily.ts";
+import { isSearXNGAvailable, searchWithSearXNG } from "./searxng.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "perplexity" | "gemini" | "exa";
+export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "searxng" | "perplexity" | "gemini" | "exa";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
 
 export interface AttributedSearchResponse extends SearchResponse {
@@ -61,7 +62,7 @@ function normalizeSearchModel(value: unknown): string | undefined {
 
 function normalizeSearchProvider(value: unknown): SearchProvider {
 	const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "perplexity", "gemini", "exa"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "searxng", "perplexity", "gemini", "exa"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -146,6 +147,11 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		return { ...result, provider: "perplexity" };
 	}
 
+	if (provider === "searxng") {
+		const result = await searchWithSearXNG(query, options);
+		return { ...result, provider: "searxng" };
+	}
+
 	if (provider === "gemini") {
 		const result = await searchWithGemini(query, options, true);
 		if (result) return { ...result, provider: "gemini" };
@@ -227,6 +233,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	if (isSearXNGAvailable()) {
+		try {
+			const result = await searchWithSearXNG(query, options);
+			return { ...result, provider: "searxng" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`SearXNG: ${errorMessage(err)}`);
+		}
+	}
+
 	if (isPerplexityAvailable()) {
 		try {
 			const result = await searchWithPerplexity(query, options);
@@ -252,8 +268,8 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	throw new Error(
 		"No search provider available. Either:\n" +
 		"  1. Use /login to sign in with a Codex subscription for OpenAI web search\n" +
-		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, tavilyApiKey, perplexityApiKey, exaApiKey, geminiApiKey, or cloudflareApiKey in ${CONFIG_PATH}\n` +
-		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, EXA_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, or CLOUDFLARE_API_KEY env vars\n" +
+		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, tavilyApiKey, searxngBaseUrl, perplexityApiKey, exaApiKey, geminiApiKey, or cloudflareApiKey in ${CONFIG_PATH}\n` +
+		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, SEARXNG_BASE_URL, EXA_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, or CLOUDFLARE_API_KEY env vars\n" +
 		"  4. Set GOOGLE_GEMINI_BASE_URL with CLOUDFLARE_API_KEY for Cloudflare AI Gateway routing\n" +
 		"  5. Sign into gemini.google.com in a supported Chromium-based browser"
 	);

--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,7 @@ import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
 import { isParallelAvailable } from "./parallel.ts";
 import { isTavilyAvailable } from "./tavily.ts";
+import { isSearXNGAvailable } from "./searxng.ts";
 import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
 import { loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 
@@ -88,6 +89,7 @@ interface ProviderAvailability {
 	brave: boolean;
 	parallel: boolean;
 	tavily: boolean;
+	searxng: boolean;
 	perplexity: boolean;
 	exa: boolean;
 	gemini: boolean;
@@ -150,7 +152,7 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -191,6 +193,7 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 		brave: isBraveAvailable(),
 		parallel: isParallelAvailable(),
 		tavily: isTavilyAvailable(),
+		searxng: isSearXNGAvailable(),
 		perplexity: isPerplexityAvailable(),
 		exa: isExaAvailable(),
 		gemini: isGeminiApiAvailable() || !!geminiWebAvail,
@@ -225,6 +228,7 @@ function firstAvailableProvider(available: ProviderAvailability, preferOpenAI: b
 	if (available.brave) return "brave";
 	if (available.parallel) return "parallel";
 	if (available.tavily) return "tavily";
+	if (available.searxng) return "searxng";
 	if (available.perplexity) return "perplexity";
 	if (available.gemini) return "gemini";
 	return fallback;
@@ -252,6 +256,9 @@ function resolveProvider(
 	}
 	if (provider === "tavily" && !available.tavily) {
 		return firstAvailableProvider(available, preferOpenAI, "tavily");
+	}
+	if (provider === "searxng" && !available.searxng) {
+		return firstAvailableProvider(available, preferOpenAI, "searxng");
 	}
 	if (provider === "exa" && !available.exa) {
 		return firstAvailableProvider(available, preferOpenAI, "exa");
@@ -1242,7 +1249,7 @@ export default function (pi: ExtensionAPI) {
 		name: "web_search",
 		label: "Web Search",
 		description:
-			`Search the web using OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, or Gemini. Returns an AI-synthesized answer with source citations. OpenAI web_search uses a Codex subscription or OpenAI API key. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation or "auto-summary" for a model-generated summary without the browser curator. Provider auto-selects: OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, Perplexity, Gemini API, then Gemini Web.`,
+			`Search the web using OpenAI, Brave, Parallel, Tavily, SearXNG, Exa, Perplexity, or Gemini. Returns an AI-synthesized answer with source citations. OpenAI web_search uses a Codex subscription or OpenAI API key. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation or "auto-summary" for a model-generated summary without the browser curator. Provider auto-selects: OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, SearXNG, Perplexity, Gemini API, then Gemini Web.`,
 		promptSnippet:
 			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
 		parameters: Type.Object({
@@ -1255,7 +1262,7 @@ export default function (pi: ExtensionAPI) {
 			),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
 			provider: Type.Optional(
-				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"], { description: "Search provider (default: auto)" }),
+				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini"], { description: "Search provider (default: auto)" }),
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review", "auto-summary"], {

--- a/searxng.ts
+++ b/searxng.ts
@@ -1,0 +1,222 @@
+import { existsSync, readFileSync } from "node:fs";
+import { activityMonitor } from "./activity.ts";
+import type { SearchOptions, SearchResult, SearchResponse } from "./perplexity.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const CONFIG_PATH = getWebSearchConfigPath();
+const SEARCH_TIMEOUT_MS = 30_000;
+
+interface WebSearchConfig {
+	searxngBaseUrl?: unknown;
+}
+
+interface NormalizedDomainFilters {
+	allowed: string[];
+	blocked: string[];
+}
+
+interface SearXNGResult {
+	title?: string;
+	url?: string;
+	content?: string;
+	engine?: string;
+	engines?: string[];
+}
+
+interface SearXNGResponse {
+	results?: SearXNGResult[];
+	answers?: string[];
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+function normalizeBaseUrl(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	try {
+		const url = new URL(trimmed);
+		if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+		url.pathname = url.pathname.replace(/\/+$/, "");
+		url.search = "";
+		url.hash = "";
+		return url.toString().replace(/\/+$/, "");
+	} catch {
+		return null;
+	}
+}
+
+function getBaseUrl(): string | null {
+	return normalizeBaseUrl(process.env.SEARXNG_BASE_URL) ?? normalizeBaseUrl(loadConfig().searxngBaseUrl);
+}
+
+function requireBaseUrl(): string {
+	const baseUrl = getBaseUrl();
+	if (!baseUrl) {
+		throw new Error(
+			"SearXNG base URL not found. Either:\n" +
+			`  1. Create ${CONFIG_PATH} with { "searxngBaseUrl": "https://search.example.com" }\n` +
+			"  2. Set SEARXNG_BASE_URL environment variable",
+		);
+	}
+	return baseUrl;
+}
+
+function normalizeCount(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 5;
+	return Math.max(1, Math.min(Math.floor(value), 20));
+}
+
+function normalizeDomain(value: string): string | null {
+	let input = value.trim().toLowerCase();
+	if (!input) return null;
+	if (input.startsWith("-")) input = input.slice(1).trim();
+	if (!input) return null;
+	try {
+		const parsed = input.includes("://") ? new URL(input) : new URL(`https://${input}`);
+		input = parsed.hostname;
+	} catch {
+		input = input.split("/")[0]?.split(":")[0] ?? "";
+	}
+	input = input.replace(/^\.+|\.+$/g, "");
+	return /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(input) ? input : null;
+}
+
+function normalizeDomainFilters(domainFilter: string[] | undefined): NormalizedDomainFilters {
+	const filters: NormalizedDomainFilters = { allowed: [], blocked: [] };
+	if (!domainFilter?.length) return filters;
+
+	for (const raw of domainFilter) {
+		const domain = normalizeDomain(raw);
+		if (!domain) continue;
+		const target = raw.trim().startsWith("-") ? filters.blocked : filters.allowed;
+		if (!target.includes(domain)) target.push(domain);
+	}
+
+	return filters;
+}
+
+function buildSearXNGQuery(query: string, domainFilter: string[] | undefined): string {
+	const filters = normalizeDomainFilters(domainFilter);
+	const parts = [query];
+	if (filters.allowed.length === 1) {
+		parts.push(`site:${filters.allowed[0]}`);
+	} else if (filters.allowed.length > 1) {
+		parts.push(filters.allowed.map(domain => `site:${domain}`).join(" OR "));
+	}
+	for (const domain of filters.blocked) {
+		parts.push(`-site:${domain}`);
+	}
+	return parts.join(" ");
+}
+
+function hostMatchesDomain(hostname: string, domain: string): boolean {
+	return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+function matchesDomainFilters(url: string, filters: NormalizedDomainFilters): boolean {
+	if (filters.allowed.length === 0 && filters.blocked.length === 0) return true;
+	let hostname = "";
+	try {
+		hostname = new URL(url).hostname.toLowerCase();
+	} catch {
+		return false;
+	}
+	if (filters.allowed.length > 0 && !filters.allowed.some(domain => hostMatchesDomain(hostname, domain))) return false;
+	return !filters.blocked.some(domain => hostMatchesDomain(hostname, domain));
+}
+
+function mapTimeRange(recencyFilter: SearchOptions["recencyFilter"]): string | null {
+	if (recencyFilter === "day" || recencyFilter === "week" || recencyFilter === "month" || recencyFilter === "year") return recencyFilter;
+	return null;
+}
+
+export function isSearXNGAvailable(): boolean {
+	return !!getBaseUrl();
+}
+
+export async function searchWithSearXNG(query: string, options: SearchOptions = {}): Promise<SearchResponse> {
+	const baseUrl = requireBaseUrl();
+	const numResults = normalizeCount(options.numResults);
+	const domainFilters = normalizeDomainFilters(options.domainFilter);
+	const searchQuery = buildSearXNGQuery(query, options.domainFilter);
+	const activityId = activityMonitor.logStart({ type: "api", query: searchQuery });
+
+	const url = new URL(`${baseUrl}/search`);
+	url.searchParams.set("q", searchQuery);
+	url.searchParams.set("format", "json");
+	const timeRange = mapTimeRange(options.recencyFilter);
+	if (timeRange) url.searchParams.set("time_range", timeRange);
+
+	try {
+		const response = await fetch(url.toString(), {
+			method: "GET",
+			headers: { "Accept": "application/json" },
+			signal: options.signal
+				? AbortSignal.any([AbortSignal.timeout(SEARCH_TIMEOUT_MS), options.signal])
+				: AbortSignal.timeout(SEARCH_TIMEOUT_MS),
+		});
+
+		if (!response.ok) {
+			activityMonitor.logError(activityId, `HTTP ${response.status}`);
+			const errorText = await response.text();
+			throw new Error(`SearXNG search error ${response.status}: ${errorText.slice(0, 300)}`);
+		}
+
+		let data: SearXNGResponse;
+		try {
+			data = await response.json() as SearXNGResponse;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			throw new Error(`SearXNG returned invalid JSON: ${message}`);
+		}
+
+		activityMonitor.logComplete(activityId, response.status);
+		const results: SearchResult[] = [];
+		for (const item of data.results ?? []) {
+			if (!item.url || !matchesDomainFilters(item.url, domainFilters)) continue;
+			results.push({
+				title: item.title || item.url,
+				url: item.url,
+				snippet: item.content || "",
+			});
+			if (results.length >= numResults) break;
+		}
+
+		const answerParts: string[] = [];
+		for (const answer of data.answers ?? []) {
+			if (typeof answer === "string" && answer.trim()) answerParts.push(answer.trim());
+		}
+		answerParts.push(...results.map((result) => {
+			if (result.snippet) return `${result.snippet}\nSource: ${result.title} (${result.url})`;
+			return `Source: ${result.title} (${result.url})`;
+		}));
+
+		return { answer: answerParts.join("\n\n"), results };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		throw err;
+	}
+}

--- a/test/curator-server-timeout.test.mjs
+++ b/test/curator-server-timeout.test.mjs
@@ -32,7 +32,7 @@ function baseOptions(timeout = 1) {
 		queries: ["test query"],
 		sessionToken: "test-token",
 		timeout,
-		availableProviders: { openai: false, brave: false, parallel: false, tavily: false, perplexity: false, exa: true, gemini: false },
+		availableProviders: { openai: false, brave: false, parallel: false, tavily: false, searxng: false, perplexity: false, exa: true, gemini: false },
 		defaultProvider: "exa",
 		searchProvider: "exa",
 		summaryModels: [],

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -9,6 +9,7 @@ const braveModuleUrl = new URL("../brave.ts", import.meta.url).href;
 const exaModuleUrl = new URL("../exa.ts", import.meta.url).href;
 const openaiModuleUrl = new URL("../openai-search.ts", import.meta.url).href;
 const tavilyModuleUrl = new URL("../tavily.ts", import.meta.url).href;
+const searxngModuleUrl = new URL("../searxng.ts", import.meta.url).href;
 const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
 
 function runChild(script, env) {
@@ -20,6 +21,7 @@ function runChild(script, env) {
 		"BRAVE_API_KEY",
 		"PARALLEL_API_KEY",
 		"TAVILY_API_KEY",
+		"SEARXNG_BASE_URL",
 		"EXA_API_KEY",
 		"PERPLEXITY_API_KEY",
 		"GEMINI_API_KEY",
@@ -131,6 +133,66 @@ test("Tavily search uses bearer auth and maps filters/content", async () => {
 	assert.equal(output.result.answer, "Tavily answer");
 	assert.deepEqual(output.result.results, [{ title: "Tavily Docs", url: "https://docs.tavily.com/search", snippet: "Search docs snippet" }]);
 	assert.deepEqual(output.result.inlineContent, [{ url: "https://docs.tavily.com/search", title: "Tavily Docs", content: "# Tavily Docs\nFull content", error: null }]);
+});
+
+
+test("SearXNG search uses configured base URL and maps JSON results", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-searxng-"));
+	const child = runChild(`
+		const { writeFileSync } = await import("node:fs");
+		writeFileSync(${JSON.stringify(home)} + "/web-search.json", JSON.stringify({ searxngBaseUrl: "https://search.example.com/" }));
+
+		let capturedUrl = "";
+		let capturedHeaders = null;
+		globalThis.fetch = async (url, init) => {
+			capturedUrl = String(url);
+			capturedHeaders = init.headers;
+			return new Response(JSON.stringify({
+				answers: ["SearXNG instant answer"],
+				results: [
+					{ title: "Pi Web Access", url: "https://github.com/nicobailon/pi-web-access", content: "repo snippet" },
+					{ title: "Blocked", url: "https://gist.github.com/nicobailon/abc", content: "blocked snippet" },
+					{ title: "Other", url: "https://example.com/nope", content: "other snippet" },
+				],
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+
+		const { isSearXNGAvailable, searchWithSearXNG } = await import(${JSON.stringify(searxngModuleUrl)});
+		const available = isSearXNGAvailable();
+		const result = await searchWithSearXNG("pi web access", {
+			domainFilter: ["github.com", "-gist.github.com"],
+			recencyFilter: "week",
+			numResults: 2,
+		});
+		const parsedUrl = new URL(capturedUrl);
+		console.log(JSON.stringify({
+			available,
+			url: parsedUrl.origin + parsedUrl.pathname,
+			q: parsedUrl.searchParams.get("q"),
+			format: parsedUrl.searchParams.get("format"),
+			timeRange: parsedUrl.searchParams.get("time_range"),
+			accept: capturedHeaders.Accept,
+			result,
+		}));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.available, true);
+	assert.equal(output.url, "https://search.example.com/search");
+	assert.match(output.q, /pi web access/);
+	assert.match(output.q, /site:github\.com/);
+	assert.match(output.q, /-site:gist\.github\.com/);
+	assert.equal(output.format, "json");
+	assert.equal(output.timeRange, "week");
+	assert.equal(output.accept, "application/json");
+	assert.deepEqual(output.result.results, [{ title: "Pi Web Access", url: "https://github.com/nicobailon/pi-web-access", snippet: "repo snippet" }]);
+	assert.match(output.result.answer, /SearXNG instant answer/);
+	assert.match(output.result.answer, /repo snippet/);
 });
 
 test("auto provider falls through to Tavily after unavailable earlier providers", async () => {


### PR DESCRIPTION
## Summary

Adds SearXNG as an optional `web_search` provider for self-hosted/private metasearch setups. This addresses the SearXNG portion of #105; Firecrawl is intentionally left out to keep this PR focused.

## Details

- Adds `searxngBaseUrl` config and `SEARXNG_BASE_URL` env support
- Uses SearXNG JSON API at `/search?format=json&q=...`
- Supports `numResults`, `recencyFilter`, and domain include/exclude filters
- Wires SearXNG into explicit provider selection, auto fallback, curator availability/buttons, and tool schema
- Updates README/CHANGELOG and provider tests

## Validation

- `npm test`
- Manual smoke test against a self-hosted SearXNG instance (`SEARXNG_BASE_URL=... node --input-type=module ...`)

Refs #105