### PR TITLE
feat(ssrf): add trust env proxy

### DIFF
--- a/extract.ts
+++ b/extract.ts
@@ -21,37 +21,51 @@ const NON_RECOVERABLE_ERRORS = ["Unsupported content type", "Response too large"
 const MIN_USEFUL_CONTENT = 500;
 const WEB_SEARCH_CONFIG_PATH = getWebSearchConfigPath();
 
+interface SsrfConfig {
+	allowRanges: string[];
+	trustEnvProxy: boolean;
+}
+
 /**
- * Read `ssrf.allowRanges` (CIDR strings) from web-search.json. Returns [] when
- * the file is missing, unreadable, or the key is unset so SSRF protection stays
- * fully on by default. Throws when `ssrf.allowRanges` is present but not an array
- * so a mistyped value (e.g. a bare string instead of a JSON array) fails loudly
- * instead of being silently ignored. Exempts synthetic ranges used by TUN/fake-IP
- * proxies (e.g. 198.18.0.0/15).
+ * Read SSRF-related config from web-search.json. Returns the safest defaults
+ * when the file is missing, unreadable, or the key is unset so protection stays
+ * fully on by default. Throws on mistyped values so misconfiguration is loud.
  */
-export function loadSsrfAllowRanges(): string[] {
-	let value: unknown;
+export function loadSsrfConfig(): SsrfConfig {
+	let ssrf: unknown;
 	try {
-		if (!existsSync(WEB_SEARCH_CONFIG_PATH)) return [];
+		if (!existsSync(WEB_SEARCH_CONFIG_PATH)) return { allowRanges: [], trustEnvProxy: false };
 		const raw = readFileSync(WEB_SEARCH_CONFIG_PATH, "utf-8");
-		value = (JSON.parse(raw) as { ssrf?: { allowRanges?: unknown } })?.ssrf?.allowRanges;
+		ssrf = (JSON.parse(raw) as { ssrf?: unknown })?.ssrf;
 	} catch {
 		// Missing/unreadable file or invalid JSON: fail safe with SSRF fully on.
-		return [];
+		return { allowRanges: [], trustEnvProxy: false };
 	}
-	if (value === undefined || value === null) return [];
-	if (!Array.isArray(value)) {
+	if (ssrf === undefined || ssrf === null) return { allowRanges: [], trustEnvProxy: false };
+	if (typeof ssrf !== "object" || Array.isArray(ssrf)) {
+		throw new Error(`ssrf in ${WEB_SEARCH_CONFIG_PATH} must be an object`);
+	}
+	const allowRangesValue = (ssrf as { allowRanges?: unknown }).allowRanges;
+	const trustEnvProxyValue = (ssrf as { trustEnvProxy?: unknown }).trustEnvProxy;
+	if (allowRangesValue !== undefined && allowRangesValue !== null && !Array.isArray(allowRangesValue)) {
 		throw new Error(`ssrf.allowRanges in ${WEB_SEARCH_CONFIG_PATH} must be an array of CIDR strings`);
 	}
+	if (trustEnvProxyValue !== undefined && typeof trustEnvProxyValue !== "boolean") {
+		throw new Error(`ssrf.trustEnvProxy in ${WEB_SEARCH_CONFIG_PATH} must be a boolean`);
+	}
 	const ranges: string[] = [];
-	for (const [index, entry] of value.entries()) {
+	for (const [index, entry] of (allowRangesValue ?? []).entries()) {
 		if (typeof entry !== "string") {
 			throw new Error(`ssrf.allowRanges in ${WEB_SEARCH_CONFIG_PATH} must contain only CIDR strings; entry ${index + 1} is ${typeof entry}`);
 		}
 		const trimmed = entry.trim();
 		if (trimmed) ranges.push(trimmed);
 	}
-	return ranges;
+	return { allowRanges: ranges, trustEnvProxy: trustEnvProxyValue === true };
+}
+
+export function loadSsrfAllowRanges(): string[] {
+	return loadSsrfConfig().allowRanges;
 }
 
 function errorMessage(err: unknown): string {
@@ -120,7 +134,8 @@ async function extractWithJinaReader(
 	const activityId = activityMonitor.logStart({ type: "api", query: `jina: ${url}` });
 
 	try {
-		await validateRemoteUrl(url, { allowRanges: loadSsrfAllowRanges(), lookup });
+		const ssrf = loadSsrfConfig();
+		await validateRemoteUrl(url, { allowRanges: ssrf.allowRanges, trustEnvProxy: ssrf.trustEnvProxy, lookup });
 		const res = await fetch(jinaUrl, {
 			headers: {
 				"Accept": "text/markdown",
@@ -407,7 +422,8 @@ export async function extractContent(
 	try {
 		const parsed = new URL(url);
 		if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-			await validateRemoteUrl(parsed, { allowRanges: loadSsrfAllowRanges(), lookup: options?.lookup });
+			const ssrf = loadSsrfConfig();
+			await validateRemoteUrl(parsed, { allowRanges: ssrf.allowRanges, trustEnvProxy: ssrf.trustEnvProxy, lookup: options?.lookup });
 		}
 	} catch (err) {
 		return { url, title: "", content: "", error: errorMessage(err) };
@@ -541,6 +557,7 @@ async function extractViaHttp(
 	signal?.addEventListener("abort", onAbort);
 
 	try {
+		const ssrf = loadSsrfConfig();
 		const response = await fetchRemoteUrl(
 			url,
 			{
@@ -557,7 +574,7 @@ async function extractViaHttp(
 					"Upgrade-Insecure-Requests": "1",
 				},
 			},
-			{ allowRanges: loadSsrfAllowRanges(), lookup: options?.lookup },
+			{ allowRanges: ssrf.allowRanges, trustEnvProxy: ssrf.trustEnvProxy, lookup: options?.lookup },
 		);
 
 		if (!response.ok) {

--- a/index.ts
+++ b/index.ts
@@ -80,6 +80,8 @@ interface WebSearchConfig {
 	ssrf?: {
 		/** CIDR ranges exempted from the SSRF guard (e.g. fake-IP proxy ranges). */
 		allowRanges?: string[];
+		/** Trust explicit HTTP(S)_PROXY env vars for hostname resolution instead of local DNS. */
+		trustEnvProxy?: boolean;
 	};
 }
 

--- a/ssrf-protection.ts
+++ b/ssrf-protection.ts
@@ -17,6 +17,15 @@ interface ValidationOptions {
 	 * strictly; an invalid entry throws so misconfiguration is not silent.
 	 */
 	allowRanges?: string[];
+	/**
+	 * When true, trust an explicitly-configured HTTP(S) proxy for hostname
+	 * resolution instead of performing local DNS lookups inside the sandbox.
+	 * This keeps localhost and literal IP blocking in place, but skips the
+	 * preflight DNS resolution step for ordinary hostnames when they will be sent
+	 * through a proxy. Intended for sandboxed environments where OpenShell and the
+	 * outbound proxy already enforce egress policy.
+	 */
+	trustEnvProxy?: boolean;
 }
 
 /** Parsed entry from `allowRanges`: a network address (4 or 16 bytes) + prefix length. */
@@ -50,6 +59,10 @@ export async function validateRemoteUrl(rawUrl: string | URL, options: Validatio
 
 	if (net.isIP(hostname)) {
 		assertPublicAddress(hostname, hostname, allowRanges);
+		return url;
+	}
+
+	if (shouldTrustEnvProxy(url, options.trustEnvProxy === true)) {
 		return url;
 	}
 
@@ -98,6 +111,36 @@ export async function fetchRemoteUrl(
 
 function normalizeHostname(hostname: string): string {
 	return hostname.toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+}
+
+function getProxyForProtocol(protocol: string): string {
+	if (protocol === "http:") {
+		return process.env.HTTP_PROXY || process.env.http_proxy || process.env.ALL_PROXY || process.env.all_proxy || "";
+	}
+	if (protocol === "https:") {
+		return process.env.HTTPS_PROXY || process.env.https_proxy ||
+			process.env.HTTP_PROXY || process.env.http_proxy ||
+			process.env.ALL_PROXY || process.env.all_proxy || "";
+	}
+	return "";
+}
+
+function hostnameMatchesNoProxy(hostname: string, noProxyEntry: string): boolean {
+	const entry = normalizeHostname(noProxyEntry.trim());
+	if (!entry) return false;
+	if (entry === "*") return true;
+	if (entry === hostname) return true;
+	const suffix = entry.startsWith("*.") ? entry.slice(1) : entry.startsWith(".") ? entry : `.${entry}`;
+	return hostname.endsWith(suffix);
+}
+
+function shouldTrustEnvProxy(url: URL, enabled: boolean): boolean {
+	if (!enabled) return false;
+	if (!getProxyForProtocol(url.protocol)) return false;
+	const hostname = normalizeHostname(url.hostname);
+	const noProxy = process.env.NO_PROXY || process.env.no_proxy || "";
+	if (!noProxy) return true;
+	return !noProxy.split(",").some(entry => hostnameMatchesNoProxy(hostname, entry));
 }
 
 function assertPublicAddress(address: string, hostname: string, allowRanges: ParsedCidr[] = []): void {


### PR DESCRIPTION
Adds an opt-in `ssrf.trustEnvProxy` setting for proxied environments.

When enabled, `pi-web-access` skips local DNS preflight for hostnames sent through explicit `HTTP_PROXY` / `HTTPS_PROXY`, while still blocking `localhost`, `*.localhost`, and literal internal IPs, and respecting `NO_PROXY`.

This is mandatory in sandboxed setups like OpenShell where outbound access is enforced by the sandbox/proxy policy, and local DNS preflight fails before the request reaches that policy boundary.