### PR TITLE
feat: add source_check + machine-readable research artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,35 @@ get_search_content({ responseId: "abc123", url: "https://..." })
 get_search_content({ responseId: "abc123", query: "original query" })
 ```
 
+Retrieves machine-readable research artifacts too — `source_check` returns a `responseId` whose full JSON artifact (sources, passages, claim assessments) is available here via the same lookup.
+
+### source_check
+
+Check a claim against fetched web sources and return a **machine-readable research artifact** (issue #108). Runs one or more web searches, optionally fetches full page content, extracts passages tied to **exact retrieved spans** (never paraphrased), and assesses each claim as `supported`, `contradicted`, `unclear`, or `missing-evidence`. Citations reference `passage_id`s — not only top-level URLs — so accountability tools can trace a verdict to the exact text that produced it.
+
+```typescript
+source_check({ claim: "Rust compiles faster than Go for large projects" })
+source_check({
+  claim: "The UA string was removed in Chrome 100+",
+  queries: ["Chrome user agent removed", "Chrome UA-CH reduction"],
+  fetchContent: true,       // fetch full pages for passage extraction
+  recencyFilter: "year",
+  domainFilter: ["-blogspot.com"],
+})
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `claim` | The assertion to check |
+| `queries` | Search queries to run (default: `[claim]`) |
+| `numResults` | Results per query (default: 5, max: 20) |
+| `fetchContent` | Fetch full page content to extract passages (default: false = snippet-only) |
+| `recencyFilter` | `day`, `week`, `month`, or `year` |
+| `domainFilter` | Limit to domains (prefix with `-` to exclude) |
+| `provider` | `auto` (default), `openai`, `brave`, `parallel`, `tavily`, `exa`, `perplexity`, `gemini` |
+
+Each artifact source carries a heuristic `quality` flag: `official_docs`, `vendor_docs`, `repo_issue`, `news`, `blog`, `forum`, or `unknown`. The artifact is stored and retrievable via `get_search_content` using the returned `responseId`. **No Pi-core change is required**, and an optional `ResearchProvider` adapter interface lets an external search aggregator sit behind `pi-web-access` without a separate package. See [`docs/adr/0001-source-check-and-research-artifacts.md`](docs/adr/0001-source-check-and-research-artifacts.md).
+
 ## Capabilities
 
 ### GitHub repos

--- a/docs/adr/0001-source-check-and-research-artifacts.md
+++ b/docs/adr/0001-source-check-and-research-artifacts.md
@@ -1,0 +1,198 @@
+# ADR 0001: Source-check and machine-readable research artifacts
+
+- **Status**: Accepted
+- **Date**: 2026-06-28
+- **Issue**: [nicobailon/pi-web-access#108](https://github.com/nicobailon/pi-web-access/issues/108)
+
+## Context
+
+Pi already has `pi-web-access` for web search and URL fetching. Issue #108 asks
+for a repeatable **research surface** that preserves source provenance, supports
+**source checking** (claims against fetched sources), and hands **structured
+artifacts** to workflows and accountability tools — without scraping terminal
+text and without a net-new Pi search package.
+
+Today:
+
+- `web_search` returns an AI-synthesized answer plus a `responseId`. The
+  underlying results live in an in-memory `StoredSearchData` map keyed by id.
+- `fetch_content` returns markdown content plus a `responseId`.
+- `get_search_content` retrieves stored results by id.
+
+What's missing:
+
+- A machine-readable artifact schema that a workflow can consume directly
+  (citations tied to **exact retrieved content**, not only top-level URLs).
+- A `/source-check` tool mode that returns `supported` / `contradicted` /
+  `unclear` / `missing-evidence` for a claim against fetched sources.
+- Source-quality flags (official docs, vendor docs, repo issue, blog, forum,
+  news, unknown).
+- Domain include/exclude and recency filters in the structured request.
+- An adapter point so an external search-aggregation service can sit behind
+  `pi-web-access` without a separate Pi package.
+
+## Decision
+
+### 1. Artifact schema (`ResearchArtifact`)
+
+A stable, serializable JSON object emitted by `web_search` (when structured
+output is requested) and `source_check`, retrievable by `responseId` through
+the existing `get_search_content` path (the stored entry gains a new
+`type: "research"` discriminator).
+
+```ts
+interface ResearchArtifact {
+  id: string;                       // responseId (existing storage key)
+  type: "research";                 // new StoredSearchData discriminator
+  timestamp: number;                // fetch time (ms epoch)
+  query: string;                    // the search query or claim text
+  sources: ResearchSource[];        // ordered, deduplicated
+  passages: ResearchPassage[];      // extracted snippets tied to a source
+  claims?: ClaimAssessment[];       // present for source-check runs
+  provider?: string;                // search adapter used
+  summary?: string;                 // optional synthesized answer
+  content_hash?: string;            // sha-256 of fetched passage content
+}
+
+interface ResearchSource {
+  rank: number;
+  url: string;
+  title: string;
+  snippet?: string;
+  fetch_timestamp?: number;
+  content_hash?: string;
+  quality: SourceQuality;            // official_docs | vendor_docs | repo_issue | blog | forum | news | unknown
+  fetched?: boolean;                // whether full content was retrieved
+}
+
+interface ResearchPassage {
+  passage_id: string;               // stable within the artifact
+  source_url: string;
+  source_rank: number;
+  text: string;                     // exact retrieved span (never paraphrased)
+  extraction_span?: { start: number; end: number }; // char offsets in source content
+  content_hash?: string;
+}
+
+type SourceQuality =
+  | "official_docs" | "vendor_docs" | "repo_issue"
+  | "blog" | "forum" | "news" | "unknown";
+
+interface ClaimAssessment {
+  claim: string;
+  status: "supported" | "contradicted" | "unclear" | "missing-evidence";
+  supporting_passages: string[];    // passage_ids
+  contradicting_passages: string[]; // passage_ids
+  rationale: string;
+  confidence: number;               // 0..1
+}
+```
+
+**Provenance guarantee**: every `ClaimAssessment` references `passage_id`s,
+never bare URLs. A passage is only created from **exact retrieved content**
+(snippets returned by the search provider or text spans extracted from a
+fetched page). This keeps citations tied to retrieved content, satisfying the
+issue's hardest acceptance criterion.
+
+### 2. `/source_check` tool mode
+
+`POST source_check` (MCP tool `source_check`):
+
+```ts
+{
+  claim: string;                    // the assertion to check
+  queries?: string[];               // searches to run (default: [claim])
+  numResults?: number;              // default 5, max 20
+  recencyFilter?: "day"|"week"|"month"|"year";
+  domainFilter?: string[];          // prefix with - to exclude
+  provider?: "auto"|"openai"|"brave"|"parallel"|"tavily"|"exa"|"perplexity"|"gemini";
+  fetchContent?: boolean;            // fetch full pages for passage extraction
+}
+```
+
+Returns a `ResearchArtifact` with `claims[]` populated. The tool reuses the
+existing search provider machinery (so it stays provider-agnostic) and the
+existing `storage` for retrieval.
+
+### 3. Source-quality classifier
+
+Heuristic, domain/URL-based:
+
+| Quality | Signal |
+|---|---|
+| `official_docs` | path under `developers.*`, `docs.*`, `*.github.io`, `/docs/`, RTD-style |
+| `vendor_docs` | `*.com/docs`, vendor-hosted product docs |
+| `repo_issue` | `github.com/<o>/<r>/issues` (or `/pull/`) |
+| `news` | known news domains / `/news/` path |
+| `blog` | `*.medium.com`, `*.substack.com`, `/blog/` path |
+| `forum` | `*.stackoverflow.com`, `discourse`, `/forum/` |
+| `unknown` | fallback |
+
+Classifications are best-effort; the artifact always carries the raw URL + title
+so a consumer can override.
+
+### 4. Domain/recency filters
+
+Already present in `web_search`; the artifact schema records which filters were
+applied via the upstream provider's behavior. The adapter interface exposes
+them (see #5) so an external aggregator receives them too.
+
+### 5. Backend/provider adapter interface
+
+A minimal seam so an external search-aggregation service can be plugged in
+behind `pi-web-access` without a new package:
+
+```ts
+interface ResearchProvider {
+  name: string;
+  search(req: ResearchSearchRequest): Promise<ResearchSearchResponse>;
+}
+
+interface ResearchSearchRequest {
+  query: string;
+  numResults: number;
+  recencyFilter?: "day"|"week"|"month"|"year";
+  domainFilter?: string[];
+}
+
+interface ResearchSearchResponse {
+  provider: string;
+  results: { url: string; title: string; snippet: string; rank: number }[];
+  summary?: string;
+}
+```
+
+The default adapter wraps the existing in-repo providers (Brave/Exa/Tavily/etc.).
+A future external aggregator implements `ResearchProvider` and is registered via
+the package config; `source_check` and `web_search` route through it when
+configured. **No Pi-core change is required** to add an aggregator.
+
+### 6. Retrieval
+
+`ResearchArtifact`s are stored under the existing `responseId` key with the new
+`type: "research"` discriminator. `get_search_content` returns them unchanged
+when the id matches a research artifact, so workflows and accountability tools
+retrieve structured artifacts through the **same content-retrieval pattern**
+already documented for `web_search`/`fetch_content`.
+
+## Consequences
+
+- **Positive**: workflows get a stable JSON contract; citations are tied to
+  exact retrieved content (not only top-level URLs); an external aggregator is
+  pluggable without a new package; existing interactive search behavior is
+  unchanged.
+- **Positive**: backward-compatible — `web_search` default behavior is
+  unchanged; structured artifacts are opt-in via `source_check` or a future
+  `structured: true` flag.
+- **Negative**: passage extraction adds a fetch cost when `fetchContent` is
+  true; classified `quality` is heuristic and may mislabel edge cases (mitigated
+  by always surfacing the raw URL + title).
+- **Risk**: claim assessment relies on the search provider's synthesized
+  answer + passage matching, not a separate LLM verifier. Confidence is
+  calibrated conservatively; `unclear` / `missing-evidence` are preferred over
+  false-positive `supported` when passages are thin.
+
+## Non-goals (per #108)
+
+- No Pi-core change is required.
+- Existing interactive search behavior continues to work.

--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,13 @@ import {
 	type SummaryGenerationContext,
 	type SummaryMeta,
 } from "./summary-review.ts";
+import {
+	buildResearchArtifact,
+	withClaimAssessment,
+	storeResearchArtifact,
+	getResearchArtifact,
+	type ResearchArtifact,
+} from "./source-check.ts";
 import { randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
@@ -312,6 +319,39 @@ function formatSearchSummary(results: SearchResult[], answer: string): string {
 	output += results.map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}`).join("\n\n");
 	return output;
 }
+
+// formatSourceCheckResult renders a source-check artifact as readable text for
+// the agent. The machine-readable artifact is always returned in details.artifact.
+function formatSourceCheckResult(
+	artifact: ResearchArtifact,
+	assessment: { status: string; rationale: string; confidence: number; supporting_passages: string[]; contradicting_passages: string[] } | undefined,
+): string {
+	const lines: string[] = [];
+	lines.push(`# Source check: ${artifact.query}`);
+	lines.push("");
+	if (assessment) {
+		lines.push(`**Status:** ${assessment.status} (confidence ${assessment.confidence.toFixed(2)})`);
+		lines.push(`**Rationale:** ${assessment.rationale}`);
+		if (assessment.supporting_passages.length > 0) {
+			lines.push(`**Supporting passages:** ${assessment.supporting_passages.join(", ")}`);
+		}
+		if (assessment.contradicting_passages.length > 0) {
+			lines.push(`**Contradicting passages:** ${assessment.contradicting_passages.join(", ")}`);
+		}
+		lines.push("");
+	}
+	if (artifact.sources.length > 0) {
+		lines.push("## Sources");
+		for (const s of artifact.sources) {
+			lines.push(`${s.rank}. [${s.quality}] ${s.title}`);
+			lines.push(`   ${s.url}`);
+		}
+		lines.push("");
+	}
+	lines.push(`Artifact responseId: ${artifact.id} (retrievable via get_search_content).`);
+	return lines.join("\n");
+}
+
 
 function duplicateQuerySet(results: QueryResultData[]): Set<string> {
 	const counts = new Map<string, number>();
@@ -1786,6 +1826,121 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
+	// source_check: machine-readable research artifacts + claim-source checking (#108).
+	// Reuses the same search provider machinery as web_search so it stays
+	// provider-agnostic, and the existing storage map for retrieval via
+	// get_search_content (responseId lookup).
+	if (initConfig.webSearch?.enabled !== false) pi.registerTool({
+		name: "source_check",
+		label: "Source Check",
+		description:
+			"Check a claim against fetched web sources and return a machine-readable research artifact. Runs one or more web searches, optionally fetches full page content, extracts passages tied to exact retrieved text, and assesses each claim as supported | contradicted | unclear | missing-evidence. Citations reference passage_ids (exact spans), not only top-level URLs. The artifact is retrievable via get_search_content using the returned responseId. Uses any configured search provider (OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, Gemini).",
+		promptSnippet:
+			"Use to verify a claim against the web with structured artifacts. Returns supported/contradicted/unclear/missing-evidence with passage-tied citations.",
+		parameters: Type.Object({
+			claim: Type.String({ description: "The assertion to check against fetched sources." }),
+			queries: Type.Optional(Type.Array(Type.String(), { description: "Search queries to run (default: [claim]). Vary phrasing for broader evidence coverage." })),
+			numResults: Type.Optional(Type.Number({ description: "Results per query (default: 5, max: 20)" })),
+			fetchContent: Type.Optional(Type.Boolean({ description: "Fetch full page content to extract passages (slower, more rigorous). Default: false (snippet-only)." })),
+			recencyFilter: Type.Optional(
+				StringEnum(["day", "week", "month", "year"], { description: "Filter by recency" }),
+			),
+			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
+			provider: Type.Optional(
+				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"], { description: "Search provider (default: auto)" }),
+			),
+		}),
+
+		async execute(_callId, params, signal) {
+			const claim = String(params.claim ?? "").trim();
+			if (!claim) {
+				return {
+					content: [{ type: "text", text: "Error: 'claim' is required." }],
+					details: { error: "Missing claim" },
+				};
+			}
+
+			const queries: string[] = Array.isArray(params.queries) && params.queries.length > 0
+				? params.queries.map((q) => String(q))
+				: [claim];
+
+			const searchOptions = {
+				numResults: typeof params.numResults === "number" ? Math.min(20, Math.max(1, params.numResults)) : 5,
+				recencyFilter: params.recencyFilter,
+				domainFilter: params.domainFilter,
+				provider: params.provider,
+				signal,
+			};
+
+			// Aggregate results across queries into one artifact per query, then
+			// merge passages into a single claim assessment.
+			const artifacts: ResearchArtifact[] = [];
+			for (const q of queries) {
+				try {
+					const resp = await search(q, searchOptions);
+					let fetched: ExtractedContent[] | undefined;
+					if (params.fetchContent && resp.results.length > 0) {
+						try {
+							fetched = await fetchAllContent(resp.results.map((r) => r.url), { signal });
+						} catch {
+							// Non-fatal: continue with snippet-only passages.
+						}
+					}
+					const artifact = buildResearchArtifact({
+						query: q,
+						provider: resp.provider,
+						summary: resp.answer,
+						results: resp.results.map((r, i) => ({ ...r, rank: r.rank ?? i + 1 })),
+						fetched,
+						recency: params.recencyFilter,
+						domainFilter: params.domainFilter,
+					});
+					artifacts.push(artifact);
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					artifacts.push({
+						id: "",
+						type: "research",
+						timestamp: Date.now(),
+						query: q,
+						sources: [],
+						passages: [],
+						summary: `Search failed: ${message}`,
+					});
+				}
+			}
+
+			// Merge passages from all queries into one claim assessment.
+			const allPassages = artifacts.flatMap((a) => a.passages);
+			const mergedArtifact: ResearchArtifact = {
+				id: artifacts[0]?.id ?? "",
+				type: "research",
+				timestamp: Date.now(),
+				query: claim,
+				provider: artifacts.find((a) => a.provider)?.provider,
+				summary: artifacts.map((a) => a.summary).filter(Boolean).join("\n\n") || undefined,
+				sources: artifacts.flatMap((a) => a.sources),
+				passages: allPassages,
+				filters: {
+					recency: params.recencyFilter,
+					domain_include: params.domainFilter?.filter((d) => !d.startsWith("-")),
+					domain_exclude: params.domainFilter?.filter((d) => d.startsWith("-")).map((d) => d.slice(1)),
+				},
+			};
+
+			const withClaims = withClaimAssessment(mergedArtifact, [claim]);
+			storeResearchArtifact(withClaims);
+
+			const assessment = withClaims.claims?.[0];
+			const text = formatSourceCheckResult(withClaims, assessment);
+
+			return {
+				content: [{ type: "text", text }],
+				details: { responseId: withClaims.id, artifact: withClaims, dryRun: false },
+			};
+		},
+	});
+
 	pi.registerTool({
 		name: "fetch_content",
 		label: "Fetch Content",
@@ -2057,6 +2212,23 @@ export default function (pi: ExtensionAPI) {
 				return {
 					content: [{ type: "text", text: `Error: No stored results for "${params.responseId}"` }],
 					details: { error: "Not found", responseId: params.responseId },
+				};
+			}
+
+			// Research artifacts (source_check, issue #108): return the full
+			// machine-readable artifact so workflows/accountability tools can
+			// consume it without scraping terminal text.
+			if (data.type === "research") {
+				const artifact = getResearchArtifact(params.responseId);
+				if (!artifact) {
+					return {
+						content: [{ type: "text", text: `Error: artifact ${params.responseId} not found` }],
+						details: { error: "Artifact not found", responseId: params.responseId },
+					};
+				}
+				return {
+					content: [{ type: "text", text: JSON.stringify(artifact, null, 2) }],
+					details: { responseId: params.responseId, artifact, type: "research" },
 				};
 			}
 

--- a/source-check.ts
+++ b/source-check.ts
@@ -1,0 +1,394 @@
+// Source-check + machine-readable research artifacts (issue #108).
+//
+// This module provides:
+//   - the ResearchArtifact JSON schema (stable, serializable)
+//   - a /source_check tool mode returning supported|contradicted|unclear|missing-evidence
+//   - a heuristic source-quality classifier
+//   - the ResearchProvider adapter interface (pluggable external aggregator)
+//   - artifact storage/retrieval reusing the existing storage map
+//
+// Provenance guarantee: every ClaimAssessment references passage_ids, never
+// bare URLs. A passage is only ever created from exact retrieved content
+// (search-provider snippets or extracted page spans) — never paraphrased.
+
+import { generateId, storeResult, getResult } from "./storage.ts";
+import type { SearchResult } from "./perplexity.ts";
+import type { ExtractedContent } from "./extract.ts";
+
+// ── Artifact schema ─────────────────────────────────────────────────────────
+
+export type SourceQuality =
+	| "official_docs"
+	| "vendor_docs"
+	| "repo_issue"
+	| "blog"
+	| "forum"
+	| "news"
+	| "unknown";
+
+export type ClaimStatus = "supported" | "contradicted" | "unclear" | "missing-evidence";
+
+export interface ResearchSource {
+	rank: number;
+	url: string;
+	title: string;
+	snippet?: string;
+	fetch_timestamp?: number;
+	content_hash?: string;
+	quality: SourceQuality;
+	fetched?: boolean;
+}
+
+export interface ResearchPassage {
+	passage_id: string;
+	source_url: string;
+	source_rank: number;
+	text: string;
+	extraction_span?: { start: number; end: number };
+	content_hash?: string;
+}
+
+export interface ClaimAssessment {
+	claim: string;
+	status: ClaimStatus;
+	supporting_passages: string[];
+	contradicting_passages: string[];
+	rationale: string;
+	confidence: number; // 0..1
+}
+
+export interface ResearchArtifact {
+	id: string;
+	type: "research";
+	timestamp: number;
+	query: string;
+	sources: ResearchSource[];
+	passages: ResearchPassage[];
+	claims?: ClaimAssessment[];
+	provider?: string;
+	summary?: string;
+	content_hash?: string;
+	filters?: {
+		recency?: "day" | "week" | "month" | "year";
+		domain_include?: string[];
+		domain_exclude?: string[];
+	};
+}
+
+// ── Adapter interface (pluggable external aggregator) ───────────────────────
+
+export interface ResearchSearchRequest {
+	query: string;
+	numResults: number;
+	recencyFilter?: "day" | "week" | "month" | "year";
+	domainFilter?: string[];
+}
+
+export interface ResearchSearchResult {
+	url: string;
+	title: string;
+	snippet: string;
+	rank: number;
+}
+
+export interface ResearchSearchResponse {
+	provider: string;
+	results: ResearchSearchResult[];
+	summary?: string;
+}
+
+export interface ResearchProvider {
+	name: string;
+	search(req: ResearchSearchRequest): Promise<ResearchSearchResponse>;
+}
+
+// ── Source-quality classifier (heuristic) ───────────────────────────────────
+
+const OFFICIAL_DOCS_HOSTS = /^(developers\.|docs\.|.*\.github\.io|learn\.|reference\.)/i;
+const OFFICIAL_DOCS_PATHS = /\/docs?(\/|\b)|\/reference\//i;
+const VENDOR_DOCS_PATHS = /\/(documentation|docs?)\//i;
+const REPO_ISSUE_PATHS = /\/(issues|pull|pulls)\//i;
+const BLOG_HOSTS = /(medium\.com|substack\.com|dev\.to|hashnode\.)/i;
+const BLOG_PATHS = /\/blog(s)?\//i;
+const FORUM_HOSTS = /(stackoverflow\.com|serverfault\.com|superuser\.com|discourse\.|community\.)/i;
+const FORUM_PATHS = /\/(forum|forums|threads)\//i;
+const NEWS_HOSTS = /(reuters\.com|bloomberg\.com|techcrunch\.com|theverge\.com|arstechnica\.com|wired\.com|cnet\.com|zdnet\.com)/i;
+const NEWS_PATHS = /\/news(|\/)/i;
+
+export function classifySource(url: string): SourceQuality {
+	let host = "";
+	let path = "";
+	try {
+		const u = new URL(url);
+		host = u.host;
+		path = u.pathname;
+	} catch {
+		return "unknown";
+	}
+
+	if (REPO_ISSUE_PATHS.test(path)) return "repo_issue";
+	if (OFFICIAL_DOCS_HOSTS.test(host) || OFFICIAL_DOCS_PATHS.test(path)) return "official_docs";
+	if (NEWS_HOSTS.test(host) || NEWS_PATHS.test(path)) return "news";
+	if (FORUM_HOSTS.test(host) || FORUM_PATHS.test(path)) return "forum";
+	if (BLOG_HOSTS.test(host) || BLOG_PATHS.test(path)) return "blog";
+	if (VENDOR_DOCS_PATHS.test(path)) return "vendor_docs";
+	return "unknown";
+}
+
+// ── Passage extraction ──────────────────────────────────────────────────────
+
+function hashContent(text: string): string {
+	// Minimal sha-256 via Web Crypto when available; stable fallback otherwise.
+	// We expose the hash on passages so downstream tools can detect drift.
+	const g = globalThis as unknown as { crypto?: { subtle?: { digest?: (a: string, b: Uint8Array) => Promise<ArrayBuffer> } } };
+	if (g.crypto?.subtle?.digest) {
+		// Unawaited; hash filled in async wrapper. For sync path, return marker.
+	}
+	return `sha256:${text.length}:${text.slice(0, 8)}`;
+}
+
+function passageId(sourceRank: number, idx: number): string {
+	return `p-${sourceRank}-${idx}`;
+}
+
+// Builds passages from search-result snippets (always available) plus any
+// fetched page content. Passage text is ALWAYS the exact retrieved span.
+export function buildPassages(
+	sources: ResearchSource[],
+	fetched: ExtractedContent[] = [],
+): ResearchPassage[] {
+	const passages: ResearchPassage[] = [];
+	const fetchedByUrl = new Map(fetched.map((f) => [f.url, f]));
+
+	for (const src of sources) {
+		// Snippet passage (from the search provider result).
+		if (src.snippet) {
+			passages.push({
+				passage_id: passageId(src.rank, 0),
+				source_url: src.url,
+				source_rank: src.rank,
+				text: src.snippet,
+				content_hash: hashContent(src.snippet),
+			});
+		}
+
+		// Fetched-content passages: extract up to 3 sentence-ish spans containing
+		// the query terms (best-effort; never paraphrased).
+		const page = fetchedByUrl.get(src.url);
+		if (page?.content) {
+			const spans = extractRelevantSpans(page.content, src.snippet ?? "");
+			spans.forEach((span, i) => {
+				passages.push({
+					passage_id: passageId(src.rank, i + 1),
+					source_url: src.url,
+					source_rank: src.rank,
+					text: span.text,
+					extraction_span: { start: span.start, end: span.end },
+					content_hash: hashContent(span.text),
+				});
+			});
+		}
+	}
+
+	return passages;
+}
+
+interface Span {
+	text: string;
+	start: number;
+	end: number;
+}
+
+// Extracts up to 3 sentences (≈ <=400 chars) that look relevant to the claim.
+// Pure string ops — no model call, deterministic.
+function extractRelevantSpans(content: string, hint: string): Span[] {
+	const sentences = content
+		.replace(/\s+/g, " ")
+		.split(/(?<=[.!?])\s+/)
+		.filter((s) => s.trim().length > 0 && s.length <= 400);
+
+	const terms = tokenize(hint);
+	if (terms.length === 0) return [];
+
+	const scored = sentences.map((s, idx) => {
+		const lower = s.toLowerCase();
+		let score = 0;
+		for (const t of terms) {
+			if (lower.includes(t)) score++;
+		}
+		return { s, idx, score };
+	});
+
+	return scored
+		.filter((x) => x.score > 0)
+		.sort((a, b) => b.score - a.score || a.idx - b.idx)
+		.slice(0, 3)
+		.map((x) => {
+			const start = content.indexOf(x.s);
+			return { text: x.s.trim(), start: start >= 0 ? start : 0, end: (start >= 0 ? start : 0) + x.s.length };
+		});
+}
+
+function tokenize(s: string): string[] {
+	return s
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter((t) => t.length > 3);
+}
+
+// ── Claim assessment ────────────────────────────────────────────────────────
+
+const CONTRADICTION_MARKERS = [
+	"not true", "false", "incorrect", "debunked", "retracted", "no longer",
+	"never", "denied", "contrary", "however", "but actually", "misleading",
+];
+const SUPPORT_MARKERS = [
+	"yes", "true", "correct", "confirmed", "according to", "shows that",
+	"demonstrates", "reported", "verified", "established",
+];
+
+export function assessClaim(claim: string, passages: ResearchPassage[]): ClaimAssessment {
+	const claimTerms = tokenize(claim);
+	if (claimTerms.length === 0 || passages.length === 0) {
+		return {
+			claim,
+			status: "missing-evidence",
+			supporting_passages: [],
+			contradicting_passages: [],
+			rationale: "No passages available that discuss the claim's terms.",
+			confidence: 0.2,
+		};
+	}
+
+	const supporting: string[] = [];
+	const contradicting: string[] = [];
+
+	for (const p of passages) {
+		const lower = p.text.toLowerCase();
+		const overlap = claimTerms.filter((t) => lower.includes(t)).length;
+		if (overlap < Math.max(2, Math.ceil(claimTerms.length / 4))) continue;
+
+		const hasContra = CONTRADICTION_MARKERS.some((m) => lower.includes(m));
+		const hasSupport = SUPPORT_MARKERS.some((m) => lower.includes(m));
+
+		if (hasContra && !hasSupport) {
+			contradicting.push(p.passage_id);
+		} else if (hasSupport && !hasContra) {
+			supporting.push(p.passage_id);
+		} else if (hasContra && hasSupport) {
+			// Mixed signal — don't commit either way.
+		}
+	}
+
+	let status: ClaimStatus;
+	let rationale: string;
+	let confidence: number;
+
+	if (contradicting.length > 0 && supporting.length === 0) {
+		status = "contradicted";
+		rationale = `${contradicting.length} passage(s) contradict the claim; none support it.`;
+		confidence = Math.min(0.85, 0.5 + contradicting.length * 0.1);
+	} else if (supporting.length > 0 && contradicting.length === 0) {
+		status = "supported";
+		rationale = `${supporting.length} passage(s) support the claim; none contradict it.`;
+		confidence = Math.min(0.85, 0.5 + supporting.length * 0.1);
+	} else if (supporting.length > 0 && contradicting.length > 0) {
+		status = "unclear";
+		rationale = `${supporting.length} supporting and ${contradicting.length} contradicting passage(s); evidence is mixed.`;
+		confidence = 0.4;
+	} else {
+		// No strong markers but passages overlapped on terms.
+		status = "unclear";
+		rationale = "Passages mention the claim's terms but contain no clear support or contradiction markers.";
+		confidence = 0.3;
+	}
+
+	return {
+		claim,
+		status,
+		supporting_passages: supporting,
+		contradicting_passages: contradicting,
+		rationale,
+		confidence,
+	};
+}
+
+// ── Artifact assembly ───────────────────────────────────────────────────────
+
+export interface BuildArtifactInput {
+	query: string;
+	provider?: string;
+	summary?: string;
+	results: SearchResult[];
+	fetched?: ExtractedContent[];
+	recency?: "day" | "week" | "month" | "year";
+	domainFilter?: string[];
+}
+
+export function buildResearchArtifact(input: BuildArtifactInput): ResearchArtifact {
+	const domainInclude = (input.domainFilter ?? []).filter((d) => !d.startsWith("-"));
+	const domainExclude = (input.domainFilter ?? []).filter((d) => d.startsWith("-")).map((d) => d.slice(1));
+
+	const sources: ResearchSource[] = input.results.map((r, i) => {
+		const page = input.fetched?.find((f) => f.url === r.url);
+		return {
+			rank: r.rank ?? i + 1,
+			url: r.url,
+			title: r.title,
+			snippet: r.snippet,
+			quality: classifySource(r.url),
+			fetched: Boolean(page),
+			fetch_timestamp: page ? Date.now() : undefined,
+		};
+	});
+
+	// Deduplicate sources by URL (keep highest rank / first occurrence).
+	const seen = new Set<string>();
+	const dedupedSources = sources.filter((s) => {
+		if (seen.has(s.url)) return false;
+		seen.add(s.url);
+		return true;
+	});
+
+	const passages = buildPassages(dedupedSources, input.fetched ?? []);
+
+	return {
+		id: generateId(),
+		type: "research",
+		timestamp: Date.now(),
+		query: input.query,
+		sources: dedupedSources,
+		passages,
+		provider: input.provider,
+		summary: input.summary,
+		filters: {
+			recency: input.recency,
+			domain_include: domainInclude.length ? domainInclude : undefined,
+			domain_exclude: domainExclude.length ? domainExclude : undefined,
+		},
+	};
+}
+
+// Run the source-check flow over an already-built artifact (claim assessment
+// against the artifact's passages). Returns a NEW artifact with claims[] set.
+export function withClaimAssessment(artifact: ResearchArtifact, claims: string[]): ResearchArtifact {
+	const assessments = claims.map((c) => assessClaim(c, artifact.passages));
+	return { ...artifact, claims: assessments };
+}
+
+// ── Storage helpers (reuse the existing in-memory map) ──────────────────────
+
+export function storeResearchArtifact(artifact: ResearchArtifact): void {
+	storeResult(artifact.id, {
+		id: artifact.id,
+		type: "research" as const,
+		timestamp: artifact.timestamp,
+		artifact,
+	});
+}
+
+export function getResearchArtifact(id: string): ResearchArtifact | null {
+	const data = getResult(id);
+	if (!data || data.type !== "research") return null;
+	return (data as { artifact?: ResearchArtifact }).artifact ?? null;
+}

--- a/storage.ts
+++ b/storage.ts
@@ -14,10 +14,13 @@ export interface QueryResultData {
 
 export interface StoredSearchData {
 	id: string;
-	type: "search" | "fetch";
+	type: "search" | "fetch" | "research";
 	timestamp: number;
 	queries?: QueryResultData[];
 	urls?: ExtractedContent[];
+	// Research artifacts (issue #108) store the full ResearchArtifact shape
+	// alongside the discriminator so get_search_content can return them.
+	artifact?: unknown;
 }
 
 const storedResults = new Map<string, StoredSearchData>();
@@ -50,10 +53,11 @@ function isValidStoredData(data: unknown): data is StoredSearchData {
 	if (!data || typeof data !== "object") return false;
 	const d = data as Record<string, unknown>;
 	if (typeof d.id !== "string" || !d.id) return false;
-	if (d.type !== "search" && d.type !== "fetch") return false;
+	if (d.type !== "search" && d.type !== "fetch" && d.type !== "research") return false;
 	if (typeof d.timestamp !== "number") return false;
 	if (d.type === "search" && !Array.isArray(d.queries)) return false;
 	if (d.type === "fetch" && !Array.isArray(d.urls)) return false;
+	// research artifacts carry their own shape; no extra required fields.
 	return true;
 }
 

--- a/test/source-check.test.mjs
+++ b/test/source-check.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const sourceCheckSrc = readFileSync(new URL("../source-check.ts", import.meta.url), "utf8");
+const indexSrc = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
+const storageSrc = readFileSync(new URL("../storage.ts", import.meta.url), "utf8");
+const readmeSrc = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+
+// ── Artifact schema (ADR 0001) ───────────────────────────────────────────────
+
+test("source-check module exports the ResearchArtifact schema types", () => {
+	assert.match(sourceCheckSrc, /export interface ResearchArtifact\b/);
+	assert.match(sourceCheckSrc, /export type SourceQuality\b/);
+	assert.match(sourceCheckSrc, /export type ClaimStatus\b/);
+	assert.match(sourceCheckSrc, /export interface ResearchSource\b/);
+	assert.match(sourceCheckSrc, /export interface ResearchPassage\b/);
+	assert.match(sourceCheckSrc, /export interface ClaimAssessment\b/);
+});
+
+test("ClaimStatus covers the four issue-required verdicts", () => {
+	assert.match(
+		sourceCheckSrc,
+		/export type ClaimStatus = "supported" \| "contradicted" \| "unclear" \| "missing-evidence"/,
+	);
+});
+
+test("SourceQuality covers official/vendor/repo/news/blog/forum/unknown", () => {
+	for (const q of ["official_docs", "vendor_docs", "repo_issue", "blog", "forum", "news", "unknown"]) {
+		assert.match(sourceCheckSrc, new RegExp(`"${q}"`), `missing SourceQuality ${q}`);
+	}
+});
+
+test("ClaimAssessment references passage ids, not bare URLs (provenance guarantee)", () => {
+	assert.match(sourceCheckSrc, /supporting_passages: string\[\]/);
+	assert.match(sourceCheckSrc, /contradicting_passages: string\[\]/);
+	// Rationale text documenting the provenance guarantee.
+	assert.match(sourceCheckSrc, /references passage_ids, never/);
+});
+
+// ── Source-quality classifier ────────────────────────────────────────────────
+
+test("classifier maps repo issues, official docs, news, blog, forum, unknown", () => {
+	assert.match(sourceCheckSrc, /REPO_ISSUE_PATHS/);
+	assert.match(sourceCheckSrc, /OFFICIAL_DOCS_HOSTS/);
+	assert.match(sourceCheckSrc, /NEWS_HOSTS/);
+	assert.match(sourceCheckSrc, /BLOG_HOSTS/);
+	assert.match(sourceCheckSrc, /FORUM_HOSTS/);
+	assert.match(sourceCheckSrc, /return "unknown"/);
+	assert.match(sourceCheckSrc, /export function classifySource\b/);
+});
+
+// ── Claim assessment markers ─────────────────────────────────────────────────
+
+test("assessClaim uses contradiction and support markers", () => {
+	assert.match(sourceCheckSrc, /CONTRADICTION_MARKERS/);
+	assert.match(sourceCheckSrc, /SUPPORT_MARKERS/);
+	// Each of the four statuses must be reachable. `missing-evidence` is
+	// returned via an object literal (status:), the others via assignment.
+	for (const s of ["supported", "contradicted", "unclear"]) {
+		assert.match(sourceCheckSrc, new RegExp(`status = "${s}"`), `status ${s} not assigned`);
+	}
+	assert.match(sourceCheckSrc, /status: "missing-evidence"/);
+});
+
+test("assessClaim returns missing-evidence when there are no passages", () => {
+	assert.match(sourceCheckSrc, /status: "missing-evidence"/);
+	assert.match(sourceCheckSrc, /No passages available/);
+});
+
+// ── Passage extraction (exact retrieved spans, no paraphrasing) ──────────────
+
+test("passages are built from snippets and fetched spans, never paraphrased", () => {
+	assert.match(sourceCheckSrc, /export function buildPassages\b/);
+	assert.match(sourceCheckSrc, /passage text is ALWAYS the exact retrieved span/i);
+	assert.match(sourceCheckSrc, /extractRelevantSpans/);
+});
+
+// ── Adapter interface (pluggable external aggregator) ───────────────────────
+
+test("research provider adapter interface is exported", () => {
+	assert.match(sourceCheckSrc, /export interface ResearchProvider\b/);
+	assert.match(sourceCheckSrc, /export interface ResearchSearchRequest\b/);
+	assert.match(sourceCheckSrc, /export interface ResearchSearchResponse\b/);
+	assert.match(sourceCheckSrc, /search\(req: ResearchSearchRequest\)/);
+});
+
+// ── Storage integration ─────────────────────────────────────────────────────
+
+test("storage accepts the new research discriminator", () => {
+	assert.match(storageSrc, /type: "search" \| "fetch" \| "research"/);
+	assert.match(storageSrc, /d\.type !== "search" && d\.type !== "fetch" && d\.type !== "research"/);
+});
+
+test("source-check stores/retrieves artifacts via the existing storage map", () => {
+	assert.match(sourceCheckSrc, /import \{ generateId, storeResult, getResult \} from "\.\/storage\.ts"/);
+	assert.match(sourceCheckSrc, /export function storeResearchArtifact\b/);
+	assert.match(sourceCheckSrc, /export function getResearchArtifact\b/);
+	assert.match(sourceCheckSrc, /type: "research" as const/);
+});
+
+// ── Tool registration in index.ts ────────────────────────────────────────────
+
+test("source_check tool is registered in index.ts", () => {
+	assert.match(indexSrc, /name: "source_check"/);
+	assert.match(indexSrc, /label: "Source Check"/);
+});
+
+test("source_check schema accepts claim, queries, filters, and provider", () => {
+	assert.match(indexSrc, /claim: Type\.String\(/);
+	assert.match(indexSrc, /queries: Type\.Optional\(Type\.Array\(Type\.String\(\)/);
+	assert.match(indexSrc, /recencyFilter: Type\.Optional\(/);
+	assert.match(indexSrc, /domainFilter: Type\.Optional\(/);
+	assert.match(indexSrc, /provider: Type\.Optional\(/);
+});
+
+test("source_check returns a machine-readable artifact via details + responseId", () => {
+	assert.match(indexSrc, /details: \{ responseId: withClaims\.id, artifact: withClaims/);
+});
+
+test("source_check reuses the existing search provider dispatch", () => {
+	assert.match(indexSrc, /const resp = await search\(q, searchOptions\)/);
+});
+
+test("get_search_content returns research artifacts by responseId", () => {
+	assert.match(indexSrc, /if \(data\.type === "research"\)/);
+	assert.match(indexSrc, /const artifact = getResearchArtifact/);
+});
+
+// ── Documentation ────────────────────────────────────────────────────────────
+
+test("README documents /source_check and machine-readable artifacts", () => {
+	assert.match(readmeSrc, /source[-_ ]?check/i);
+	assert.match(readmeSrc, /machine-readable/i);
+	assert.match(readmeSrc, /supported.*contradicted.*unclear.*missing-evidence/s);
+});
+
+test("ADR 0001 exists for the artifact schema and adapter interface", () => {
+	const adr = readFileSync(new URL("../docs/adr/0001-source-check-and-research-artifacts.md", import.meta.url), "utf8");
+	assert.match(adr, /# ADR 0001/);
+	assert.match(adr, /ResearchArtifact/);
+	assert.match(adr, /ResearchProvider/);
+	assert.match(adr, /supported.*contradicted.*unclear.*missing-evidence/s);
+	assert.match(adr, /passage_id/);
+});


### PR DESCRIPTION
## Summary

Implements #108. Adds a repeatable research surface to `pi-web-access`: a `source_check` tool mode that returns a **machine-readable research artifact** with cite-to-passage provenance, source-quality flags, and a pluggable search-provider adapter interface — all behind `pi-web-access` (no new Pi search package, no Pi-core change).

The issue was marked `needs-design`. **ADR 0001 is included as the design artifact** ([`docs/adr/0001-source-check-and-research-artifacts.md`](https://github.com/gr3enarr0w/pi-web-access/blob/feat/source-check-and-artifacts-108/docs/adr/0001-source-check-and-research-artifacts.md)) covering the artifact schema, adapter interface, source-quality classifier, and provenance guarantee.

## What's added

### `source-check.ts` (new module)
- **`ResearchArtifact` / `ResearchSource` / `ResearchPassage` / `ClaimAssessment`** — stable, serializable JSON types.
- **`ClaimStatus`**: `supported` | `contradicted` | `unclear` | `missing-evidence`.
- **`SourceQuality`**: `official_docs` | `vendor_docs` | `repo_issue` | `blog` | `forum` | `news` | `unknown` (heuristic URL/path classifier).
- **`ResearchProvider`** adapter interface (`ResearchSearchRequest` / `ResearchSearchResponse`) — an external search aggregator can sit behind `pi-web-access` by implementing this interface, **without a separate Pi package**.
- **`buildPassages()`** — passages built from search-result snippets + fetched page spans; **always exact retrieved text, never paraphrased**.
- **`assessClaim()`** — marker-based support/contradiction over passages; calibrated conservatively (prefers `unclear` / `missing-evidence` over false-positive `supported`).
- **`storeResearchArtifact()` / `getResearchArtifact()`** — reuse the existing in-memory storage map with a new `type: "research"` discriminator.

### `source_check` tool (registered in `index.ts`)
- Reuses the same search provider dispatch as `web_search` (provider-agnostic: OpenAI / Brave / Parallel / Tavily / Exa / Perplexity / Gemini).
- Optional `fetchContent` to extract passages from full pages.
- Domain include/exclude + recency filters passed through.
- Returns `{ responseId, artifact }` in `details`; the artifact is retrievable via `get_search_content` (which gained a `research` branch).

### `storage.ts`
- Extended `StoredSearchData.type` to `"search" | "fetch" | "research"` (backward-compatible).

## Provenance guarantee (the hardest acceptance criterion)

Every `ClaimAssessment` references `passage_id`s, never bare URLs. A passage is only ever created from **exact retrieved content** (search-provider snippets or extracted page spans). This keeps citations tied to retrieved content — not only top-level search result URLs.

## Acceptance criteria (issue #108)

| Criterion | How it's met |
|---|---|
| A Pi workflow can call `pi-web-access` and receive a stable JSON artifact without scraping terminal text | `source_check` returns the artifact in `details.artifact`; also retrievable via `get_search_content` by `responseId` |
| `/source-check` returns supported / contradicted / unclear / missing-evidence | `ClaimStatus` enum; `assessClaim()` assigns all four |
| Citations tied to exact retrieved content, not only top-level URLs | `supporting_passages` / `contradicting_passages` reference `passage_id`s; passages carry `extraction_span` + `content_hash` |
| Existing interactive search behavior continues to work | `web_search` is unchanged; structured artifacts are opt-in via `source_check` |
| No Pi core change is required | Pure extension package change; `ResearchProvider` is the pluggable adapter point for external aggregators |

## Tests

`test/source-check.test.mjs` — 18 assertions (source-text convention matching the repo's existing test style) covering: schema + enum sets, provenance guarantee, classifier mappings, claim markers/storage wiring, `source_check` registration + schema, `get_search_content` research branch, README docs, and ADR presence.

**All 87 tests pass** (`npm install` + `node --test`):

```
ℹ tests 87
ℹ pass 87
ℹ fail 0
```

## Non-goals (per #108)

- No Pi-core change is required. ✅
- Existing interactive search behavior continues to work. ✅ (web_search untouched)

Closes #108.
