### PR TITLE
fix(search): resolve block-scoped ReferenceError inside openCuratorBrowser catch block

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -964,6 +964,7 @@ export default function (pi: ExtensionAPI) {
 	async function openCuratorBrowser(callId: string, pc: PendingCurate, searchesComplete = true): Promise<void> {
 		if (pendingCurates.get(callId) !== pc) return;
 		let handle: CuratorServerHandle | null = null;
+		let sendCuratorFallbackUpdate: ((message: string) => void) | null = null;
 		try {
 			pc.phase = "curating";
 
@@ -1136,9 +1137,9 @@ export default function (pi: ExtensionAPI) {
 			}
 			if (searchesComplete) handle.searchesDone();
 
-			const sendCuratorFallbackUpdate = (message: string) => {
+			sendCuratorFallbackUpdate = (message: string) => {
 				pc.onUpdate?.({
-					content: [{ type: "text", text: `${message}\nOpen manually: ${handle.url}` }],
+					content: [{ type: "text", text: `${message}\nOpen manually: ${handle!.url}` }],
 					details: {
 						phase: "curator-fallback",
 						progress: searchesComplete ? 1 : 0.5,
@@ -1185,7 +1186,7 @@ export default function (pi: ExtensionAPI) {
 			console.error(`Failed to open curator UI: ${message}`);
 			if (handle && activeCurators.get(callId) === handle && pendingCurates.get(callId) === pc) {
 				pc.browserOpenError = message;
-				sendCuratorFallbackUpdate("Search curator is running, but the browser did not open automatically.");
+				sendCuratorFallbackUpdate?.("Search curator is running, but the browser did not open automatically.");
 			} else if (pendingCurates.get(callId) === pc || (handle && activeCurators.get(callId) === handle)) {
 				closeCurator(callId);
 			}

--- a/test/curator-fallback.test.mjs
+++ b/test/curator-fallback.test.mjs
@@ -31,3 +31,8 @@ test("README documents manual browser fallback", () => {
 	assert.match(readmeSrc, /Docker, WSL, SSH, or headless environments/);
 	assert.match(readmeSrc, /Copy it into a browser that can reach the Pi host/);
 });
+
+test("sendCuratorFallbackUpdate is declared with wider scope than the try block to avoid catch block ReferenceError", () => {
+	assert.match(indexSrc, /let sendCuratorFallbackUpdate: \(\(message: string\) => void\) \| null = null;/);
+	assert.match(indexSrc, /sendCuratorFallbackUpdate = \(message: string\) => \{/);
+});


### PR DESCRIPTION
### 🚀 Problem & Root Cause Analysis

When running `web_search` in a headless, SSH, WSL, Docker, or other terminal environment without an available GUI browser, the agent tries to automatically open the browser curator via `openInBrowser()`. When this fails (as is expected in headless environments), it throws an error and drops into the `catch (err)` block of `openCuratorBrowser()`.

Inside this `catch` block, the code attempts to call `sendCuratorFallbackUpdate()` to notify the user and keep the curator running with a manual copy-paste URL. However:
1. `sendCuratorFallbackUpdate` was declared with `const` **inside** the `try` block.
2. Under ES6 block-scoping rules, `const` and `let` variables defined inside a block are block-scoped and **not** visible inside the corresponding `catch` block of the same `try/catch` statement.

This resulted in a critical **`ReferenceError: sendCuratorFallbackUpdate is not defined`** whenever a headless/manual browser fallback was triggered, crashing the entire agent harness session instantly with an uncaught exception.

---

### 🛠️ Solution

1. **Widen Variable Scope:** Declared `sendCuratorFallbackUpdate` with `let` outside of the `try` block so that it is properly bound and accessible within both the `try` and `catch` blocks.
2. **Defensive Call:** Used optional chaining `sendCuratorFallbackUpdate?.(...)` in the `catch` block to handle cases where the server setup itself fails before the fallback updater is initialized.
3. **Safe Nullability Check:** Used non-null assertion `handle!.url` inside the fallback updater since we guarantee `handle` is successfully created and active in that specific execution path.

---

### 🚨 How to Reproduce (Before this PR)
1. Run Pi in a headless SSH session (no active X11 display/GUI browser).
2. Invoke `web_search` with standard options.
3. The browser open attempt fails, triggering the `catch` block.
4. **Crash:** `ReferenceError: sendCuratorFallbackUpdate is not defined` occurs, abruptly exiting the process.

---

### 🧪 Testing & Verification

1. **Added Regression Test:** Added a new test assertion to `test/curator-fallback.test.mjs` verifying that `sendCuratorFallbackUpdate` is correctly scoped outside the `try` block and assigned cleanly inside it.
2. **Full Suite Passed:** Ran `npm test` locally. All 70 unit tests passed cleanly:
   ```text
   TAP version 13
   # tests 70
   # suites 0
   # pass 70
   # fail 0
   ```