### PR TITLE
feat: add SearXNG and Firecrawl as self-hosted search/extraction providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 bun.lock
 package-lock.json
+pi-web-access-*.tgz

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -38,7 +38,7 @@ export function generateCuratorPage(
 	queries: string[],
 	sessionToken: string,
 	timeout: number,
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean; searxng: boolean; firecrawl: boolean },
 	defaultProvider: string,
 	searchProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
@@ -665,6 +665,16 @@ main {
   color: #a6e3a1;
   background: rgba(166, 227, 161, 0.14);
   border-color: rgba(166, 227, 161, 0.3);
+}
+.provider-tag.provider-searxng {
+  color: #94e2d5;
+  background: rgba(148, 226, 213, 0.14);
+  border-color: rgba(148, 226, 213, 0.3);
+}
+.provider-tag.provider-firecrawl {
+  color: #fab387;
+  background: rgba(250, 179, 135, 0.14);
+  border-color: rgba(250, 179, 135, 0.3);
 }
 .provider-tag.provider-unknown {
   color: var(--fg-muted);
@@ -1389,7 +1399,7 @@ const SCRIPT = `(function() {
   var token = DATA.sessionToken;
   var timeoutSec = DATA.timeout;
   var queries = Array.isArray(DATA.queries) ? DATA.queries : [];
-  var providers = ["openai", "exa", "brave", "parallel", "tavily", "perplexity", "gemini"];
+  var providers = ["openai", "exa", "brave", "parallel", "tavily", "perplexity", "gemini", "searxng", "firecrawl"];
   var availProviders = DATA.availableProviders && typeof DATA.availableProviders === "object" ? DATA.availableProviders : {};
   var workflow = "summary-review";
   var initialDefaultProvider = typeof DATA.defaultProvider === "string" ? DATA.defaultProvider : "exa";
@@ -1590,6 +1600,8 @@ const SCRIPT = `(function() {
 
   function providerLabel(provider) {
     if (provider === "openai") return "OpenAI";
+    if (provider === "searxng") return "SearXNG";
+    if (provider === "firecrawl") return "Firecrawl";
     if (provider === "brave") return "Brave";
     if (provider === "parallel") return "Parallel";
     if (provider === "tavily") return "Tavily";

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -12,7 +12,7 @@ export interface CuratorServerOptions {
 	queries: string[];
 	sessionToken: string;
 	timeout: number;
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean; searxng: boolean; firecrawl: boolean };
 	defaultProvider: string;
 	searchProvider: string;
 	summaryModels: Array<{ value: string; label: string }>;
@@ -244,6 +244,8 @@ export function startCuratorServer(
 
 	function isAvailableProvider(provider: string): boolean {
 		if (provider === "openai") return availableProviders.openai;
+		if (provider === "searxng") return availableProviders.searxng;
+		if (provider === "firecrawl") return availableProviders.firecrawl;
 		if (provider === "brave") return availableProviders.brave;
 		if (provider === "parallel") return availableProviders.parallel;
 		if (provider === "tavily") return availableProviders.tavily;

--- a/extract.ts
+++ b/extract.ts
@@ -9,6 +9,7 @@ import { extractGitHub } from "./github-extract.ts";
 import { isYouTubeURL, isYouTubeEnabled, extractYouTube, extractYouTubeFrame, extractYouTubeFrames, getYouTubeStreamInfo } from "./youtube-extract.ts";
 import { extractWithUrlContext, extractWithGeminiWeb } from "./gemini-url-context.ts";
 import { extractWithParallel, isParallelAvailable } from "./parallel.ts";
+import { extractWithFirecrawl, isFirecrawlConfigured } from "./firecrawl.ts";
 import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } from "./video-extract.ts";
 import { existsSync, readFileSync } from "node:fs";
 import { fetchRemoteUrl, validateRemoteUrl, type Lookup } from "./ssrf-protection.ts";
@@ -462,6 +463,18 @@ export async function extractContent(
 	if (jinaResult) return jinaResult;
 	if (signal?.aborted) return abortedResult(url);
 
+	// Firecrawl extraction (self-hosted, Playwright-based)
+	let firecrawlError: string | null = null;
+	try {
+		if (isFirecrawlConfigured()) {
+			const fcResult = await extractWithFirecrawl(url, signal, options);
+			if (fcResult) return fcResult;
+		}
+	} catch (err) {
+		if (isAbortError(err)) return abortedResult(url);
+		firecrawlError = errorMessage(err);
+	}
+
 	let parallelError: string | null = null;
 	try {
 		if (isParallelAvailable()) {
@@ -493,9 +506,11 @@ export async function extractContent(
 
 	const guidance = [
 		httpResult.error,
+		...(firecrawlError ? [`Firecrawl fallback failed: ${firecrawlError}`] : []),
 		...(parallelError ? [`Parallel fallback failed: ${parallelError}`] : []),
 		"",
 		"Fallback options:",
+		`  \u2022 Set FIRECRAWL_BASE_URL / FIRECRAWL_BASIC_AUTH (self-hosted) in environment`,
 		`  \u2022 Set PARALLEL_API_KEY in ${WEB_SEARCH_CONFIG_PATH}`,
 		`  \u2022 Set GEMINI_API_KEY in ${WEB_SEARCH_CONFIG_PATH}`,
 		"  \u2022 Sign into gemini.google.com in Chrome",

--- a/firecrawl.ts
+++ b/firecrawl.ts
@@ -1,0 +1,316 @@
+import { existsSync, readFileSync } from "node:fs";
+import { activityMonitor } from "./activity.ts";
+import type { SearchOptions, SearchResponse, SearchResult } from "./perplexity.ts";
+import type { ExtractedContent, ExtractOptions } from "./extract.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const CONFIG_PATH = getWebSearchConfigPath();
+const SEARCH_TIMEOUT_MS = 60_000;
+const EXTRACT_TIMEOUT_MS = 60_000;
+
+interface WebSearchConfig {
+	firecrawlBaseUrl?: unknown;
+	firecrawlApiKey?: unknown;
+}
+
+interface FirecrawlSearchData {
+	title?: string;
+	url?: string;
+	description?: string;
+}
+
+interface FirecrawlSearchResponse {
+	success: boolean;
+	data?: FirecrawlSearchData[];
+	error?: string;
+}
+
+interface FirecrawlScrapeMetadata {
+	title?: string;
+	sourceURL?: string;
+	[key: string]: unknown;
+}
+
+interface FirecrawlScrapeData {
+	title?: string;
+	url?: string;
+	markdown?: string;
+	metadata?: FirecrawlScrapeMetadata;
+}
+
+interface FirecrawlScrapeResponse {
+	success?: boolean;
+	data?: FirecrawlScrapeData;
+	error?: string;
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+function normalizeUrl(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim().replace(/\/+$/, "");
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeApiKey(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function getBaseUrl(): string | null {
+	return (
+		normalizeUrl(process.env.FIRECRAWL_BASE_URL) ??
+		normalizeUrl(loadConfig().firecrawlBaseUrl)
+	);
+}
+
+/** Build headers for Firecrawl API calls, optionally with API key or HTTP Basic auth. */
+function buildHeaders(): Record<string, string> {
+	const headers: Record<string, string> = { "Content-Type": "application/json" };
+
+	// API key takes precedence (Firecrawl v1)
+	const apiKey = normalizeApiKey(process.env.FIRECRAWL_API_KEY) ?? normalizeApiKey(loadConfig().firecrawlApiKey);
+	if (apiKey) {
+		headers["Authorization"] = `Bearer ${apiKey}`;
+		return headers;
+	}
+
+	// HTTP Basic Auth fallback (for reverse-proxy setups, FIRECRAWL_BASIC_AUTH=user:pass)
+	const basicAuth = normalizeApiKey(process.env.FIRECRAWL_BASIC_AUTH);
+	if (basicAuth) {
+		headers["Authorization"] = "Basic " + Buffer.from(basicAuth).toString("base64");
+	}
+
+	return headers;
+}
+
+function normalizeCount(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 5;
+	return Math.max(1, Math.min(Math.floor(value), 20));
+}
+
+function hostMatches(host: string, domain: string): boolean {
+	const h = host.toLowerCase();
+	const d = domain.toLowerCase().replace(/^\.+/, "");
+	return h === d || h.endsWith("." + d);
+}
+
+function applyDomainFilter(
+	results: SearchResult[],
+	includeDomains?: string[],
+	excludeDomains?: string[],
+): SearchResult[] {
+	if (!includeDomains?.length && !excludeDomains?.length) return results;
+	return results.filter(r => {
+		let host: string | null = null;
+		try { host = new URL(r.url).hostname; } catch { /* unparseable URL */ }
+		if (includeDomains?.length && !(host && includeDomains.some(d => hostMatches(host!, d)))) return false;
+		if (excludeDomains?.length && host && excludeDomains.some(d => hostMatches(host!, d))) return false;
+		return true;
+	});
+}
+
+/** Pick the first non-empty metadata value across candidate keys. */
+function pickMeta(
+	meta: Record<string, unknown> | undefined,
+	keys: string[],
+): string | undefined {
+	if (!meta) return undefined;
+	for (const k of keys) {
+		const v = meta[k];
+		if (typeof v === "string" && v.trim()) return v;
+		if (Array.isArray(v) && typeof v[0] === "string" && v[0].trim()) return v[0];
+	}
+	return undefined;
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+/** Determine include/exclude domains from the SearchOptions-style domainFilter. */
+function parseDomainFilter(domainFilter: string[] | undefined): { include_domains: string[]; exclude_domains: string[] } {
+	const include_domains: string[] = [];
+	const exclude_domains: string[] = [];
+	if (!domainFilter?.length) return { include_domains, exclude_domains };
+	for (const raw of domainFilter) {
+		const domain = raw.trim().toLowerCase().replace(/^-/, "").replace(/^\.+|\.+$/g, "");
+		if (!domain || !/^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(domain)) continue;
+		if (raw.trim().startsWith("-")) exclude_domains.push(domain);
+		else include_domains.push(domain);
+	}
+	return { include_domains, exclude_domains };
+}
+
+// ─── Search ───
+
+export function isFirecrawlConfigured(): boolean {
+	return !!getBaseUrl();
+}
+
+export async function searchWithFirecrawl(
+	query: string,
+	options: SearchOptions = {},
+): Promise<SearchResponse> {
+	const baseUrl = getBaseUrl();
+	if (!baseUrl) {
+		throw new Error(
+			"Firecrawl base URL not configured. Either:\n" +
+			`  1. Create ${CONFIG_PATH} with { "firecrawlBaseUrl": "http://localhost:3002" }\n` +
+			"  2. Set FIRECRAWL_BASE_URL environment variable",
+		);
+	}
+
+	const numResults = normalizeCount(options.numResults);
+	const { include_domains, exclude_domains } = parseDomainFilter(options.domainFilter);
+	const activityId = activityMonitor.logStart({ type: "api", query });
+
+	try {
+		const response = await fetch(`${baseUrl}/v1/search`, {
+			method: "POST",
+			headers: buildHeaders(),
+			body: JSON.stringify({
+				query,
+				limit: numResults,
+				scrapeOptions: { formats: [] },
+			}),
+			signal: options.signal
+				? AbortSignal.any([AbortSignal.timeout(SEARCH_TIMEOUT_MS), options.signal])
+				: AbortSignal.timeout(SEARCH_TIMEOUT_MS),
+		});
+
+		if (!response.ok) {
+			activityMonitor.logError(activityId, `HTTP ${response.status}`);
+			const errorText = await response.text();
+			throw new Error(`Firecrawl search error ${response.status}: ${errorText.slice(0, 300)}`);
+		}
+
+		const data = (await response.json()) as FirecrawlSearchResponse;
+		activityMonitor.logComplete(activityId, response.status);
+
+		if (!data.success) {
+			throw new Error(`Firecrawl search unsuccessful: ${data.error ?? "unknown error"}`);
+		}
+
+		let results: SearchResult[] = (data.data ?? []).slice(0, numResults).map(d => ({
+			title: d.title ?? "",
+			url: d.url ?? "",
+			snippet: d.description ?? "",
+		}));
+
+		results = applyDomainFilter(results, include_domains, exclude_domains);
+
+		const answer = results
+			.map(r => r.snippet ? `${r.snippet}\nSource: ${r.title} (${r.url})` : `Source: ${r.title} (${r.url})`)
+			.join("\n\n");
+
+		return { answer, results };
+	} catch (err) {
+		const message = errorMessage(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		throw err;
+	}
+}
+
+// ─── Content Extraction ───
+
+/**
+ * Extract content from a URL using Firecrawl's /v1/scrape endpoint.
+ * Returns null when Firecrawl is not configured or the page can't be scraped.
+ */
+export async function extractWithFirecrawl(
+	url: string,
+	signal?: AbortSignal,
+	options?: Pick<ExtractOptions, "timeoutMs">,
+): Promise<ExtractedContent | null> {
+	const baseUrl = getBaseUrl();
+	if (!baseUrl) return null;
+
+	const timeoutMs = options?.timeoutMs ?? EXTRACT_TIMEOUT_MS;
+	const activityId = activityMonitor.logStart({ type: "api", query: `fc-scrape: ${url}` });
+
+	try {
+		const response = await fetch(`${baseUrl}/v1/scrape`, {
+			method: "POST",
+			headers: buildHeaders(),
+			body: JSON.stringify({
+				url,
+				formats: ["markdown"],
+			}),
+			signal: AbortSignal.any([
+				AbortSignal.timeout(timeoutMs),
+				...(signal ? [signal] : []),
+			]),
+		});
+
+		if (!response.ok) {
+			activityMonitor.logComplete(activityId, response.status);
+			return null;
+		}
+
+		const data = (await response.json()) as FirecrawlScrapeResponse;
+
+		if (data.success === false) {
+			activityMonitor.logComplete(activityId, 200);
+			return null;
+		}
+
+		const doc = data.data;
+		if (!doc) {
+			activityMonitor.logComplete(activityId, 200);
+			return null;
+		}
+
+		const rawContent = doc.markdown ?? "";
+		if (!rawContent.trim()) {
+			activityMonitor.logComplete(activityId, 200);
+			return null;
+		}
+
+		const title = doc.metadata?.title ?? doc.title ?? "";
+		const author = pickMeta(doc.metadata, ["author", "article:author", "dc.creator", "parsely-author"]);
+		const publishedDate = pickMeta(doc.metadata, ["publishedTime", "article:published_time", "date"]);
+
+		let content = rawContent;
+		const wordCount = rawContent.split(/\s+/).filter(Boolean).length;
+
+		activityMonitor.logComplete(activityId, response.status);
+
+		return {
+			url,
+			title,
+			content,
+			error: null,
+		};
+	} catch (err) {
+		const message = errorMessage(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		return null;
+	}
+}

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -9,9 +9,11 @@ import { isBraveAvailable, searchWithBrave } from "./brave.ts";
 import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
 import { isParallelAvailable, searchWithParallel } from "./parallel.ts";
 import { isTavilyAvailable, searchWithTavily } from "./tavily.ts";
+import { isSearXNGConfigured, searchWithSearXNG } from "./searxng.ts";
+import { isFirecrawlConfigured, searchWithFirecrawl } from "./firecrawl.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "perplexity" | "gemini" | "exa";
+export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "perplexity" | "gemini" | "exa" | "searxng" | "firecrawl";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
 
 export interface AttributedSearchResponse extends SearchResponse {
@@ -61,7 +63,7 @@ function normalizeSearchModel(value: unknown): string | undefined {
 
 function normalizeSearchProvider(value: unknown): SearchProvider {
 	const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "perplexity", "gemini", "exa"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "perplexity", "gemini", "exa", "searxng", "firecrawl"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -131,6 +133,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		return { ...result, provider: "brave" };
 	}
 
+	if (provider === "searxng") {
+		const result = await searchWithSearXNG(query, options);
+		return { ...result, provider: "searxng" };
+	}
+
+	if (provider === "firecrawl") {
+		const result = await searchWithFirecrawl(query, options);
+		return { ...result, provider: "firecrawl" };
+	}
+
 	if (provider === "parallel") {
 		const result = await searchWithParallel(query, options);
 		return { ...result, provider: "parallel" };
@@ -197,6 +209,27 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	// Self-hosted providers first (local-first priority)
+	if (isSearXNGConfigured()) {
+		try {
+			const result = await searchWithSearXNG(query, options);
+			return { ...result, provider: "searxng" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`SearXNG: ${errorMessage(err)}`);
+		}
+	}
+
+	if (isFirecrawlConfigured()) {
+		try {
+			const result = await searchWithFirecrawl(query, options);
+			return { ...result, provider: "firecrawl" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Firecrawl: ${errorMessage(err)}`);
+		}
+	}
+
 	if (isBraveAvailable()) {
 		try {
 			const result = await searchWithBrave(query, options);
@@ -252,10 +285,11 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	throw new Error(
 		"No search provider available. Either:\n" +
 		"  1. Use /login to sign in with a Codex subscription for OpenAI web search\n" +
-		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, tavilyApiKey, perplexityApiKey, exaApiKey, geminiApiKey, or cloudflareApiKey in ${CONFIG_PATH}\n` +
-		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, EXA_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, or CLOUDFLARE_API_KEY env vars\n" +
-		"  4. Set GOOGLE_GEMINI_BASE_URL with CLOUDFLARE_API_KEY for Cloudflare AI Gateway routing\n" +
-		"  5. Sign into gemini.google.com in a supported Chromium-based browser"
+		`  2. Set FIRECRAWL_BASE_URL or SEARXNG_BASE_URL (self-hosted)\n` +
+		`  3. Set openaiApiKey, braveApiKey, parallelApiKey, tavilyApiKey, perplexityApiKey, exaApiKey, geminiApiKey, or cloudflareApiKey in ${CONFIG_PATH}\n` +
+		"  4. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, EXA_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, or CLOUDFLARE_API_KEY env vars\n" +
+		"  5. Set GOOGLE_GEMINI_BASE_URL with CLOUDFLARE_API_KEY for Cloudflare AI Gateway routing\n" +
+		"  6. Sign into gemini.google.com in a supported Chromium-based browser"
 	);
 }
 

--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,8 @@ import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
 import { isParallelAvailable } from "./parallel.ts";
 import { isTavilyAvailable } from "./tavily.ts";
+import { isSearXNGConfigured } from "./searxng.ts";
+import { isFirecrawlConfigured } from "./firecrawl.ts";
 import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
 import { loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 
@@ -91,6 +93,8 @@ interface ProviderAvailability {
 	perplexity: boolean;
 	exa: boolean;
 	gemini: boolean;
+	searxng: boolean;
+	firecrawl: boolean;
 }
 
 type WebSearchWorkflow = "none" | "summary-review" | "auto-summary";
@@ -150,7 +154,7 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini", "searxng", "firecrawl"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -194,6 +198,8 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 		perplexity: isPerplexityAvailable(),
 		exa: isExaAvailable(),
 		gemini: isGeminiApiAvailable() || !!geminiWebAvail,
+		searxng: isSearXNGConfigured(),
+		firecrawl: isFirecrawlConfigured(),
 	};
 }
 
@@ -221,6 +227,9 @@ async function loadCuratorBootstrap(
 
 function firstAvailableProvider(available: ProviderAvailability, preferOpenAI: boolean, fallback: ResolvedSearchProvider): ResolvedSearchProvider {
 	if (preferOpenAI && available.openai) return "openai";
+	// Self-hosted providers prioritized for zero-data-leakage setups
+	if (available.searxng) return "searxng";
+	if (available.firecrawl) return "firecrawl";
 	if (available.exa) return "exa";
 	if (available.brave) return "brave";
 	if (available.parallel) return "parallel";
@@ -243,6 +252,12 @@ function resolveProvider(
 	}
 	if (provider === "openai" && !available.openai) {
 		return firstAvailableProvider(available, false, "openai");
+	}
+	if (provider === "searxng" && !available.searxng) {
+		return firstAvailableProvider(available, preferOpenAI, "searxng");
+	}
+	if (provider === "firecrawl" && !available.firecrawl) {
+		return firstAvailableProvider(available, preferOpenAI, "firecrawl");
 	}
 	if (provider === "brave" && !available.brave) {
 		return firstAvailableProvider(available, preferOpenAI, "brave");
@@ -1255,7 +1270,7 @@ export default function (pi: ExtensionAPI) {
 			),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
 			provider: Type.Optional(
-				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"], { description: "Search provider (default: auto)" }),
+				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini", "searxng", "firecrawl"], { description: "Search provider (default: auto)" }),
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review", "auto-summary"], {

--- a/searxng.ts
+++ b/searxng.ts
@@ -1,0 +1,210 @@
+import { existsSync, readFileSync } from "node:fs";
+import { activityMonitor } from "./activity.ts";
+import type { SearchOptions, SearchResponse, SearchResult } from "./perplexity.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const CONFIG_PATH = getWebSearchConfigPath();
+const SEARCH_TIMEOUT_MS = 30_000;
+
+interface WebSearchConfig {
+	searxngBaseUrl?: unknown;
+}
+
+interface SearXNGResult {
+	title?: string;
+	url?: string;
+	content?: string;
+	publishedDate?: string | null;
+	engine?: string;
+}
+
+interface SearXNGResponse {
+	results?: SearXNGResult[];
+	infoboxes?: unknown[];
+	suggestions?: string[];
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+function normalizeUrl(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim().replace(/\/+$/, "");
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function getBaseUrl(): string | null {
+	return (
+		normalizeUrl(process.env.SEARXNG_BASE_URL) ??
+		normalizeUrl(loadConfig().searxngBaseUrl)
+	);
+}
+
+function normalizeCount(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 5;
+	return Math.max(1, Math.min(Math.floor(value), 20));
+}
+
+function normalizeDomain(value: string): string | null {
+	let input = value.trim().toLowerCase();
+	if (!input) return null;
+	if (input.startsWith("-")) input = input.slice(1).trim();
+	if (!input) return null;
+	try {
+		const parsed = input.includes("://") ? new URL(input) : new URL(`https://${input}`);
+		input = parsed.hostname;
+	} catch {
+		input = input.split("/")[0]?.split(":")[0] ?? "";
+	}
+	input = input.replace(/^\.+|\.+$/g, "");
+	return /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(input) ? input : null;
+}
+
+function hostMatchesDomain(hostname: string, domain: string): boolean {
+	return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+function matchesDomainFilters(url: string, domainFilter: string[] | undefined): boolean {
+	if (!domainFilter?.length) return true;
+	const includes: string[] = [];
+	const excludes: string[] = [];
+	for (const raw of domainFilter) {
+		const domain = normalizeDomain(raw);
+		if (!domain) continue;
+		if (raw.trim().startsWith("-")) excludes.push(domain);
+		else includes.push(domain);
+	}
+
+	let hostname = "";
+	try {
+		hostname = new URL(url).hostname.toLowerCase();
+	} catch {
+		return false;
+	}
+
+	if (includes.length > 0 && !includes.some(d => hostMatchesDomain(hostname, d))) return false;
+	return !excludes.some(d => hostMatchesDomain(hostname, d));
+}
+
+function buildSearXNGQuery(query: string, domainFilter: string[] | undefined): string {
+	if (!domainFilter?.length) return query;
+	const includes: string[] = [];
+	const excludes: string[] = [];
+	for (const raw of domainFilter) {
+		const domain = normalizeDomain(raw);
+		if (!domain) continue;
+		if (raw.trim().startsWith("-")) excludes.push(domain);
+		else includes.push(domain);
+	}
+
+	const parts = [query];
+	if (includes.length > 0) parts.push(`(${includes.map(d => `site:${d}`).join(" OR ")})`);
+	for (const d of excludes) parts.push(`-site:${d}`);
+	return parts.join(" ");
+}
+
+function mapRecencyFilter(filter: string | undefined): string | undefined {
+	if (!filter) return undefined;
+	const map: Record<string, string> = {
+		day: "day",
+		week: "week",
+		month: "month",
+		year: "year",
+	};
+	return map[filter];
+}
+
+export function isSearXNGConfigured(): boolean {
+	return !!getBaseUrl();
+}
+
+export async function searchWithSearXNG(
+	query: string,
+	options: SearchOptions = {},
+): Promise<SearchResponse> {
+	const baseUrl = getBaseUrl();
+	if (!baseUrl) {
+		throw new Error(
+			"SearXNG base URL not configured. Either:\n" +
+			`  1. Create ${CONFIG_PATH} with { "searxngBaseUrl": "http://localhost:4000" }\n` +
+			"  2. Set SEARXNG_BASE_URL environment variable",
+		);
+	}
+
+	const numResults = normalizeCount(options.numResults);
+	const searchQuery = buildSearXNGQuery(query, options.domainFilter);
+	const activityId = activityMonitor.logStart({ type: "api", query: searchQuery });
+
+	const params = new URLSearchParams({
+		q: searchQuery,
+		format: "json",
+		language: "en",
+		categories: "general",
+	});
+
+	const recency = mapRecencyFilter(options.recencyFilter);
+	if (recency) params.set("time_range", recency);
+
+	try {
+		const response = await fetch(`${baseUrl}/search?${params.toString()}`, {
+			method: "GET",
+			headers: {
+				"Accept": "application/json",
+			},
+			signal: options.signal
+				? AbortSignal.any([AbortSignal.timeout(SEARCH_TIMEOUT_MS), options.signal])
+				: AbortSignal.timeout(SEARCH_TIMEOUT_MS),
+		});
+
+		if (!response.ok) {
+			activityMonitor.logError(activityId, `HTTP ${response.status}`);
+			const errorText = await response.text();
+			throw new Error(`SearXNG error ${response.status}: ${errorText.slice(0, 300)}`);
+		}
+
+		const data = (await response.json()) as SearXNGResponse;
+		activityMonitor.logComplete(activityId, response.status);
+
+		const results: SearchResult[] = [];
+		for (const item of data.results ?? []) {
+			if (!item.url) continue;
+			if (!matchesDomainFilters(item.url, options.domainFilter)) continue;
+			results.push({
+				title: item.title || item.url,
+				url: item.url,
+				snippet: item.content || "",
+			});
+			if (results.length >= numResults) break;
+		}
+
+		const answer = results
+			.map(r => r.snippet ? `${r.snippet}\nSource: ${r.title} (${r.url})` : `Source: ${r.title} (${r.url})`)
+			.join("\n\n");
+
+		return { answer, results };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		throw err;
+	}
+}


### PR DESCRIPTION
## Summary

Adds **SearXNG** (self-hosted metasearch) and **Firecrawl** (self-hosted web scraping) as optional providers for `web_search` and `fetch_content`. Addresses the self-hosted portion of [#105](https://github.com/nicobailon/pi-web-access/issues/105).

No breaking changes — these providers are only activated when their environment variables or config keys are set. All existing behavior is preserved.

## New Providers

### SearXNG (`searxng.ts`)
- Lightweight metasearch via SearXNG JSON API (`/search?format=json`)
- Config: `SEARXNG_BASE_URL` env or `searxngBaseUrl` in `web-search.json`
- Supports `numResults`, `recencyFilter`, domain include/exclude filters

### Firecrawl (`firecrawl.ts`)
- **Search** via `/v1/search` endpoint
- **Content extraction** via `/v1/scrape` endpoint (Playwright-rendered Markdown + metadata)
- Auth: `FIRECRAWL_API_KEY` (Bearer token) or `FIRECRAWL_BASIC_AUTH` (HTTP Basic for reverse-proxy setups)
- Config: `FIRECRAWL_BASE_URL` env or `firecrawlBaseUrl` in `web-search.json`

## Integration

- Both providers wired into the **auto fallback chain** in `gemini-search.ts` (local-first priority before SaaS providers)
- Firecrawl added as an **extraction fallback** in `extract.ts` (after Jina Reader, before Parallel/Gemini)
- Both providers exposed in the **curator UI** (provider buttons, labels, CSS tags, server-side validation)
- Provider availability checks (`isSearXNGConfigured()`, `isFirecrawlConfigured()`) skip gracefully when unconfigured

## Implementation Notes

- Follows the same patterns as existing providers (`brave.ts`, `tavily.ts`)
- Firecrawl extraction returns `null` on any failure (not throw), making it a proper fallback tier
- Domain filters applied client-side for consistency across all providers
- Config caching follows the same approach as all other providers (no invalidation until restart)

Refs #105