### PR TITLE
fix: drop pi-ai/compat subpath, use bare package name (jiti subpath alias bug)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Box, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { StringEnum, complete, type Model } from "@earendil-works/pi-ai/compat";
+import { StringEnum, complete, type Model } from "@earendil-works/pi-ai";
 import { fetchAllContent, type ExtractedContent } from "./extract.ts";
 import { normalizeFetchContentParams } from "./fetch-params.ts";
 import { clearCloneCache } from "./github-extract.ts";

--- a/openai-search.ts
+++ b/openai-search.ts
@@ -117,7 +117,7 @@ function extractAccountId(token: string): string | undefined {
 
 export async function resolveOpenAIAuth(ctx?: ExtensionContext): Promise<OpenAIAuth | undefined> {
 	if (ctx) {
-		const { getModel } = await import("@earendil-works/pi-ai/compat");
+		const { getModel } = await import("@earendil-works/pi-ai");
 		for (const candidate of AUTH_MODEL_CANDIDATES) {
 			for (const modelId of candidate.models) {
 				const model = getModel(candidate.provider, modelId);

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -1,4 +1,4 @@
-import { complete, type Message, type Model } from "@earendil-works/pi-ai/compat";
+import { complete, type Message, type Model } from "@earendil-works/pi-ai";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 import type { QueryResultData } from "./storage.ts";


### PR DESCRIPTION
## Problem

`pi-web-access` 0.13.0 imports from the `@earendil-works/pi-ai/compat` subpath in three files. All fail under the current `pi-coding-agent` + `jiti` 2.7.0 combo:

```
Failed to load extension: Cannot find module
`.../pi-ai/dist/index.js/compat`
```

The extension is completely unloadable.

## Root cause

`pi-coding-agent`'s extension loader (`dist/core/extensions/loader.js`) registers jiti aliases mapping `@earendil-works/*` packages to the right entrypoints:

```js
"@earendil-works/pi-ai": piAiCompatEntry,
"@earendil-works/pi-ai/compat": piAiCompatEntry,
```

**jiti 2.7.0 only honors the bare package-name alias.** Subpath aliases containing `/` are ignored: jiti resolves the package main (`dist/index.js`) and appends the subpath as a literal path, producing `dist/index.js/compat` which does not exist.

The loader comment spells out the intended convention:

> Extensions resolve the pi-ai root to the compat entrypoint (a strict superset of the core entrypoint).

## Fix

Drop the `/compat` subpath everywhere. Import from the bare `@earendil-works/pi-ai`, which the loader alias resolves to the compat entrypoint:

```diff
- import { ... } from "@earendil-works/pi-ai/compat";
+ import { ... } from "@earendil-works/pi-ai";
```

Three files changed (all the call sites):

- `index.ts:4` — static import of `StringEnum`, `complete`, `Model`
- `summary-review.ts:1` — static import of `complete`, `Message`, `Model`
- `openai-search.ts:120` — dynamic `await import(...)` for `getModel`

## Verification

Patched the installed extension, fully reloaded pi:

- Before: `[Extension issues] pi-web-access Failed to load extension: Cannot find module ...`
- After: `[Extensions] ... pi-web-access` loads cleanly, no errors.

`StringEnum`, `complete`, `Message`, `Model`, and `getModel` all resolve via the bare-name alias.

## Notes

- The deeper jiti bug (subpath aliases containing `/` not matched) affects any extension using a subpath import. A jiti-side fix would make this more robust, but this change aligns `pi-web-access` with pi documented extension convention regardless.
- `compat` is explicitly a temporary entrypoint per `pi-ai`, so these imports are already on a deprecation path; this change does not increase exposure.