### PR TITLE
feat: add Bright Data search provider, Web Unlocker fallback, and structured feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 bun.lock
 package-lock.json
+
+# Vendored Bright Data reference material (docs/CLI/skills) — not part of the package
+BRIGHT DATA DOCS/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added Bright Data provider support (opt-in via `brightdataApiKey` / `BRIGHTDATA_API_TOKEN`), spanning three surfaces with no new tools:
+  - `web_search` SERP provider (`provider: "brightdata"`) and `auto`-chain fallback.
+  - `fetch_content` Web Unlocker fallback for bot-blocked / CAPTCHA pages, tried after the direct-HTTP and Jina paths and before Parallel/Gemini.
+  - Structured platform feeds: supported URLs (Amazon, Reddit, npm, PyPI) auto-route through `fetch_content` to Bright Data dataset snapshots and return structured JSON. The router is data-driven (`brightdata-feeds.ts`), so additional feeds are a single-entry change. Unlocker zone is configurable via `brightdataZone` / `BRIGHTDATA_ZONE` (default `mcp_unlocker`).
+
 ## [0.13.0] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,11 +36,22 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
   "braveApiKey": "BSA_...",
   "exaApiKey": "exa-...",
   "perplexityApiKey": "pplx-...",
-  "geminiApiKey": "AIza..."
+  "geminiApiKey": "AIza...",
+  "brightdataApiKey": "brd-..."
 }
 ```
 
-In `auto` mode (default), `web_search` tries OpenAI when suitable and available, then Exa (direct API if keyed, MCP if not), Brave, Parallel, Tavily, Perplexity, Gemini API, then Gemini Web when browser-cookie access is enabled.
+In `auto` mode (default), `web_search` tries OpenAI when suitable and available, then Exa (direct API if keyed, MCP if not), Brave, Parallel, Tavily, Perplexity, Bright Data, Gemini API, then Gemini Web when browser-cookie access is enabled.
+
+### Bright Data (optional)
+
+With a `brightdataApiKey` set, Bright Data adds two capabilities on top of the existing tools — no new tools, no change to zero-config behavior when the key is absent:
+
+- **SERP search** — `web_search({ provider: "brightdata" })`, and a step in the `auto` chain.
+- **Web Unlocker fetch fallback** — `fetch_content` routes bot-blocked / CAPTCHA pages through Bright Data's Unlocker (tried after the free HTTP and Jina paths, before Parallel/Gemini).
+- **Structured platform feeds** — when `fetch_content` receives a supported platform URL (Amazon, Reddit, npm, PyPI), it returns structured JSON instead of scraped markdown. The router is data-driven, so more of Bright Data's feeds can be enabled by adding a single entry in `brightdata-feeds.ts`.
+
+Config: `brightdataApiKey` in `~/.pi/web-search.json` or `BRIGHTDATA_API_TOKEN` env var. Bright Data uses separate zone types — set the Web Unlocker zone with `brightdataUnlockerZone` / `BRIGHTDATA_UNLOCKER_ZONE` (default `mcp_unlocker`, also accepts legacy `brightdataZone` / `BRIGHTDATA_ZONE`) and, optionally, a dedicated SERP zone with `brightdataSerpZone` / `BRIGHTDATA_SERP_ZONE` (falls back to the Unlocker zone). Structured feeds are asynchronous snapshot jobs, so they add latency; a request that does not resolve in time falls through to normal extraction.
 
 Optional dependencies for video frame extraction:
 
@@ -96,7 +107,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "auto-summary" })
 | `numResults` | Results per query (default: 5, max: 20) |
 | `recencyFilter` | `day`, `week`, `month`, or `year` |
 | `domainFilter` | Limit to domains (prefix with `-` to exclude) |
-| `provider` | `auto` (default), `openai`, `brave`, `parallel`, `tavily`, `exa`, `perplexity`, or `gemini` |
+| `provider` | `auto` (default), `openai`, `brave`, `parallel`, `tavily`, `exa`, `perplexity`, `gemini`, or `brightdata` |
 | `includeContent` | Fetch full page content from sources in background |
 | `workflow` | `none` (skip curator), `summary-review` (open curator and auto-generate a summary draft, default), or `auto-summary` (generate a summary without opening the curator) |
 

--- a/brightdata-feeds.ts
+++ b/brightdata-feeds.ts
@@ -1,0 +1,230 @@
+import { activityMonitor } from "./activity.ts";
+import type { ExtractedContent } from "./extract.ts";
+import { getBrightDataApiKey, isBrightDataAvailable } from "./brightdata.ts";
+
+// Bright Data structured "web_data_*" feeds are async snapshot jobs: POST a
+// trigger with the input URL, receive a snapshot_id, then poll until the
+// snapshot is ready. Unlike search/scrape (synchronous), these can take from a
+// few seconds to a minute — so we cap the wait and fall through to normal
+// extraction if it does not resolve in time.
+const TRIGGER_URL = "https://api.brightdata.com/datasets/v3/trigger";
+const SNAPSHOT_URL = "https://api.brightdata.com/datasets/v3/snapshot";
+
+function envInt(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (!raw) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+// Overridable via env primarily as a test seam (mirrors the Bright Data MCP's
+// POLLING_TIMEOUT). Defaults are tuned for real snapshot latency.
+const POLL_INTERVAL_MS = envInt("BRIGHTDATA_POLL_INTERVAL_MS", 2_000);
+const POLL_TIMEOUT_MS = envInt("BRIGHTDATA_POLL_TIMEOUT_MS", 90_000);
+const REQUEST_TIMEOUT_MS = 30_000;
+const PENDING_STATUSES = new Set(["running", "building", "collecting", "pending", "scheduled"]);
+
+/**
+ * One row per supported platform. This is the extensible "socket": adding any
+ * of Bright Data's other ~40 structured feeds is a single entry here — a
+ * dataset id plus a URL pattern — with no other code changes. dataset ids are
+ * Bright Data's stable identifiers (see their MCP `datasets` list).
+ */
+export interface FeedDefinition {
+	/** Stable slug, matching Bright Data's dataset short id. */
+	id: string;
+	/** Bright Data dataset id (gd_...). */
+	datasetId: string;
+	/** Human-readable label used as the extracted title. */
+	label: string;
+	/** URL pattern that routes a fetch to this feed. */
+	match: RegExp;
+	/**
+	 * Build the trigger input payload from the URL. Datasets have different
+	 * required fields (most take `{ url }`, but npm/PyPI take `{ package_name }`),
+	 * so each feed maps its own. Returns null when the URL lacks what the dataset
+	 * needs, in which case the caller falls through to normal extraction.
+	 */
+	buildInput: (url: string) => Record<string, unknown> | null;
+}
+
+const urlInput = (url: string): Record<string, unknown> => ({ url });
+
+function npmPackageInput(url: string): Record<string, unknown> | null {
+	const match = url.match(/npmjs\.com\/package\/([^?#]+)/i);
+	if (!match) return null;
+	// Handle scoped packages (@scope/name) and strip any /v/<version> suffix.
+	const name = decodeURIComponent(match[1].replace(/\/v\/.*$/, "").replace(/\/+$/, ""));
+	return name ? { package_name: name } : null;
+}
+
+function pypiPackageInput(url: string): Record<string, unknown> | null {
+	const match = url.match(/pypi\.org\/project\/([^/?#]+)/i);
+	return match ? { package_name: decodeURIComponent(match[1]) } : null;
+}
+
+export const BRIGHTDATA_FEEDS: FeedDefinition[] = [
+	{
+		id: "amazon_product",
+		datasetId: "gd_l7q7dkf244hwjntr0",
+		label: "Amazon product (structured)",
+		match: /^https?:\/\/(?:www\.)?amazon\.[a-z.]+\/(?:[^?#]*\/)?dp\/[A-Z0-9]/i,
+		buildInput: urlInput,
+	},
+	{
+		id: "reddit_posts",
+		datasetId: "gd_lvz8ah06191smkebj4",
+		label: "Reddit post (structured)",
+		match: /^https?:\/\/(?:www\.)?reddit\.com\/r\/[^/]+\/comments\//i,
+		buildInput: urlInput,
+	},
+	{
+		id: "npm_package",
+		datasetId: "gd_mk57m0301khq4jmsul",
+		label: "npm package (structured)",
+		match: /^https?:\/\/(?:www\.)?npmjs\.com\/package\//i,
+		buildInput: npmPackageInput,
+	},
+	{
+		id: "pypi_package",
+		datasetId: "gd_mk57kc3t1wwgmnepp9",
+		label: "PyPI package (structured)",
+		match: /^https?:\/\/pypi\.org\/project\//i,
+		buildInput: pypiPackageInput,
+	},
+	{
+		// github handling in extract.ts (clone) runs first and is preferred; this
+		// row documents the mapping and acts as a fallback only if that path is
+		// ever disabled. It also demonstrates how a "code" feed plugs in.
+		id: "github_repository_file",
+		datasetId: "gd_lyrexgxc24b3d4imjt",
+		label: "GitHub repository file (structured)",
+		match: /^https?:\/\/github\.com\/[^/]+\/[^/]+\/blob\//i,
+		buildInput: urlInput,
+	},
+];
+
+/** Return the feed whose URL pattern matches, or null. */
+export function detectBrightDataFeed(url: string): FeedDefinition | null {
+	for (const feed of BRIGHTDATA_FEEDS) {
+		if (feed.match.test(url)) return feed;
+	}
+	return null;
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) return reject(new Error("Aborted"));
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(new Error("Aborted"));
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+function requestSignal(signal?: AbortSignal): AbortSignal {
+	const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function formatFeedData(feed: FeedDefinition, url: string, records: unknown): string {
+	const pretty = JSON.stringify(records, null, 2);
+	return [
+		`# ${feed.label}`,
+		`Source: ${url}`,
+		`Dataset: ${feed.datasetId}`,
+		"",
+		"```json",
+		pretty,
+		"```",
+	].join("\n");
+}
+
+/**
+ * Trigger a feed snapshot for a URL and poll until it is ready. Returns null
+ * (never throws) on any failure or timeout so the caller falls through to the
+ * normal extraction chain.
+ */
+export async function fetchBrightDataFeed(
+	url: string,
+	feed: FeedDefinition,
+	signal?: AbortSignal,
+): Promise<ExtractedContent | null> {
+	const apiKey = getBrightDataApiKey();
+	if (!apiKey) return null;
+
+	const input = feed.buildInput(url);
+	if (!input) return null;
+
+	const headers = {
+		"Content-Type": "application/json",
+		"Authorization": `Bearer ${apiKey}`,
+	};
+	const activityId = activityMonitor.logStart({ type: "api", query: `brightdata feed ${feed.id}: ${url}` });
+
+	try {
+		const triggerRes = await fetch(
+			`${TRIGGER_URL}?dataset_id=${encodeURIComponent(feed.datasetId)}&include_errors=true`,
+			{
+				method: "POST",
+				headers,
+				body: JSON.stringify([input]),
+				signal: requestSignal(signal),
+			},
+		);
+		if (!triggerRes.ok) {
+			activityMonitor.logError(activityId, `trigger HTTP ${triggerRes.status}`);
+			return null;
+		}
+
+		const triggerData = await triggerRes.json() as { snapshot_id?: string };
+		const snapshotId = triggerData?.snapshot_id;
+		if (!snapshotId) {
+			activityMonitor.logError(activityId, "no snapshot_id");
+			return null;
+		}
+
+		const deadline = Date.now() + POLL_TIMEOUT_MS;
+		while (Date.now() < deadline) {
+			if (signal?.aborted) return null;
+			await delay(POLL_INTERVAL_MS, signal);
+
+			const snapshotRes = await fetch(
+				`${SNAPSHOT_URL}/${encodeURIComponent(snapshotId)}?format=json`,
+				{ method: "GET", headers, signal: requestSignal(signal) },
+			);
+
+			// 202 = snapshot still building.
+			if (snapshotRes.status === 202) continue;
+			if (!snapshotRes.ok) {
+				activityMonitor.logError(activityId, `snapshot HTTP ${snapshotRes.status}`);
+				return null;
+			}
+
+			const data = await snapshotRes.json() as unknown;
+			const status = (data && typeof data === "object" && !Array.isArray(data))
+				? (data as { status?: unknown }).status
+				: undefined;
+			if (typeof status === "string" && PENDING_STATUSES.has(status.toLowerCase())) continue;
+
+			activityMonitor.logComplete(activityId, snapshotRes.status);
+			return { url, title: feed.label, content: formatFeedData(feed, url, data), error: null };
+		}
+
+		activityMonitor.logError(activityId, "poll timeout");
+		return null;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		return null;
+	}
+}

--- a/brightdata.ts
+++ b/brightdata.ts
@@ -1,0 +1,327 @@
+import { existsSync, readFileSync } from "node:fs";
+import { activityMonitor } from "./activity.ts";
+import type { ExtractedContent } from "./extract.ts";
+import type { SearchOptions, SearchResult, SearchResponse } from "./perplexity.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+// Bright Data exposes both SERP search and the Web Unlocker (scrape) through a
+// single endpoint: POST /request with { url, zone, format, data_format }.
+// Structured platform feeds use a separate trigger/poll API — see brightdata-feeds.ts.
+const BRIGHTDATA_REQUEST_URL = "https://api.brightdata.com/request";
+const CONFIG_PATH = getWebSearchConfigPath();
+const REQUEST_TIMEOUT_MS = 60_000;
+const DEFAULT_ZONE = "mcp_unlocker";
+const MIN_USEFUL_CONTENT = 200;
+
+interface WebSearchConfig {
+	brightdataApiKey?: unknown;
+	// `brightdataZone` is kept for back-compat and used as the Unlocker zone.
+	brightdataZone?: unknown;
+	brightdataUnlockerZone?: unknown;
+	brightdataSerpZone?: unknown;
+}
+
+interface NormalizedDomainFilters {
+	allowed: string[];
+	blocked: string[];
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+function normalizeString(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+export function getBrightDataApiKey(): string | null {
+	return normalizeString(process.env.BRIGHTDATA_API_TOKEN)
+		?? normalizeString(process.env.BRIGHTDATA_API_KEY)
+		?? normalizeString(loadConfig().brightdataApiKey);
+}
+
+// Bright Data uses distinct zone types: a Web Unlocker zone for scraping and a
+// SERP zone for search. Both flow through POST /request with the zone name.
+export function getBrightDataUnlockerZone(): string {
+	return normalizeString(process.env.BRIGHTDATA_UNLOCKER_ZONE)
+		?? normalizeString(process.env.BRIGHTDATA_ZONE)
+		?? normalizeString(loadConfig().brightdataUnlockerZone)
+		?? normalizeString(loadConfig().brightdataZone)
+		?? DEFAULT_ZONE;
+}
+
+// SERP falls back to the Unlocker zone when no dedicated SERP zone is set
+// (matches the Bright Data MCP, which routes search through the unlocker zone).
+export function getBrightDataSerpZone(): string {
+	return normalizeString(process.env.BRIGHTDATA_SERP_ZONE)
+		?? normalizeString(loadConfig().brightdataSerpZone)
+		?? getBrightDataUnlockerZone();
+}
+
+export function isBrightDataAvailable(): boolean {
+	return !!getBrightDataApiKey();
+}
+
+function missingKeyError(): Error {
+	return new Error(
+		"Bright Data API token not found. Either:\n" +
+		`  1. Create ${CONFIG_PATH} with { "brightdataApiKey": "your-token" }\n` +
+		"  2. Set BRIGHTDATA_API_TOKEN environment variable\n" +
+		"Get a token at https://brightdata.com/cp/setting/users",
+	);
+}
+
+function requestSignal(signal?: AbortSignal): AbortSignal {
+	const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+/**
+ * Shared POST /request call. Returns the raw response body as text so callers
+ * can parse JSON (SERP) or use the markdown directly (Unlocker).
+ */
+async function brightdataRequest(
+	body: Record<string, unknown>,
+	signal: AbortSignal | undefined,
+	query: string,
+): Promise<string> {
+	const apiKey = getBrightDataApiKey();
+	if (!apiKey) throw missingKeyError();
+
+	const activityId = activityMonitor.logStart({ type: "api", query });
+
+	try {
+		const response = await fetch(BRIGHTDATA_REQUEST_URL, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": `Bearer ${apiKey}`,
+			},
+			body: JSON.stringify(body),
+			signal: requestSignal(signal),
+		});
+
+		if (!response.ok) {
+			activityMonitor.logError(activityId, `HTTP ${response.status}`);
+			const errorText = await response.text();
+			throw new Error(`Bright Data request error ${response.status}: ${errorText.slice(0, 300)}`);
+		}
+
+		const text = await response.text();
+		activityMonitor.logComplete(activityId, response.status);
+		return text;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.toLowerCase().includes("abort")) {
+			activityMonitor.logComplete(activityId, 0);
+		} else {
+			activityMonitor.logError(activityId, message);
+		}
+		throw err;
+	}
+}
+
+function normalizeCount(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 5;
+	return Math.max(1, Math.min(Math.floor(value), 20));
+}
+
+function normalizeDomain(value: string): string | null {
+	let input = value.trim().toLowerCase();
+	if (!input) return null;
+	if (input.startsWith("-")) input = input.slice(1).trim();
+	if (!input) return null;
+	try {
+		const parsed = input.includes("://") ? new URL(input) : new URL(`https://${input}`);
+		input = parsed.hostname;
+	} catch {
+		input = input.split("/")[0]?.split(":")[0] ?? "";
+	}
+	input = input.replace(/^\.+|\.+$/g, "");
+	return /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(input) ? input : null;
+}
+
+function normalizeDomainFilters(domainFilter: string[] | undefined): NormalizedDomainFilters {
+	const filters: NormalizedDomainFilters = { allowed: [], blocked: [] };
+	if (!domainFilter?.length) return filters;
+
+	for (const raw of domainFilter) {
+		const domain = normalizeDomain(raw);
+		if (!domain) continue;
+		const target = raw.trim().startsWith("-") ? filters.blocked : filters.allowed;
+		if (!target.includes(domain)) target.push(domain);
+	}
+
+	return filters;
+}
+
+function buildSearchQuery(query: string, filters: NormalizedDomainFilters): string {
+	const parts = [query];
+	if (filters.allowed.length === 1) {
+		parts.push(`site:${filters.allowed[0]}`);
+	} else if (filters.allowed.length > 1) {
+		parts.push(filters.allowed.map(domain => `site:${domain}`).join(" OR "));
+	}
+	for (const domain of filters.blocked) {
+		parts.push(`-site:${domain}`);
+	}
+	return parts.join(" ");
+}
+
+const RECENCY_TBS: Record<string, string> = {
+	day: "qdr:d",
+	week: "qdr:w",
+	month: "qdr:m",
+	year: "qdr:y",
+};
+
+function buildGoogleSearchUrl(query: string, options: SearchOptions): string {
+	const filters = normalizeDomainFilters(options.domainFilter);
+	const params = new URLSearchParams({ q: buildSearchQuery(query, filters) });
+	const numResults = normalizeCount(options.numResults);
+	// Ask Google for a little headroom so post-filtering still leaves enough.
+	params.set("num", String(Math.min(numResults + 5, 20)));
+	if (options.recencyFilter && RECENCY_TBS[options.recencyFilter]) {
+		params.set("tbs", RECENCY_TBS[options.recencyFilter]);
+	}
+	return `https://www.google.com/search?${params.toString()}`;
+}
+
+function hostMatchesDomain(hostname: string, domain: string): boolean {
+	return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+function matchesDomainFilters(url: string, filters: NormalizedDomainFilters): boolean {
+	if (filters.allowed.length === 0 && filters.blocked.length === 0) return true;
+	let hostname = "";
+	try {
+		hostname = new URL(url).hostname.toLowerCase();
+	} catch {
+		return false;
+	}
+	if (filters.allowed.length > 0 && !filters.allowed.some(domain => hostMatchesDomain(hostname, domain))) {
+		return false;
+	}
+	return !filters.blocked.some(domain => hostMatchesDomain(hostname, domain));
+}
+
+interface GoogleOrganicEntry {
+	link?: unknown;
+	title?: unknown;
+	description?: unknown;
+}
+
+/**
+ * SERP search via the Bright Data Web Unlocker. Google is returned as parsed
+ * JSON (`brd_json=1`), from which we read the `organic` array.
+ */
+export async function searchWithBrightData(
+	query: string,
+	options: SearchOptions = {},
+): Promise<SearchResponse> {
+	const numResults = normalizeCount(options.numResults);
+	const filters = normalizeDomainFilters(options.domainFilter);
+	const searchUrl = buildGoogleSearchUrl(query, options);
+
+	const raw = await brightdataRequest(
+		{
+			url: `${searchUrl}&brd_json=1`,
+			zone: getBrightDataSerpZone(),
+			format: "raw",
+			data_format: "parsed_light",
+		},
+		options.signal,
+		`brightdata serp: ${query}`,
+	);
+
+	let payload: { organic?: GoogleOrganicEntry[] };
+	try {
+		payload = JSON.parse(raw) as { organic?: GoogleOrganicEntry[] };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Bright Data returned a non-JSON SERP response: ${message}`);
+	}
+
+	const organic = Array.isArray(payload.organic) ? payload.organic : [];
+	const results: SearchResult[] = [];
+	for (const entry of organic) {
+		const url = typeof entry.link === "string" ? entry.link.trim() : "";
+		const title = typeof entry.title === "string" ? entry.title.trim() : "";
+		if (!url || !title || !matchesDomainFilters(url, filters)) continue;
+		const snippet = typeof entry.description === "string" ? entry.description.trim() : "";
+		results.push({ title, url, snippet });
+		if (results.length >= numResults) break;
+	}
+
+	const answer = results
+		.map((result) => {
+			if (result.snippet) return `${result.snippet}\nSource: ${result.title} (${result.url})`;
+			return `Source: ${result.title} (${result.url})`;
+		})
+		.join("\n\n");
+
+	return { answer, results };
+}
+
+function titleFromMarkdown(markdown: string, url: string): string {
+	const match = markdown.match(/^#{1,6}\s+(.+)/m);
+	if (match) {
+		const cleaned = match[1].replace(/[*`]+/g, "").trim();
+		if (cleaned) return cleaned;
+	}
+	try {
+		return new URL(url).pathname.split("/").filter(Boolean).pop() || url;
+	} catch {
+		return url;
+	}
+}
+
+/**
+ * Fetch a page through the Web Unlocker as a fetch_content fallback. Bypasses
+ * bot detection / CAPTCHAs that defeat the direct-HTTP and Jina paths. Returns
+ * null (never throws) so the caller can fall through to the next extractor.
+ */
+export async function scrapeWithBrightData(
+	url: string,
+	signal?: AbortSignal,
+): Promise<ExtractedContent | null> {
+	if (!isBrightDataAvailable()) return null;
+
+	try {
+		const markdown = await brightdataRequest(
+			{
+				url,
+				zone: getBrightDataUnlockerZone(),
+				format: "raw",
+				data_format: "markdown",
+			},
+			signal,
+			`brightdata unlocker: ${url}`,
+		);
+
+		const trimmed = markdown.trim();
+		if (trimmed.length < MIN_USEFUL_CONTENT) return null;
+
+		return { url, title: titleFromMarkdown(trimmed, url), content: trimmed, error: null };
+	} catch {
+		// Fall through to the next extractor in the chain.
+		return null;
+	}
+}

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -8,7 +8,7 @@ function safeInlineJSON(data: unknown): string {
 }
 
 function buildProviderButtons(
-	available: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	available: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean; brightdata: boolean },
 	selected: string,
 	hasInitialQueries: boolean,
 ): string {
@@ -19,6 +19,7 @@ function buildProviderButtons(
 		{ value: "parallel", label: "Parallel", available: available.parallel },
 		{ value: "tavily", label: "Tavily", available: available.tavily },
 		{ value: "perplexity", label: "Perplexity", available: available.perplexity },
+		{ value: "brightdata", label: "Bright Data", available: available.brightdata },
 		{ value: "gemini", label: "Gemini", available: available.gemini },
 	];
 
@@ -38,7 +39,7 @@ export function generateCuratorPage(
 	queries: string[],
 	sessionToken: string,
 	timeout: number,
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean; brightdata: boolean },
 	defaultProvider: string,
 	searchProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
@@ -665,6 +666,11 @@ main {
   color: #a6e3a1;
   background: rgba(166, 227, 161, 0.14);
   border-color: rgba(166, 227, 161, 0.3);
+}
+.provider-tag.provider-brightdata {
+  color: #f9e2af;
+  background: rgba(249, 226, 175, 0.14);
+  border-color: rgba(249, 226, 175, 0.3);
 }
 .provider-tag.provider-unknown {
   color: var(--fg-muted);
@@ -1389,7 +1395,7 @@ const SCRIPT = `(function() {
   var token = DATA.sessionToken;
   var timeoutSec = DATA.timeout;
   var queries = Array.isArray(DATA.queries) ? DATA.queries : [];
-  var providers = ["openai", "exa", "brave", "parallel", "tavily", "perplexity", "gemini"];
+  var providers = ["openai", "exa", "brave", "parallel", "tavily", "perplexity", "brightdata", "gemini"];
   var availProviders = DATA.availableProviders && typeof DATA.availableProviders === "object" ? DATA.availableProviders : {};
   var workflow = "summary-review";
   var initialDefaultProvider = typeof DATA.defaultProvider === "string" ? DATA.defaultProvider : "exa";
@@ -1595,6 +1601,7 @@ const SCRIPT = `(function() {
     if (provider === "tavily") return "Tavily";
     if (provider === "perplexity") return "Perplexity";
     if (provider === "exa") return "Exa";
+    if (provider === "brightdata") return "Bright Data";
     if (provider === "gemini") return "Gemini";
     return "Unknown";
   }

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -12,7 +12,7 @@ export interface CuratorServerOptions {
 	queries: string[];
 	sessionToken: string;
 	timeout: number;
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; perplexity: boolean; exa: boolean; gemini: boolean; brightdata: boolean };
 	defaultProvider: string;
 	searchProvider: string;
 	summaryModels: Array<{ value: string; label: string }>;
@@ -250,6 +250,7 @@ export function startCuratorServer(
 		if (provider === "perplexity") return availableProviders.perplexity;
 		if (provider === "exa") return availableProviders.exa;
 		if (provider === "gemini") return availableProviders.gemini;
+		if (provider === "brightdata") return availableProviders.brightdata;
 		return false;
 	}
 

--- a/extract.ts
+++ b/extract.ts
@@ -9,6 +9,8 @@ import { extractGitHub } from "./github-extract.ts";
 import { isYouTubeURL, isYouTubeEnabled, extractYouTube, extractYouTubeFrame, extractYouTubeFrames, getYouTubeStreamInfo } from "./youtube-extract.ts";
 import { extractWithUrlContext, extractWithGeminiWeb } from "./gemini-url-context.ts";
 import { extractWithParallel, isParallelAvailable } from "./parallel.ts";
+import { isBrightDataAvailable, scrapeWithBrightData } from "./brightdata.ts";
+import { detectBrightDataFeed, fetchBrightDataFeed } from "./brightdata-feeds.ts";
 import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } from "./video-extract.ts";
 import { existsSync, readFileSync } from "node:fs";
 import { fetchRemoteUrl, validateRemoteUrl, type Lookup } from "./ssrf-protection.ts";
@@ -425,6 +427,19 @@ export async function extractContent(
 		}
 	}
 
+	// Structured platform feeds (Amazon/Reddit/npm/PyPI/…). Only runs when a
+	// Bright Data key is configured; github URLs are handled by the clone path
+	// above, so they never reach here. Falls through to normal extraction if the
+	// snapshot job fails or times out.
+	if (isBrightDataAvailable()) {
+		const feed = detectBrightDataFeed(url);
+		if (feed) {
+			const feedResult = await fetchBrightDataFeed(url, feed, signal);
+			if (feedResult) return feedResult;
+			if (signal?.aborted) return abortedResult(url);
+		}
+	}
+
 	const ytInfo = isYouTubeURL(url);
 	let youtubeEnabled = false;
 	try {
@@ -460,6 +475,13 @@ export async function extractContent(
 
 	const jinaResult = await extractWithJinaReader(url, signal, options?.lookup);
 	if (jinaResult) return jinaResult;
+	if (signal?.aborted) return abortedResult(url);
+
+	// Web Unlocker: the strongest unblocker (bypasses CAPTCHA / bot detection),
+	// tried after the free HTTP + Jina paths and before Parallel/Gemini. Only
+	// runs when a Bright Data key is configured; returns null to fall through.
+	const brightDataResult = await scrapeWithBrightData(url, signal);
+	if (brightDataResult) return brightDataResult;
 	if (signal?.aborted) return abortedResult(url);
 
 	let parallelError: string | null = null;

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -9,9 +9,10 @@ import { isBraveAvailable, searchWithBrave } from "./brave.ts";
 import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
 import { isParallelAvailable, searchWithParallel } from "./parallel.ts";
 import { isTavilyAvailable, searchWithTavily } from "./tavily.ts";
+import { isBrightDataAvailable, searchWithBrightData } from "./brightdata.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "perplexity" | "gemini" | "exa";
+export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "perplexity" | "gemini" | "exa" | "brightdata";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
 
 export interface AttributedSearchResponse extends SearchResponse {
@@ -61,7 +62,7 @@ function normalizeSearchModel(value: unknown): string | undefined {
 
 function normalizeSearchProvider(value: unknown): SearchProvider {
 	const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "perplexity", "gemini", "exa"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "perplexity", "gemini", "exa", "brightdata"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -144,6 +145,11 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	if (provider === "perplexity") {
 		const result = await searchWithPerplexity(query, options);
 		return { ...result, provider: "perplexity" };
+	}
+
+	if (provider === "brightdata") {
+		const result = await searchWithBrightData(query, options);
+		return { ...result, provider: "brightdata" };
 	}
 
 	if (provider === "gemini") {
@@ -237,6 +243,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	if (isBrightDataAvailable()) {
+		try {
+			const result = await searchWithBrightData(query, options);
+			return { ...result, provider: "brightdata" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Bright Data: ${errorMessage(err)}`);
+		}
+	}
+
 	try {
 		const geminiResult = await searchWithGemini(query, options, false);
 		if (geminiResult) return { ...geminiResult, provider: "gemini" };
@@ -252,8 +268,8 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	throw new Error(
 		"No search provider available. Either:\n" +
 		"  1. Use /login to sign in with a Codex subscription for OpenAI web search\n" +
-		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, tavilyApiKey, perplexityApiKey, exaApiKey, geminiApiKey, or cloudflareApiKey in ${CONFIG_PATH}\n` +
-		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, EXA_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, or CLOUDFLARE_API_KEY env vars\n" +
+		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, tavilyApiKey, perplexityApiKey, exaApiKey, geminiApiKey, brightdataApiKey, or cloudflareApiKey in ${CONFIG_PATH}\n` +
+		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, EXA_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, BRIGHTDATA_API_TOKEN, or CLOUDFLARE_API_KEY env vars\n" +
 		"  4. Set GOOGLE_GEMINI_BASE_URL with CLOUDFLARE_API_KEY for Cloudflare AI Gateway routing\n" +
 		"  5. Sign into gemini.google.com in a supported Chromium-based browser"
 	);

--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,7 @@ import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
 import { isParallelAvailable } from "./parallel.ts";
 import { isTavilyAvailable } from "./tavily.ts";
+import { isBrightDataAvailable } from "./brightdata.ts";
 import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
 import { loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 
@@ -91,6 +92,7 @@ interface ProviderAvailability {
 	perplexity: boolean;
 	exa: boolean;
 	gemini: boolean;
+	brightdata: boolean;
 }
 
 type WebSearchWorkflow = "none" | "summary-review" | "auto-summary";
@@ -150,7 +152,7 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini", "brightdata"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -194,6 +196,7 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 		perplexity: isPerplexityAvailable(),
 		exa: isExaAvailable(),
 		gemini: isGeminiApiAvailable() || !!geminiWebAvail,
+		brightdata: isBrightDataAvailable(),
 	};
 }
 
@@ -226,6 +229,7 @@ function firstAvailableProvider(available: ProviderAvailability, preferOpenAI: b
 	if (available.parallel) return "parallel";
 	if (available.tavily) return "tavily";
 	if (available.perplexity) return "perplexity";
+	if (available.brightdata) return "brightdata";
 	if (available.gemini) return "gemini";
 	return fallback;
 }
@@ -261,6 +265,9 @@ function resolveProvider(
 	}
 	if (provider === "gemini" && !available.gemini) {
 		return firstAvailableProvider(available, preferOpenAI, "gemini");
+	}
+	if (provider === "brightdata" && !available.brightdata) {
+		return firstAvailableProvider(available, preferOpenAI, "brightdata");
 	}
 	return provider;
 }
@@ -1242,7 +1249,7 @@ export default function (pi: ExtensionAPI) {
 		name: "web_search",
 		label: "Web Search",
 		description:
-			`Search the web using OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, or Gemini. Returns an AI-synthesized answer with source citations. OpenAI web_search uses a Codex subscription or OpenAI API key. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation or "auto-summary" for a model-generated summary without the browser curator. Provider auto-selects: OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, Perplexity, Gemini API, then Gemini Web.`,
+			`Search the web using OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, Bright Data, or Gemini. Returns an AI-synthesized answer with source citations. OpenAI web_search uses a Codex subscription or OpenAI API key. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation or "auto-summary" for a model-generated summary without the browser curator. Provider auto-selects: OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, Perplexity, Bright Data, Gemini API, then Gemini Web.`,
 		promptSnippet:
 			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
 		parameters: Type.Object({
@@ -1255,7 +1262,7 @@ export default function (pi: ExtensionAPI) {
 			),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
 			provider: Type.Optional(
-				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"], { description: "Search provider (default: auto)" }),
+				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini", "brightdata"], { description: "Search provider (default: auto)" }),
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review", "auto-summary"], {

--- a/test/brightdata.test.mjs
+++ b/test/brightdata.test.mjs
@@ -1,0 +1,266 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const brightdataModuleUrl = new URL("../brightdata.ts", import.meta.url).href;
+const feedsModuleUrl = new URL("../brightdata-feeds.ts", import.meta.url).href;
+const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
+
+function runChild(script, env) {
+	const childEnv = { ...process.env };
+	for (const key of [
+		"PI_CODING_AGENT_DIR",
+		"XDG_CONFIG_HOME",
+		"OPENAI_API_KEY",
+		"BRAVE_API_KEY",
+		"PARALLEL_API_KEY",
+		"TAVILY_API_KEY",
+		"EXA_API_KEY",
+		"PERPLEXITY_API_KEY",
+		"GEMINI_API_KEY",
+		"BRIGHTDATA_API_TOKEN",
+		"BRIGHTDATA_API_KEY",
+		"BRIGHTDATA_ZONE",
+	]) {
+		delete childEnv[key];
+	}
+	Object.assign(childEnv, env);
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+}
+
+test("isBrightDataAvailable reflects presence of a token", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-bd-avail-"));
+	const child = runChild(`
+		const { isBrightDataAvailable } = await import(${JSON.stringify(brightdataModuleUrl)});
+		console.log(JSON.stringify({ available: isBrightDataAvailable() }));
+	`, { HOME: home, USERPROFILE: home });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(JSON.parse(child.stdout.trim()).available, false);
+
+	const child2 = runChild(`
+		const { isBrightDataAvailable } = await import(${JSON.stringify(brightdataModuleUrl)});
+		console.log(JSON.stringify({ available: isBrightDataAvailable() }));
+	`, { HOME: home, USERPROFILE: home, BRIGHTDATA_API_TOKEN: "bd-token" });
+	assert.equal(child2.status, 0, child2.stderr);
+	assert.equal(JSON.parse(child2.stdout.trim()).available, true);
+});
+
+test("SERP search sends brd_json + bearer auth, parses organic, applies filters", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-bd-serp-"));
+	const child = runChild(`
+		let capturedUrl = "";
+		let capturedHeaders = null;
+		let capturedBody = null;
+		globalThis.fetch = async (url, init) => {
+			capturedUrl = String(url);
+			capturedHeaders = init.headers;
+			capturedBody = JSON.parse(init.body);
+			return new Response(JSON.stringify({
+				organic: [
+					{ link: "https://github.com/nicobailon/pi-web-access", title: "Repo", description: "the repo" },
+					{ link: "https://gist.github.com/x/abc", title: "Gist", description: "a gist" },
+					{ link: "https://example.com/nope", title: "Example", description: "nope" },
+				],
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+
+		const { searchWithBrightData } = await import(${JSON.stringify(brightdataModuleUrl)});
+		const result = await searchWithBrightData("sdk docs", {
+			domainFilter: ["github.com", "-gist.github.com"],
+			recencyFilter: "week",
+			numResults: 2,
+		});
+		console.log(JSON.stringify({ capturedUrl, capturedHeaders, capturedBody, results: result.results, answer: result.answer }));
+	`, { HOME: home, USERPROFILE: home, BRIGHTDATA_API_TOKEN: "bd-token" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const out = JSON.parse(child.stdout.trim());
+	assert.equal(out.capturedUrl, "https://api.brightdata.com/request");
+	assert.equal(out.capturedHeaders.Authorization, "Bearer bd-token");
+	assert.equal(out.capturedBody.zone, "mcp_unlocker");
+	assert.equal(out.capturedBody.format, "raw");
+	assert.equal(out.capturedBody.data_format, "parsed_light");
+	assert.match(out.capturedBody.url, /[?&]brd_json=1/);
+	assert.match(out.capturedBody.url, /tbs=qdr%3Aw/);
+	assert.match(decodeURIComponent(out.capturedBody.url), /site:github\.com/);
+	assert.match(decodeURIComponent(out.capturedBody.url), /-site:gist\.github\.com/);
+	// gist (blocked) and example (not allowed) are filtered out post-parse.
+	assert.deepEqual(out.results.map((r) => r.url), ["https://github.com/nicobailon/pi-web-access"]);
+	assert.match(out.answer, /the repo/);
+});
+
+test("SERP search honors a custom zone from config", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-bd-zone-"));
+	const child = runChild(`
+		const dir = ${JSON.stringify(home)};
+		const { writeFileSync } = await import("node:fs");
+		writeFileSync(dir + "/web-search.json", JSON.stringify({ brightdataApiKey: "cfg-token", brightdataZone: "my_zone" }));
+		let capturedBody = null;
+		globalThis.fetch = async (url, init) => {
+			capturedBody = JSON.parse(init.body);
+			return new Response(JSON.stringify({ organic: [] }), { status: 200 });
+		};
+		const { searchWithBrightData } = await import(${JSON.stringify(brightdataModuleUrl)});
+		await searchWithBrightData("q");
+		console.log(JSON.stringify({ zone: capturedBody.zone }));
+	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(JSON.parse(child.stdout.trim()).zone, "my_zone");
+});
+
+test("Web Unlocker scrape returns markdown; falls through (null) without a key or on error", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-bd-scrape-"));
+
+	// Happy path: markdown returned.
+	const ok = runChild(`
+		let capturedBody = null;
+		globalThis.fetch = async (url, init) => {
+			capturedBody = JSON.parse(init.body);
+			return new Response("# Title\\n\\n" + "content ".repeat(50), { status: 200 });
+		};
+		const { scrapeWithBrightData } = await import(${JSON.stringify(brightdataModuleUrl)});
+		const result = await scrapeWithBrightData("https://blocked.example.com/a");
+		console.log(JSON.stringify({ data_format: capturedBody.data_format, title: result?.title, hasContent: !!result?.content, error: result?.error }));
+	`, { HOME: home, USERPROFILE: home, BRIGHTDATA_API_TOKEN: "bd-token" });
+	assert.equal(ok.status, 0, ok.stderr);
+	const okOut = JSON.parse(ok.stdout.trim());
+	assert.equal(okOut.data_format, "markdown");
+	assert.equal(okOut.title, "Title");
+	assert.equal(okOut.hasContent, true);
+	assert.equal(okOut.error, null);
+
+	// No key: returns null without any network call.
+	const noKey = runChild(`
+		let called = false;
+		globalThis.fetch = async () => { called = true; return new Response("x", { status: 200 }); };
+		const { scrapeWithBrightData } = await import(${JSON.stringify(brightdataModuleUrl)});
+		const result = await scrapeWithBrightData("https://blocked.example.com/a");
+		console.log(JSON.stringify({ result, called }));
+	`, { HOME: home, USERPROFILE: home });
+	assert.equal(noKey.status, 0, noKey.stderr);
+	const noKeyOut = JSON.parse(noKey.stdout.trim());
+	assert.equal(noKeyOut.result, null);
+	assert.equal(noKeyOut.called, false);
+
+	// HTTP error: returns null (caller falls through to the next extractor).
+	const err = runChild(`
+		globalThis.fetch = async () => new Response("blocked", { status: 403 });
+		const { scrapeWithBrightData } = await import(${JSON.stringify(brightdataModuleUrl)});
+		const result = await scrapeWithBrightData("https://blocked.example.com/a");
+		console.log(JSON.stringify({ result }));
+	`, { HOME: home, USERPROFILE: home, BRIGHTDATA_API_TOKEN: "bd-token" });
+	assert.equal(err.status, 0, err.stderr);
+	assert.equal(JSON.parse(err.stdout.trim()).result, null);
+});
+
+test("feed detection routes known platform URLs and ignores others", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-bd-detect-"));
+	const child = runChild(`
+		const { detectBrightDataFeed } = await import(${JSON.stringify(feedsModuleUrl)});
+		const cases = {
+			amazon: detectBrightDataFeed("https://www.amazon.com/Great-Thing/dp/B0ABCD1234")?.id ?? null,
+			reddit: detectBrightDataFeed("https://www.reddit.com/r/rust/comments/abc/title/")?.id ?? null,
+			npm: detectBrightDataFeed("https://www.npmjs.com/package/p-limit")?.id ?? null,
+			pypi: detectBrightDataFeed("https://pypi.org/project/requests/")?.id ?? null,
+			github: detectBrightDataFeed("https://github.com/nicobailon/pi-web-access/blob/main/index.ts")?.id ?? null,
+			plain: detectBrightDataFeed("https://example.com/article")?.id ?? null,
+			amazonHome: detectBrightDataFeed("https://www.amazon.com/")?.id ?? null,
+		};
+		console.log(JSON.stringify(cases));
+	`, { HOME: home, USERPROFILE: home });
+	assert.equal(child.status, 0, child.stderr);
+	const out = JSON.parse(child.stdout.trim());
+	assert.equal(out.amazon, "amazon_product");
+	assert.equal(out.reddit, "reddit_posts");
+	assert.equal(out.npm, "npm_package");
+	assert.equal(out.pypi, "pypi_package");
+	assert.equal(out.github, "github_repository_file");
+	assert.equal(out.plain, null);
+	assert.equal(out.amazonHome, null);
+});
+
+test("feed fetch triggers a snapshot, polls past 'building', and returns records", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-bd-feed-"));
+	const child = runChild(`
+		const calls = [];
+		let triggerBody = null;
+		let snapshotHits = 0;
+		globalThis.fetch = async (url, init) => {
+			const u = String(url);
+			calls.push(u);
+			if (u.startsWith("https://api.brightdata.com/datasets/v3/trigger")) {
+				triggerBody = JSON.parse(init.body);
+				return new Response(JSON.stringify({ snapshot_id: "snap1" }), { status: 200 });
+			}
+			if (u.startsWith("https://api.brightdata.com/datasets/v3/snapshot/")) {
+				snapshotHits++;
+				if (snapshotHits === 1) return new Response(JSON.stringify({ status: "building" }), { status: 200 });
+				return new Response(JSON.stringify([{ title: "p-limit", downloads: 123 }]), { status: 200 });
+			}
+			throw new Error("Unexpected fetch " + u);
+		};
+		const { detectBrightDataFeed, fetchBrightDataFeed } = await import(${JSON.stringify(feedsModuleUrl)});
+		const feed = detectBrightDataFeed("https://www.npmjs.com/package/p-limit");
+		const result = await fetchBrightDataFeed("https://www.npmjs.com/package/p-limit", feed);
+		console.log(JSON.stringify({ calls, triggerBody, title: result?.title, containsDataset: result?.content.includes(feed.datasetId), containsRecord: result?.content.includes("p-limit"), error: result?.error }));
+	`, { HOME: home, USERPROFILE: home, BRIGHTDATA_API_TOKEN: "bd-token", BRIGHTDATA_POLL_INTERVAL_MS: "0" });
+	assert.equal(child.status, 0, child.stderr);
+	const out = JSON.parse(child.stdout.trim());
+	assert.ok(out.calls.some((c) => c.includes("/trigger?dataset_id=")));
+	// npm uses package_name (not url) — the per-feed input mapping.
+	assert.deepEqual(out.triggerBody, [{ package_name: "p-limit" }]);
+	assert.equal(out.title, "npm package (structured)");
+	assert.equal(out.containsDataset, true);
+	assert.equal(out.containsRecord, true);
+	assert.equal(out.error, null);
+});
+
+test("feed fetch returns null without a key (no network call)", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-bd-feed-nokey-"));
+	const child = runChild(`
+		let called = false;
+		globalThis.fetch = async () => { called = true; return new Response("{}", { status: 200 }); };
+		const { detectBrightDataFeed, fetchBrightDataFeed } = await import(${JSON.stringify(feedsModuleUrl)});
+		const feed = detectBrightDataFeed("https://pypi.org/project/requests/");
+		const result = await fetchBrightDataFeed("https://pypi.org/project/requests/", feed);
+		console.log(JSON.stringify({ result, called }));
+	`, { HOME: home, USERPROFILE: home });
+	assert.equal(child.status, 0, child.stderr);
+	const out = JSON.parse(child.stdout.trim());
+	assert.equal(out.result, null);
+	assert.equal(out.called, false);
+});
+
+test("auto provider falls through to Bright Data when it is the only key", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-bd-auto-"));
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			const u = String(url);
+			calls.push(u);
+			if (u === "https://mcp.exa.ai/mcp") return new Response("Exa unavailable", { status: 503 });
+			if (u === "https://api.brightdata.com/request") {
+				return new Response(JSON.stringify({
+					organic: [{ link: "https://docs.rs/tokio", title: "Tokio", description: "async runtime" }],
+				}), { status: 200, headers: { "content-type": "application/json" } });
+			}
+			throw new Error("Unexpected fetch " + u);
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("rust async runtime", { provider: "auto" });
+		console.log(JSON.stringify({ calls, provider: result.provider, answer: result.answer }));
+	`, { HOME: home, USERPROFILE: home, BRIGHTDATA_API_TOKEN: "bd-token" });
+	assert.equal(child.status, 0, child.stderr);
+	const out = JSON.parse(child.stdout.trim());
+	assert.ok(out.calls.includes("https://api.brightdata.com/request"));
+	assert.equal(out.provider, "brightdata");
+	assert.match(out.answer, /async runtime/);
+});


### PR DESCRIPTION
## Summary

Adds [Bright Data](https://brightdata.com) as an optional provider in pi-web-access — product code only, opt-in via API key, with no change to the zero-config default when unset.

- **`web_search`**: explicit `provider: "brightdata"` plus auto-chain fallback (… → Perplexity → Bright Data → Gemini)
- **`fetch_content`**: Web Unlocker fallback for bot-blocked / CAPTCHA pages (after HTTP/Readability + Jina, before Parallel/Gemini)
- **`fetch_content`**: structured-feed router — supported platform URLs (Amazon, Reddit, npm, PyPI) return JSON via Bright Data dataset snapshots; adding another feed is a one-line entry in `brightdata-feeds.ts`
- **REST client** (`brightdata.ts`): direct API calls — no CLI/subprocess dependency

## Files changed (9)

| Area | Files |
|------|-------|
| New provider client | `brightdata.ts` |
| Structured feeds | `brightdata-feeds.ts` |
| Search routing | `gemini-search.ts`, `index.ts` |
| Fetch fallback | `extract.ts` |
| Docs | `README.md`, `CHANGELOG.md` |
| Tests | `test/brightdata.test.mjs` |
| Housekeeping | `.gitignore` |

## Configuration

Set `brightdataApiKey` in `~/.pi/web-search.json` or `BRIGHTDATA_API_TOKEN`. Zones: `BRIGHTDATA_UNLOCKER_ZONE` (default `mcp_unlocker`, legacy `brightdataZone` accepted) and optional `BRIGHTDATA_SERP_ZONE` (falls back to the Unlocker zone). Like Brave/Tavily/Parallel, Bright Data requires an API key.

## Test plan

- [x] `node --test test/brightdata.test.mjs` — 8/8 pass
- [x] Explicit `provider: "brightdata"` returns SERP results
- [x] Auto-chain tries Bright Data after Perplexity, before Gemini
- [x] `fetch_content` uses the Web Unlocker after Jina when a key is present
- [x] Structured feeds route Amazon/Reddit/npm/PyPI URLs to dataset snapshots (per-feed input: `{url}` for most, `{package_name}` for npm/PyPI)
- [x] Missing key → silently skipped in auto; non-fatal fallthrough on error/timeout
- [x] Smoke-tested against the live Bright Data API (SERP, Unlocker, and a structured feed verified end-to-end)
- [x] Zero-config Exa/OpenAI default unchanged
