### PR TITLE
fix: move sendCuratorFallbackUpdate into catch block to fix ReferenceError

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1136,20 +1136,6 @@ export default function (pi: ExtensionAPI) {
 			}
 			if (searchesComplete) handle.searchesDone();
 
-			const sendCuratorFallbackUpdate = (message: string) => {
-				pc.onUpdate?.({
-					content: [{ type: "text", text: `${message}\nOpen manually: ${handle.url}` }],
-					details: {
-						phase: "curator-fallback",
-						progress: searchesComplete ? 1 : 0.5,
-						curatorUrl: handle.url,
-						timeoutSeconds: pc.timeoutSeconds,
-						shortcut: curateKey,
-						browserOpenError: pc.browserOpenError,
-					},
-				});
-			};
-
 			pc.onUpdate?.({
 				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],
 				details: {
@@ -1181,6 +1167,19 @@ export default function (pi: ExtensionAPI) {
 			}
 			await openInBrowser(pi, handle.url);
 		} catch (err) {
+			const sendCuratorFallbackUpdate = (message: string) => {
+				pc.onUpdate?.({
+					content: [{ type: "text", text: `${message}\nOpen manually: ${handle?.url}` }],
+					details: {
+						phase: "curator-fallback",
+						progress: searchesComplete ? 1 : 0.5,
+						curatorUrl: handle?.url,
+						timeoutSeconds: pc.timeoutSeconds,
+						shortcut: curateKey,
+						browserOpenError: pc.browserOpenError,
+					},
+				});
+			};
 			const message = err instanceof Error ? err.message : String(err);
 			console.error(`Failed to open curator UI: ${message}`);
 			if (handle && activeCurators.get(callId) === handle && pendingCurates.get(callId) === pc) {


### PR DESCRIPTION
## Summary

Fixes a `ReferenceError: sendCuratorFallbackUpdate is not defined` crash that occurs when the curator browser fails to open on non-macOS platforms.

## Root Cause

The `sendCuratorFallbackUpdate` helper was defined with `const` inside the `try` block of `openCuratorBrowser()`, but it is called exclusively from the `catch` block. Since `const`/`let` are block-scoped in JavaScript, the function is not accessible from `catch`, causing an unhandled `ReferenceError`.

`sendCuratorFallbackUpdate` is never invoked inside the `try` block — it was misplaced there, likely a leftover from a refactoring iteration.

## Changes

1. **Moved** the `sendCuratorFallbackUpdate` definition from the `try` block into the `catch` block where it is actually called.
2. **Changed `handle.url` → `handle?.url`** with optional chaining as a defensive safeguard. The current call site is already gated behind a `handle && ...` check, so this isn't required to fix the crash itself, but it guards against future call sites where `handle` could still be `null` (e.g. if the catch is entered before the curator server finishes starting).

I confirmed via inspection that `sendCuratorFallbackUpdate` has no other call sites in `openCuratorBrowser()` — it's referenced exactly once, in the `catch` block.

## Affected Platforms

This is not WSL-specific. Any environment where `openInBrowser()`'s platform branch fails — `xdg-open` missing/misconfigured on Linux, `open`/`cmd start` failing on macOS/Windows, headless/container environments with no browser at all — will hit this same `catch` path and crash. WSL2 is simply the environment I reproduced it in; macOS users are less likely to hit it in practice because the Glimpse window path returns early (`return`), skipping `openInBrowser` entirely, but a Glimpse open failure that falls through to `openInBrowser` would trigger it there too.

## Repro / Testing

### Environment (where I reproduced it)

- OS: Windows 11 WSL2 (Ubuntu)
- Node.js: v24.16.0
- pi-web-access: v0.13.0

### Steps to Reproduce

1. Use pi agent in an environment without a working `xdg-open`/`open`/`cmd start` (e.g. WSL2 without a browser mapping, or headless Linux)
2. Run a web search (`web_search`) with curator browser (`workflow: summary-review`)
3. `openInBrowser()` throws → `catch` block runs → `ReferenceError` on `sendCuratorFallbackUpdate`

### Error

```
pi exiting due to uncaughtException:
ReferenceError: sendCuratorFallbackUpdate is not defined
    at openCuratorBrowser (/pi-web-access/index.ts:1188:9)
```

### After Fix

The curator browser open failure is now handled gracefully — the fallback message is properly delivered to the user via `pc.onUpdate` instead of crashing.

### Test Coverage

No existing test covers the `openCuratorBrowser` catch/fallback path. I did not add one in this PR since I don't see a test harness for this module yet — happy to add a regression test (e.g. mocking `openInBrowser` to reject and asserting `onUpdate` is called instead of throwing) if the maintainer points me to the preferred testing setup/conventions for this repo.

Closes #103
