### PR TITLE
Fix web activity shortcut widget registration

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -499,7 +499,7 @@ function updateWidget(ctx: ExtensionContext): void {
 			(resetMs > 0 ? theme.fg("dim", ` (resets in ${resetSec}s)`) : ""),
 	);
 
-	ctx.ui.setWidget("web-activity", new Text(lines.join("\n"), 0, 0));
+	ctx.ui.setWidget("web-activity", () => new Text(lines.join("\n"), 0, 0));
 }
 
 function formatEntryLine(

--- a/test/tool-registration-config.test.mjs
+++ b/test/tool-registration-config.test.mjs
@@ -18,6 +18,17 @@ test("fetch tools remain registered outside the web_search gate", () => {
 	assert.match(indexSrc, /\n\t}\);\n\n\tpi\.registerTool\(\{\n\t\tname: "fetch_content"/);
 });
 
+test("web activity widget uses a supported component factory", () => {
+	assert.match(
+		indexSrc,
+		/ctx\.ui\.setWidget\("web-activity", \(\) => new Text\(lines\.join\("\\n"\), 0, 0\)\);/,
+	);
+	assert.doesNotMatch(
+		indexSrc,
+		/ctx\.ui\.setWidget\("web-activity", new Text/,
+	);
+});
+
 test("README documents webSearch.enabled", () => {
 	assert.match(readmeSrc, /"webSearch": \{\n    "enabled": true\n  \}/);
 	assert.match(readmeSrc, /webSearch\.enabled` to `false` to unregister the `web_search` tool/);


### PR DESCRIPTION
## Summary

Pass a component factory to `ctx.ui.setWidget` for the Ctrl+Shift+W web activity widget instead of passing a `Text` instance directly.

Pi's current widget API accepts either a string array or a component factory. Passing the component instance reaches the factory branch and throws `content is not a function`.

## Validation

- `node --test test/tool-registration-config.test.mjs`
- `npm test` — 70 tests passed
