### PR TITLE
fix: hoist curator fallback helper so the catch block can reach it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a `ReferenceError: sendCuratorFallbackUpdate is not defined` crash that took down the whole process when the curator browser failed to auto-open (Docker, WSL, SSH, and headless environments). The fallback helper was declared inside the `try` block but called from the sibling `catch` block; it is now declared at function scope so the browser-open failure path resolves correctly.
+
 ## [0.13.0] - 2026-06-25
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -964,6 +964,20 @@ export default function (pi: ExtensionAPI) {
 	async function openCuratorBrowser(callId: string, pc: PendingCurate, searchesComplete = true): Promise<void> {
 		if (pendingCurates.get(callId) !== pc) return;
 		let handle: CuratorServerHandle | null = null;
+		const sendCuratorFallbackUpdate = (message: string) => {
+			if (!handle) return;
+			pc.onUpdate?.({
+				content: [{ type: "text", text: `${message}\nOpen manually: ${handle.url}` }],
+				details: {
+					phase: "curator-fallback",
+					progress: searchesComplete ? 1 : 0.5,
+					curatorUrl: handle.url,
+					timeoutSeconds: pc.timeoutSeconds,
+					shortcut: curateKey,
+					browserOpenError: pc.browserOpenError,
+				},
+			});
+		};
 		try {
 			pc.phase = "curating";
 
@@ -1135,20 +1149,6 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 			if (searchesComplete) handle.searchesDone();
-
-			const sendCuratorFallbackUpdate = (message: string) => {
-				pc.onUpdate?.({
-					content: [{ type: "text", text: `${message}\nOpen manually: ${handle.url}` }],
-					details: {
-						phase: "curator-fallback",
-						progress: searchesComplete ? 1 : 0.5,
-						curatorUrl: handle.url,
-						timeoutSeconds: pc.timeoutSeconds,
-						shortcut: curateKey,
-						browserOpenError: pc.browserOpenError,
-					},
-				});
-			};
 
 			pc.onUpdate?.({
 				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],

--- a/test/curator-fallback.test.mjs
+++ b/test/curator-fallback.test.mjs
@@ -14,6 +14,31 @@ test("web_search curator auto-open failures keep the curator alive with a manual
 	assert.doesNotMatch(indexSrc, /Failed to open curator UI: \$\{message\}`\);\n\t\t\tif \(pendingCurates\.get\(callId\) === pc \|\| \(handle && activeCurators\.get\(callId\) === handle\)\) \{\n\t\t\t\tcloseCurator\(callId\);/);
 });
 
+test("curator fallback helper is declared at function scope so the catch block can reach it", () => {
+	// Regression for a ReferenceError crash: sendCuratorFallbackUpdate was declared
+	// with `const` inside the try block but called from the sibling catch block,
+	// which threw "sendCuratorFallbackUpdate is not defined" whenever browser
+	// auto-open failed (Docker/WSL/SSH/headless), taking down the whole process.
+	const fnStart = indexSrc.indexOf("async function openCuratorBrowser(");
+	assert.notEqual(fnStart, -1, "expected openCuratorBrowser to exist");
+
+	const declIndex = indexSrc.indexOf("const sendCuratorFallbackUpdate =", fnStart);
+	const tryIndex = indexSrc.indexOf("try {", fnStart);
+	const callIndex = indexSrc.indexOf(
+		'sendCuratorFallbackUpdate("Search curator is running, but the browser did not open automatically.")',
+		fnStart,
+	);
+
+	assert.notEqual(declIndex, -1, "expected sendCuratorFallbackUpdate to be declared");
+	assert.notEqual(tryIndex, -1, "expected a try block in openCuratorBrowser");
+	assert.notEqual(callIndex, -1, "expected the fallback call inside the catch block");
+	assert.ok(
+		declIndex < tryIndex,
+		"sendCuratorFallbackUpdate must be declared before the try block so the catch block can reference it",
+	);
+	assert.ok(callIndex > tryIndex, "expected the fallback call after the try block");
+});
+
 test("cancel diagnostics include curator URL and browser-open error", () => {
 	assert.match(indexSrc, /curatorUrl\?: string;/);
 	assert.match(indexSrc, /browserOpenError\?: string;/);


### PR DESCRIPTION
## Summary

Fixes a `ReferenceError` crash that takes down the entire Pi process when the search curator's browser fails to auto-open — the common case in Docker, WSL, SSH, and other headless environments.

## Root cause

In `openCuratorBrowser` (`index.ts`), the `sendCuratorFallbackUpdate` helper is declared with `const` **inside** the `try` block, but it is invoked from the sibling `catch` block:

```ts
try {
  ...
  const sendCuratorFallbackUpdate = (message) => { ... }; // declared in try scope
  ...
  await openInBrowser(pi, handle.url);                    // throws in headless envs
} catch (err) {
  ...
  sendCuratorFallbackUpdate("...browser did not open..."); // not in scope here
}
```

`const`/`let` are block-scoped, so the identifier does not exist in the `catch` block. When `openInBrowser` throws (no display/browser available), the `catch` handler runs the intended graceful-fallback path and instead throws:

```
ReferenceError: sendCuratorFallbackUpdate is not defined
    at openCuratorBrowser (.../pi-web-access/index.ts)
```

Because this executes on an async tick with no surrounding handler, Pi treats it as an `uncaughtException` and exits. The error is masked on desktops where the browser opens successfully and the `catch` block never runs — it only manifests in headless environments, which is exactly where the fallback was meant to help.

Regression introduced in b50d118 (`fix: keep curator alive when browser open fails`).

## Fix

- Hoist `sendCuratorFallbackUpdate` to function scope (before the `try`) so both the `try` and `catch` blocks can reference it.
- Add an `if (!handle) return;` guard, since the helper is now declared before `handle` is assigned. The only caller already guards with `if (handle && ...)`, so behavior is unchanged.

## Tests

- Added a regression test in `test/curator-fallback.test.mjs` asserting the helper is declared before the `try` block. Verified it **fails** against current `main` and **passes** with this fix.
- Full suite green locally with dependencies installed (`npm test` → 70/70 pass).

## Reproduction

Run `web_search` (with the default browser-curator workflow) on any host with no reachable browser (Docker/WSL/SSH/headless). Before this fix, Pi crashes with the `ReferenceError` above instead of printing the manual curator URL.
