### PR TITLE
Improve startup time: Defer content extraction until first use

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { Box, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { StringEnum, complete, type Model } from "@earendil-works/pi-ai/compat";
-import { fetchAllContent, type ExtractedContent } from "./extract.ts";
+import type { ExtractedContent, ExtractOptions } from "./extract.ts";
 import { normalizeFetchContentParams } from "./fetch-params.ts";
 import { clearCloneCache } from "./github-extract.ts";
 import { search, type SearchProvider, type ResolvedSearchProvider } from "./gemini-search.ts";
@@ -46,6 +46,16 @@ import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } f
 import { loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 
 const WEB_SEARCH_CONFIG_PATH = getWebSearchConfigPath();
+
+let extractModulePromise: Promise<typeof import("./extract.ts")> | undefined;
+async function fetchAllContent(
+	urls: string[],
+	signal?: AbortSignal,
+	options?: ExtractOptions,
+): Promise<ExtractedContent[]> {
+	const extractModule = await (extractModulePromise ??= import("./extract.ts"));
+	return extractModule.fetchAllContent(urls, signal, options);
+}
 
 /** Shared collapsed/expanded renderer for an error/cancel plan produced by
  * buildSearchErrorPlan(). Used by every tool renderResult's error branch so

--- a/test/lazy-extract-load.test.mjs
+++ b/test/lazy-extract-load.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const indexUrl = new URL("../index.ts", import.meta.url).href;
+
+test("registers eagerly and loads content extraction on first use", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(indexUrl),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+		timeout: 30_000,
+	});
+
+	assert.equal(
+		child.status,
+		0,
+		"Lazy extraction regression child failed:\n" + errorSummary(child.stderr),
+	);
+});
+
+function buildChildScript(moduleUrl) {
+	return `
+		import assert from "node:assert/strict";
+		import { existsSync } from "node:fs";
+		import { mkdtemp, writeFile } from "node:fs/promises";
+		import { createServer } from "node:http";
+		import { register } from "node:module";
+		import { tmpdir } from "node:os";
+		import { join } from "node:path";
+
+		const tempDir = await mkdtemp(join(tmpdir(), "pi-web-access-lazy-"));
+		const markerPath = join(tempDir, "extract-loaded");
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		await writeFile(
+			join(tempDir, "web-search.json"),
+			JSON.stringify({ ssrf: { allowRanges: ["127.0.0.0/8"] } }),
+		);
+
+		const hookSource = \`
+			import { appendFileSync } from "node:fs";
+			let markerPath;
+			export function initialize(data) { markerPath = data.markerPath; }
+			export async function load(url, context, nextLoad) {
+				if (new URL(url).pathname.endsWith("/extract.ts")) {
+					appendFileSync(markerPath, url + "\\\\n");
+				}
+				return nextLoad(url, context);
+			}
+		\`;
+		register("data:text/javascript," + encodeURIComponent(hookSource), {
+			parentURL: import.meta.url,
+			data: { markerPath },
+		});
+
+		const { default: initializeExtension } = await import(${JSON.stringify(moduleUrl)});
+		assert.equal(existsSync(markerPath), false, "extract.ts loaded during extension import");
+
+		const tools = [];
+		const commands = [];
+		const shortcuts = [];
+		const events = [];
+		const pi = new Proxy({}, {
+			get(_target, property) {
+				if (property === "registerTool") return (tool) => tools.push(tool);
+				if (property === "registerCommand") return (name) => commands.push(name);
+				if (property === "registerShortcut") return (name) => shortcuts.push(name);
+				if (property === "on") return (name) => events.push(name);
+				return () => {};
+			},
+		});
+
+		initializeExtension(pi);
+		assert.deepEqual(
+			tools.map((tool) => tool.name),
+			["web_search", "fetch_content", "get_search_content"],
+		);
+		assert.ok(commands.includes("websearch"), "websearch command was not registered");
+		assert.ok(shortcuts.length > 0, "shortcuts were not registered");
+		assert.ok(events.includes("session_start"), "session handlers were not registered");
+		assert.equal(existsSync(markerPath), false, "extract.ts loaded during registration");
+
+		const articleText = "Lazy loading keeps extension startup responsive while preserving first-use extraction. ";
+		const html = \`<!doctype html><html><head><title>Lazy extraction</title></head><body>
+			<article><h1>Lazy extraction works</h1><p>\${articleText.repeat(20)}</p></article>
+		</body></html>\`;
+		const server = createServer((_request, response) => {
+			response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			response.end(html);
+		});
+		await new Promise((resolve, reject) => {
+			server.once("error", reject);
+			server.listen(0, "127.0.0.1", resolve);
+		});
+
+		try {
+			const address = server.address();
+			assert.ok(address && typeof address === "object");
+			const fetchTool = tools.find((tool) => tool.name === "fetch_content");
+			const result = await fetchTool.execute(
+				"lazy-load-regression",
+				{ url: \`http://127.0.0.1:\${address.port}/article\` },
+				undefined,
+				() => {},
+			);
+
+			assert.equal(existsSync(markerPath), true, "extract.ts did not load on first use");
+			assert.equal(result.details.successful, 1);
+			assert.match(result.content.at(-1).text, /preserving first-use extraction/);
+		} finally {
+			await new Promise((resolve) => server.close(resolve));
+		}
+	`;
+}
+
+function errorSummary(value, size = 2000) {
+	return value.length > size ? value.slice(-size) : value;
+}


### PR DESCRIPTION
## Change Brief

At the most basic level: this PR is a startup performance change, not a change to extraction behavior or tool availability.

## Summary

- Replaces the eager `extract.ts` runtime import with a memoized dynamic import.
- Keeps `web_search`, `fetch_content`, `get_search_content`, commands, shortcuts, and session handlers registered eagerly.
- Defers the Readability, LinkeDOM, Turndown, PDF, and video extraction graph until `fetch_content` or a background content fetch first needs it.
- Adds a regression test that observes module loading directly and exercises first-use HTML extraction against a local server.

## Why

Importing the extension eagerly loaded the full content-extraction dependency graph even when a session only needed search. Deferring that graph removes most of the extension's startup overhead while preserving the existing fetch path and sharing one import promise across concurrent first-use calls.

## Before / After

Before, loading the extension also loaded content extraction and its heavy transitive dependencies before tool registration completed.

After, registrations remain synchronous and immediately available. The extraction graph loads once, on the first direct or background content fetch, and then remains cached.

Measured isolated startup overhead:

| Environment | Before | After |
| --- | ---: | ---: |
| Current | 66 ms | 15 ms |
| Home | 77 ms | 16 ms |
| Direct import | ~65 ms | ~12 ms |

## Specific Changes

- **Startup path**: use type-only extraction imports and a memoized `import("./extract.ts")` wrapper.
- **Regression coverage**: verify eager registration without loading `extract.ts`, then invoke `fetch_content` and verify both module loading and extracted article content without timing assertions.

## Commit Notes

- `perf: lazy-load content extraction`
  - Why: avoid paying extraction-only initialization costs during every extension startup.
  - What changed: defer and memoize the extraction module import, with first-use integration coverage.
  - Implication: the first content fetch pays the module-load cost; later fetches reuse the loaded module.

## Testing

- `npm test` — 70 tests passed.
- Typecheck — no typecheck script or `tsconfig.json` is configured in the package.
