### PR TITLE
fix: prevent pi crash when curator browser fails to open

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -964,6 +964,21 @@ export default function (pi: ExtensionAPI) {
 	async function openCuratorBrowser(callId: string, pc: PendingCurate, searchesComplete = true): Promise<void> {
 		if (pendingCurates.get(callId) !== pc) return;
 		let handle: CuratorServerHandle | null = null;
+		// Hoisted out of try so the catch path can call it (const in try is not visible in catch).
+		const sendCuratorFallbackUpdate = (message: string) => {
+			if (!handle) return;
+			pc.onUpdate?.({
+				content: [{ type: "text", text: `${message}\nOpen manually: ${handle.url}` }],
+				details: {
+					phase: "curator-fallback",
+					progress: searchesComplete ? 1 : 0.5,
+					curatorUrl: handle.url,
+					timeoutSeconds: pc.timeoutSeconds,
+					shortcut: curateKey,
+					browserOpenError: pc.browserOpenError,
+				},
+			});
+		};
 		try {
 			pc.phase = "curating";
 
@@ -1135,20 +1150,6 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 			if (searchesComplete) handle.searchesDone();
-
-			const sendCuratorFallbackUpdate = (message: string) => {
-				pc.onUpdate?.({
-					content: [{ type: "text", text: `${message}\nOpen manually: ${handle.url}` }],
-					details: {
-						phase: "curator-fallback",
-						progress: searchesComplete ? 1 : 0.5,
-						curatorUrl: handle.url,
-						timeoutSeconds: pc.timeoutSeconds,
-						shortcut: curateKey,
-						browserOpenError: pc.browserOpenError,
-					},
-				});
-			};
 
 			pc.onUpdate?.({
 				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],


### PR DESCRIPTION
## Summary

When `openInBrowser` / `xdg-open` fails (headless Linux, missing browser, no display, etc.), `openCuratorBrowser`'s recovery path currently throws a second error and **kills the entire pi process**:

```
ReferenceError: sendCuratorFallbackUpdate is not defined
    at openCuratorBrowser (index.ts:1188:9)
```

`sendCuratorFallbackUpdate` was declared with `const` **inside the `try` block**, but invoked from the sibling **`catch`**. `const` is block-scoped, so the catch path cannot see it.

This PR hoists the helper to function scope so a failed browser open degrades to the intended fallback message (manual curator URL) instead of an uncaught exception.

Fixes #103  
Fixes #116  
Fixes #126  
Fixes #127  

## Change

```diff
 async function openCuratorBrowser(...) {
   let handle = null;
+  const sendCuratorFallbackUpdate = (message) => {
+    if (!handle) return;
+    pc.onUpdate?.({ /* manual URL fallback */ });
+  };
   try {
-    const sendCuratorFallbackUpdate = (message) => { ... };
     await openInBrowser(pi, handle.url);
   } catch (err) {
     sendCuratorFallbackUpdate("..."); // now in scope
   }
 }
```

## Test plan

- [ ] On a machine where `xdg-open` cannot open a browser (or mock `openInBrowser` to throw), run `web_search` with default `summary-review` workflow
- [ ] Confirm pi **does not exit** with `uncaughtException`
- [ ] Confirm fallback update / manual curator URL is surfaced
- [ ] Confirm normal path still works when a browser is available
- [ ] Optional: temporary `throw new Error("boom")` after `activeCurators.set` still hits catch without `ReferenceError`

## Workaround (until merge)

```json
// ~/.pi/agent/web-search.json  (or ~/.pi/web-search.json)
{ "workflow": "none" }
```