### PR TITLE
Add SERPdive search provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added SERPdive search provider with request-time credential sources, a free-tier `krill` default that never spends on install, opt-in `mako`/`moby` retrieval depth, locally applied domain filters, and recency documented as a query hint rather than a guaranteed freshness filter. Thanks Eden d'Alexis (@edendalexis) for #139.
 - Added opt-in ordered search routing through `searchRouting.providers` with explicit transient, quota, and network fallback kinds; named providers remain strict, single-provider config retains precedence, and exhausted routes preserve per-provider diagnostics. Thanks @smithyyang for #77.
 - Added optional self-hosted SearXNG search with SSRF-guarded base URLs, local-first auto selection, result filters, and documented `ssrf.allowRanges` opt-ins. Thanks to Marcos A. Núñez (@marnunez) for PR #107 and Avinash Kanaujiya (@avinashkanaujiya) for issue #105.
 - Added optional self-hosted Firecrawl extraction for `fetch_content`, using `/v2/scrape` by default (or `/v1/scrape` for older images), request-time credential sources, cache-only requests by default, cross-origin redirect credential stripping, and local-first fallback behavior when configured. Thanks Florian Kinder (@fank) for PR #123 and Avinash Kanaujiya (@avinashkanaujiya) for issue #105.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Pi Web Access
 
-**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, Tavily, self-hosted SearXNG, optional browser-cookie Gemini Web, or bring your own API keys.**
+**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, Tavily, SERPdive, self-hosted SearXNG, optional browser-cookie Gemini Web, or bring your own API keys.**
 
 [![npm version](https://img.shields.io/npm/v/pi-web-access?style=for-the-badge)](https://www.npmjs.com/package/pi-web-access)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
@@ -14,11 +14,11 @@ https://github.com/user-attachments/assets/cac6a17a-1eeb-4dde-9818-cdf85d8ea98f
 
 ## Why Pi Web Access
 
-**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, or Gemini API for more control; configure a self-hosted SearXNG endpoint for private search; or opt into browser-cookie access for Gemini Web.
+**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, Tavily, SERPdive, Exa, Perplexity, or Gemini API for more control; configure a self-hosted SearXNG endpoint for private search; or opt into browser-cookie access for Gemini Web.
 
 **Video Understanding** — Point it at a YouTube video or local screen recording and ask questions about what's on screen. Full transcripts, visual descriptions, and frame extraction at exact timestamps.
 
-**Smart Fallbacks** — Every capability has a fallback chain. Search tries configured SearXNG first for local/private search, then OpenAI when suitable and available, Exa, Brave, Parallel, Tavily, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. With no SearXNG configured, the existing zero-config order is unchanged. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages try configured self-hosted Firecrawl first, then Jina Reader, Parallel, and Gemini extraction. Something always works.
+**Smart Fallbacks** — Every capability has a fallback chain. Search tries configured SearXNG first for local/private search, then OpenAI when suitable and available, Exa, Brave, Parallel, Tavily, SERPdive, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. With no SearXNG configured, the existing zero-config order is unchanged. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages try configured self-hosted Firecrawl first, then Jina Reader, Parallel, and Gemini extraction. Something always works.
 
 **GitHub Cloning** — GitHub URLs are cloned locally instead of scraped. The agent gets real file contents and a local path to explore, not rendered HTML.
 
@@ -40,7 +40,7 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
 }
 ```
 
-In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first for local/private search, then OpenAI when suitable and available, Exa (direct API if keyed, MCP if not), Brave, Parallel, Tavily, Perplexity, Gemini API, and Gemini Web when browser-cookie access is enabled. With no SearXNG configured, the existing zero-config order is unchanged. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
+In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first for local/private search, then OpenAI when suitable and available, Exa (direct API if keyed, MCP if not), Brave, Parallel, Tavily, SERPdive, Perplexity, Gemini API, and Gemini Web when browser-cookie access is enabled. With no SearXNG configured, the existing zero-config order is unchanged. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
 
 For sandboxed networks that provide outbound proxy transport through environment variables, set `ssrf.trustEnvProxy` to `true` to skip local DNS preflight for proxied hostnames:
 
@@ -88,7 +88,7 @@ fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on sc
 
 ### web_search
 
-Search the web via OpenAI, Brave, Parallel, Tavily, self-hosted SearXNG, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
+Search the web via OpenAI, Brave, Parallel, Tavily, SERPdive, self-hosted SearXNG, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
 
 ```typescript
 web_search({ query: "rust async programming" })
@@ -108,7 +108,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "auto-summary" })
 | `numResults` | Results per query (default: 5, max: 20) |
 | `recencyFilter` | `day`, `week`, `month`, or `year` |
 | `domainFilter` | Limit to domains (prefix with `-` to exclude) |
-| `provider` | Configured provider when omitted or set to `auto`; otherwise `openai`, `brave`, `parallel`, `tavily`, `searxng`, `exa`, `perplexity`, or `gemini` (auto-selects when no provider or routing is configured) |
+| `provider` | Configured provider when omitted or set to `auto`; otherwise `openai`, `brave`, `parallel`, `tavily`, `serpdive`, `searxng`, `exa`, `perplexity`, or `gemini` (auto-selects when no provider or routing is configured) |
 | `includeContent` | Fetch full page content from sources in background |
 | `workflow` | `none` (skip curator), `summary-review` (open curator and auto-generate a summary draft, default), or `auto-summary` (generate a summary without opening the curator) |
 
@@ -205,7 +205,7 @@ When Readability fails or returns only a cookie notice, the extension retries co
 
 ```
 web_search(query)
-  → SearXNG (if configured) → OpenAI (when suitable) → Exa → Brave → Parallel → Tavily → Perplexity → Gemini
+  → SearXNG (if configured) → OpenAI (when suitable) → Exa → Brave → Parallel → Tavily → SERPdive → Perplexity → Gemini
 
 fetch_content(url)
   → Video file?  Gemini API (Files API) → Gemini Web (if browser cookies enabled)
@@ -273,6 +273,8 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "exaApiKey": "exa-...",
   "parallelApiKey": "...",
   "tavilyApiKey": "tvly-...",
+  "serpdiveApiKey": "sd_live_...",
+  "serpdiveModel": "krill",
   "searxngBaseUrl": "https://search.example.com",
   "firecrawlBaseUrl": "https://crawl.example.com",
   "firecrawlApiKey": "fc-...",
@@ -322,7 +324,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
 }
 ```
 
-All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `tavilyApiKey`, `firecrawlApiKey`, `exaApiKey`, `perplexityApiKey`, `geminiApiKey`, and `cloudflareApiKey`) accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time. Escape `$$` as a literal leading `$` and `$!` as a literal leading `!`:
+All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `tavilyApiKey`, `serpdiveApiKey`, `firecrawlApiKey`, `exaApiKey`, `perplexityApiKey`, `geminiApiKey`, and `cloudflareApiKey`) accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time. Escape `$$` as a literal leading `$` and `$!` as a literal leading `!`:
 
 ```json
 {
@@ -341,7 +343,26 @@ Set `searxngBaseUrl` or `SEARXNG_BASE_URL` to use a self-hosted SearXNG JSON API
 
 Set `firecrawlBaseUrl` or `FIRECRAWL_BASE_URL` to use Firecrawl as an extraction-only fallback for `fetch_content`. It calls `/v2/scrape` by default; set `firecrawlApiVersion` or `FIRECRAWL_API_VERSION` to `v1` for older self-hosted images. Firecrawl requests are cache-only by default (`lockdown: true`), so the Firecrawl server does not make fresh outbound target requests unless you explicitly set `firecrawlFreshScrape: true` or `FIRECRAWL_FRESH_SCRAPE=1`. Enable fresh scraping only for a Firecrawl deployment whose own egress, redirects, DNS rebinding behavior, and internal-network access are isolated or allowlisted; this extension can preflight the submitted URL but cannot control network requests made by the Firecrawl server. The configured Firecrawl API base URL and redirects are still validated by the same SSRF guard as other remote requests, and Firecrawl credentials are stripped from cross-origin API redirects.
 
-Without an explicit `$` or `!` source, `OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `FIRECRAWL_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars retain their existing precedence over literal config file values. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` or `searchProvider` sets the default search provider and is used when a tool call omits `provider` or sends `"auto"`: `"openai"`, `"brave"`, `"parallel"`, `"tavily"`, `"searxng"`, `"exa"`, `"perplexity"`, or `"gemini"`. If either single-provider field is configured, it takes precedence over `searchRouting`. Otherwise, `searchRouting` can opt into an ordered `providers` list and an explicit `fallbackOn` list containing `"transient"`, `"quota"`, and/or `"network"`; only those typed failures continue to the next available candidate. Named providers remain strict, and exhausted routes return per-provider diagnostics. Random, weighted, sticky, and cooldown routing are not enabled. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the configured search and source-check tools while leaving fetch/content tools available. `toolNames` can opt into alternate public tool names for environments where another extension or model reserves the defaults, without changing behavior: `webSearch`, `sourceCheck`, `fetchContent`, and `getSearchContent` default to `web_search`, `source_check`, `fetch_content`, and `get_search_content`. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on the configured search tool, or toggled at runtime with `/curator`. `chromeProfile` pins Gemini Web cookie lookup to a specific Chromium profile. When omitted, detected Chromium profiles are scanned in stable order and the first profile containing the required Gemini cookies is used. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid browser data access and surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. Cookie databases are copied to a temporary read-only working copy; the reader uses `node:sqlite` when available and otherwise tries the `sqlite3` CLI or Python's standard-library SQLite module. `searchModel` overrides the Gemini API model used by the configured search tool without changing URL, YouTube, or video extraction defaults. Gemini API grounded search uses `gemini-2.5-flash` by default; set `searchModel` to choose another model. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected. `ssrf.trustEnvProxy` is a separate opt-in for sandboxed environments with valid HTTP(S) proxy env vars; it skips local DNS preflight only for proxied hostnames and still blocks localhost, literal private IPs, and `NO_PROXY` matches. It does not configure proxy transport.
+Without an explicit `$` or `!` source, `OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `SERPDIVE_API_KEY`, `FIRECRAWL_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars retain their existing precedence over literal config file values. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` or `searchProvider` sets the default search provider and is used when a tool call omits `provider` or sends `"auto"`: `"openai"`, `"brave"`, `"parallel"`, `"tavily"`, `"serpdive"`, `"searxng"`, `"exa"`, `"perplexity"`, or `"gemini"`. If either single-provider field is configured, it takes precedence over `searchRouting`. Otherwise, `searchRouting` can opt into an ordered `providers` list and an explicit `fallbackOn` list containing `"transient"`, `"quota"`, and/or `"network"`; only those typed failures continue to the next available candidate. Named providers remain strict, and exhausted routes return per-provider diagnostics. Random, weighted, sticky, and cooldown routing are not enabled. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the configured search and source-check tools while leaving fetch/content tools available. `toolNames` can opt into alternate public tool names for environments where another extension or model reserves the defaults, without changing behavior: `webSearch`, `sourceCheck`, `fetchContent`, and `getSearchContent` default to `web_search`, `source_check`, `fetch_content`, and `get_search_content`. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on the configured search tool, or toggled at runtime with `/curator`. `chromeProfile` pins Gemini Web cookie lookup to a specific Chromium profile. When omitted, detected Chromium profiles are scanned in stable order and the first profile containing the required Gemini cookies is used. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid browser data access and surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. Cookie databases are copied to a temporary read-only working copy; the reader uses `node:sqlite` when available and otherwise tries the `sqlite3` CLI or Python's standard-library SQLite module. `searchModel` overrides the Gemini API model used by the configured search tool without changing URL, YouTube, or video extraction defaults. Gemini API grounded search uses `gemini-2.5-flash` by default; set `searchModel` to choose another model. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected. `ssrf.trustEnvProxy` is a separate opt-in for sandboxed environments with valid HTTP(S) proxy env vars; it skips local DNS preflight only for proxied hostnames and still blocks localhost, literal private IPs, and `NO_PROXY` matches. It does not configure proxy transport.
+
+### SERPdive
+
+`serpdiveApiKey` enables the SERPdive provider; get a key at [serpdive.com](https://serpdive.com/dashboard/keys). `serpdiveModel` (or `SERPDIVE_MODEL`) picks the retrieval depth:
+
+| Model | Cost | What comes back |
+| --- | --- | --- |
+| `krill` (default) | free, fair use | Extracted page content. No API-side answer synthesis — the answer is assembled from the sources, as for Brave and SearXNG. |
+| `mako` | 1 credit | The fact-carrying sentences of each page, plus a synthesized answer. |
+| `moby` | 1.5 credits | The full readable content of every page, plus a cited answer. |
+
+The model is the only thing that decides retrieval depth: `includeContent` controls whether that content is also returned inline, it never changes the model. For full page text, set `serpdiveModel` to `moby` yourself. The default is the free tier on purpose: installing this provider never starts spending on your behalf. An unrecognised value falls back to `krill` rather than failing, so a typo cannot cost money. Current pricing: [serpdive.com/pricing](https://serpdive.com/pricing).
+
+Two behaviours worth knowing, both consequences of the API surface:
+
+- **Recency is a hint, not a filter.** SERPdive exposes no time-range parameter. `recencyFilter` is appended to the question ("past week"), which biases ranking toward recent pages; results outside the window can still come back.
+- **Domain filters are applied locally.** SERPdive has no include/exclude domain parameter, so `domainFilter` is applied to the results that come back. It can narrow a page of results, not ask the engine for more from a given domain.
+
+`numResults` maps to `max_results`, which the API treats as a cap between 1 and 10 — never a minimum. Values above 10 are clamped; the engine returns what it judges relevant, which is often fewer.
 
 ### Shortcuts
 
@@ -385,10 +406,11 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Content f
 | `brave.ts` | Brave Search API provider |
 | `parallel.ts` | Parallel search provider and extraction fallback |
 | `tavily.ts` | Tavily Search API provider |
+| `serpdive.ts` | SERPdive Search API provider |
 | `searxng.ts` | Self-hosted SearXNG JSON API search provider |
 | `exa.ts` | Exa.ai search provider — direct API and MCP proxy |
 | `extract.ts` | URL/file path routing, HTTP extraction, fallback orchestration |
-| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, Tavily, Exa, Perplexity, Gemini API, Gemini Web |
+| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, Tavily, SERPdive, Exa, Perplexity, Gemini API, Gemini Web |
 | `gemini-url-context.ts` | Gemini URL Context + Web extraction fallbacks |
 | `gemini-web.ts` | Gemini Web client (cookie auth, StreamGenerate) |
 | `gemini-web-config.ts` | Gemini Web profile and browser-cookie opt-in config |

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -8,7 +8,7 @@ function safeInlineJSON(data: unknown): string {
 }
 
 function buildProviderButtons(
-	available: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	available: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
 	selected: string,
 	hasInitialQueries: boolean,
 ): string {
@@ -18,6 +18,7 @@ function buildProviderButtons(
 		{ value: "brave", label: "Brave", available: available.brave },
 		{ value: "parallel", label: "Parallel", available: available.parallel },
 		{ value: "tavily", label: "Tavily", available: available.tavily },
+		{ value: "serpdive", label: "SERPdive", available: available.serpdive },
 		{ value: "searxng", label: "SearXNG", available: available.searxng },
 		{ value: "perplexity", label: "Perplexity", available: available.perplexity },
 		{ value: "gemini", label: "Gemini", available: available.gemini },
@@ -39,7 +40,7 @@ export function generateCuratorPage(
 	queries: string[],
 	sessionToken: string,
 	timeout: number,
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean },
 	defaultProvider: string,
 	searchProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
@@ -666,6 +667,11 @@ main {
   color: #a6e3a1;
   background: rgba(166, 227, 161, 0.14);
   border-color: rgba(166, 227, 161, 0.3);
+}
+.provider-tag.provider-serpdive {
+  color: #94e2d5;
+  background: rgba(148, 226, 213, 0.14);
+  border-color: rgba(148, 226, 213, 0.3);
 }
 .provider-tag.provider-unknown {
   color: var(--fg-muted);
@@ -1390,7 +1396,7 @@ const SCRIPT = `(function() {
   var token = DATA.sessionToken;
   var timeoutSec = DATA.timeout;
   var queries = Array.isArray(DATA.queries) ? DATA.queries : [];
-  var providers = ["openai", "exa", "brave", "parallel", "tavily", "searxng", "perplexity", "gemini"];
+  var providers = ["openai", "exa", "brave", "parallel", "tavily", "serpdive", "searxng", "perplexity", "gemini"];
   var availProviders = DATA.availableProviders && typeof DATA.availableProviders === "object" ? DATA.availableProviders : {};
   var workflow = "summary-review";
   var initialDefaultProvider = typeof DATA.defaultProvider === "string" ? DATA.defaultProvider : "exa";
@@ -1594,6 +1600,7 @@ const SCRIPT = `(function() {
     if (provider === "brave") return "Brave";
     if (provider === "parallel") return "Parallel";
     if (provider === "tavily") return "Tavily";
+    if (provider === "serpdive") return "SERPdive";
     if (provider === "searxng") return "SearXNG";
     if (provider === "perplexity") return "Perplexity";
     if (provider === "exa") return "Exa";

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -12,7 +12,7 @@ export interface CuratorServerOptions {
 	queries: string[];
 	sessionToken: string;
 	timeout: number;
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean };
 	defaultProvider: string;
 	searchProvider: string;
 	summaryModels: Array<{ value: string; label: string }>;
@@ -253,6 +253,7 @@ export function startCuratorServer(
 		if (provider === "brave") return availableProviders.brave;
 		if (provider === "parallel") return availableProviders.parallel;
 		if (provider === "tavily") return availableProviders.tavily;
+		if (provider === "serpdive") return availableProviders.serpdive;
 		if (provider === "searxng") return availableProviders.searxng;
 		if (provider === "perplexity") return availableProviders.perplexity;
 		if (provider === "exa") return availableProviders.exa;

--- a/evidence/CONTRACT-EVIDENCE.md
+++ b/evidence/CONTRACT-EVIDENCE.md
@@ -1,0 +1,496 @@
+# SERPdive API — contract evidence
+
+Every block below is a real call against `https://api.serpdive.com/v1/search`, captured on 2026-07-25. Reproduce any of them with your own key: the script that
+generated this file is `evidence/contract-probe.mjs`. Page content is truncated to keep the file
+readable — nothing else is edited, and the API key is redacted.
+
+---
+
+## 1. Default request and response shape
+
+### Query only
+
+The whole request surface is `query`, `model`, `answer`, `max_results`. Everything else is ignored.
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases"}
+```
+
+`HTTP 200` in 2059 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "mako",
+  "response_time_ms": 1906,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (431 chars)"
+    },
+    {
+      "url": "https://redis.io/blog/best-open-source-vector-databases-comparison/",
+      "title": "Comparing the best open source vector databases (2026)",
+      "content": "Chroma prioritizes simplicity and developer experience, particularly for Python workflows.… (90 chars)"
+    },
+    "… 5 more, same shape"
+  ]
+}
+```
+
+## 2. Models
+
+### krill — free tier
+
+No answer synthesis on this tier: requesting one is ignored rather than refused (see §3).
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"krill"}
+```
+
+`HTTP 200` in 2145 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "krill",
+  "response_time_ms": 2113,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (213 chars)"
+    },
+    {
+      "url": "https://redis.io/blog/best-open-source-vector-databases-comparison/",
+      "title": "Comparing the best open source vector databases (2026)",
+      "content": "This comparison breaks down the leading open source vector databases for production AI wor… (190 chars)"
+    },
+    "… 3 more, same shape"
+  ]
+}
+```
+
+### mako — 1 credit
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"mako"}
+```
+
+`HTTP 200` in 1976 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "mako",
+  "response_time_ms": 1941,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (713 chars)"
+    },
+    {
+      "url": "https://redis.io/blog/best-open-source-vector-databases-comparison/",
+      "title": "Comparing the best open source vector databases (2026)",
+      "content": "This comparison breaks down the leading open source vector databases for production AI wor… (457 chars)"
+    },
+    "… 3 more, same shape"
+  ]
+}
+```
+
+### moby — 1.5 credits
+
+Full readable page content; note the content lengths against mako above.
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"moby"}
+```
+
+`HTTP 200` in 2647 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "moby",
+  "response_time_ms": 2561,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (14041 chars)"
+    },
+    {
+      "url": "https://redis.io/blog/best-open-source-vector-databases-comparison/",
+      "title": "Comparing the best open source vector databases (2026)",
+      "content": "Serve your agents fresh data at Redis speed.\nComparing the best open source vector databas… (13856 chars)"
+    },
+    "… 4 more, same shape"
+  ]
+}
+```
+
+## 3. `answer`
+
+### answer: true with mako
+
+The `answer` key is present only when requested.
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"mako","answer":true}
+```
+
+`HTTP 200` in 2490 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "mako",
+  "response_time_ms": 2456,
+  "answer": "The best open source vector databases are: \n1. Opensearch \n2. Apache Cassandra \n3. pgvector \n4. Milvus \n5. Qdrant \n6. Weaviate \n7. Vald.… (136 chars)",
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (529 chars)"
+    },
+    {
+      "url": "https://redis.io/blog/best-open-source-vector-databases-comparison/",
+      "title": "Comparing the best open source vector databases (2026)",
+      "content": "This comparison breaks down the leading open source vector databases for production AI wor… (591 chars)"
+    },
+    "… 3 more, same shape"
+  ]
+}
+```
+
+### answer: true with krill
+
+Silently ignored on the free tier — no `answer` key, no error, still a complete result.
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"krill","answer":true}
+```
+
+`HTTP 200` in 1642 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "krill",
+  "response_time_ms": 1612,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (322 chars)"
+    },
+    {
+      "url": "https://redis.io/blog/best-open-source-vector-databases-comparison/",
+      "title": "Comparing the best open source vector databases (2026)",
+      "content": "This comparison breaks down the leading open source vector databases for production AI wor… (293 chars)"
+    },
+    "… 2 more, same shape"
+  ]
+}
+```
+
+## 4. `max_results` is a cap, never a minimum
+
+A cap, applied at the edge after the search. The engine still reads a full corpus, so a small
+cap trims the response, not the work — and asking for more does not produce more.
+
+### max_results: 1
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"krill","max_results":1}
+```
+
+`HTTP 200` in 1697 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "krill",
+  "response_time_ms": 1665,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (213 chars)"
+    }
+  ]
+}
+```
+
+### max_results: 3
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"krill","max_results":3}
+```
+
+`HTTP 200` in 1725 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "krill",
+  "response_time_ms": 1681,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (634 chars)"
+    },
+    {
+      "url": "https://redis.io/blog/best-open-source-vector-databases-comparison/",
+      "title": "Comparing the best open source vector databases (2026)",
+      "content": "Some vector databases work best with Kubernetes orchestration, while others offer cloud-ho… (182 chars)"
+    },
+    "… 1 more, same shape"
+  ]
+}
+```
+
+### max_results: 10
+
+The ceiling of the range. Fewer come back when fewer are judged relevant — see §1, where no cap returned 5.
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"krill","max_results":10}
+```
+
+`HTTP 200` in 1706 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "krill",
+  "response_time_ms": 1676,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (502 chars)"
+    },
+    {
+      "url": "https://redis.io/blog/best-open-source-vector-databases-comparison/",
+      "title": "Comparing the best open source vector databases (2026)",
+      "content": "This comparison breaks down the leading open source vector databases for production AI wor… (97 chars)"
+    },
+    "… 5 more, same shape"
+  ]
+}
+```
+
+### max_results: 50
+
+Above the range: clamped down to 10, silently. Never a 400.
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"krill","max_results":50}
+```
+
+`HTTP 200` in 1820 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "krill",
+  "response_time_ms": 1788,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (213 chars)"
+    },
+    {
+      "url": "https://redis.io/blog/best-open-source-vector-databases-comparison/",
+      "title": "Comparing the best open source vector databases (2026)",
+      "content": "This comparison breaks down the leading open source vector databases for production AI wor… (247 chars)"
+    },
+    "… 3 more, same shape"
+  ]
+}
+```
+
+### max_results: 0
+
+Below the range: clamped UP to 1, silently — it is the minimum of the range, NOT a way to say "no cap". One result comes back.
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"krill","max_results":0}
+```
+
+`HTTP 200` in 1845 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "krill",
+  "response_time_ms": 1800,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (322 chars)"
+    }
+  ]
+}
+```
+
+### max_results: "abc"
+
+Unparseable, and this is the asymmetry worth knowing: an out-of-range NUMBER is clamped into the range, but a value that is not a number at all drops the cap entirely and the default applies. Same for null or an absent field.
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"krill","max_results":"abc"}
+```
+
+`HTTP 200` in 2096 ms
+
+```json
+{
+  "query": "best open source vector databases",
+  "model": "krill",
+  "response_time_ms": 2014,
+  "results": [
+    {
+      "url": "https://www.instaclustr.com/education/vector-database/best-open-source-vector-database-solutions-top-5-in-2026/",
+      "title": "Best open source vector database solutions: Top 5 in 2026",
+      "content": "Notable open source vector database solutions · 1. Opensearch · 2. Apache Cassandra · 3. p… (520 chars)"
+    },
+    {
+      "url": "https://medium.com/@pratik-rupareliya/top-15-vector-databases-in-2026-a-production-decision-guide-from-100-enterprise-deployments-dd58a04f51a5",
+      "title": "Medium",
+      "content": "Top 15 vector databases in 2026: A production decision guide from 100+ enterprise deployme… (408 chars)"
+    },
+    "… 4 more, same shape"
+  ]
+}
+```
+
+## 5. Errors
+
+### Missing query
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"model":"krill"}
+```
+
+`HTTP 400` in 39 ms
+
+```json
+{
+  "error": "missing_query",
+  "message": "The \"query\" field is required, e.g. {\"query\": \"your search\"}."
+}
+```
+
+### Invalid key
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_not_a_real_key
+content-type: application/json
+
+{"query":"best open source vector databases"}
+```
+
+`HTTP 401` in 533 ms
+
+```json
+{
+  "error": "invalid_api_key",
+  "message": "This API key is invalid or was revoked. Manage your keys at https://serpdive.com/dashboard/keys"
+}
+```
+
+### No key at all
+
+```http
+POST https://api.serpdive.com/v1/search
+(no authorization header sent)
+content-type: application/json
+
+{"query":"best open source vector databases"}
+```
+
+`HTTP 401` in 27 ms
+
+```json
+{
+  "error": "missing_api_key",
+  "message": "No API key. Send it as \"Authorization: Bearer sd_live_…\" — create one at https://serpdive.com/dashboard/keys"
+}
+```
+
+## 6. Abort
+
+### Client aborts mid-flight
+
+The request is cancellable at any point; the provider maps this to the framework abort path.
+
+```http
+POST https://api.serpdive.com/v1/search
+authorization: Bearer sd_live_…            # a valid key, redacted
+content-type: application/json
+
+{"query":"best open source vector databases","model":"krill"}
+```
+
+Client aborted after 300 ms → `AbortError` raised locally; no response body.

--- a/evidence/contract-probe.mjs
+++ b/evidence/contract-probe.mjs
@@ -1,0 +1,140 @@
+// Regenerates evidence/CONTRACT-EVIDENCE.md from REAL calls against the
+// SERPdive API. Run it with your own key to reproduce the file:
+//
+//   SERPDIVE_API_KEY=sd_live_… node evidence/contract-probe.mjs
+//
+// The key is read from the environment and never written to the output —
+// the script asserts that before exiting.
+import fs from 'node:fs';
+
+const KEY = process.env.SERPDIVE_API_KEY;
+if (!KEY) {
+  console.error('SERPDIVE_API_KEY is not set. Get a key at https://serpdive.com/dashboard/keys');
+  process.exit(1);
+}
+const URL = 'https://api.serpdive.com/v1/search';
+const out = [];
+const say = (s = '') => out.push(s);
+
+async function call(body, { key = KEY, abortAfterMs = null } = {}) {
+  const ctrl = new AbortController();
+  if (abortAfterMs) setTimeout(() => ctrl.abort(), abortAfterMs);
+  const t0 = Date.now();
+  try {
+    const res = await fetch(URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...(key ? { authorization: `Bearer ${key}` } : {}) },
+      body: JSON.stringify(body),
+      signal: ctrl.signal,
+    });
+    const json = await res.json().catch(() => null);
+    return { status: res.status, ms: Date.now() - t0, json };
+  } catch (err) {
+    return { status: null, ms: Date.now() - t0, aborted: err.name === 'AbortError', err: err.name };
+  }
+}
+
+// Reduce a response to its SHAPE: keep the structure, truncate the content.
+function shape(j) {
+  if (!j) return null;
+  const c = JSON.parse(JSON.stringify(j));
+  if (Array.isArray(c.results)) {
+    c.results = c.results.slice(0, 2).map((r) => ({
+      ...r,
+      content: typeof r.content === 'string' ? `${r.content.slice(0, 90)}… (${r.content.length} chars)` : r.content,
+    }));
+    if (j.results.length > 2) c.results.push(`… ${j.results.length - 2} more, same shape`);
+  }
+  if (typeof c.answer === 'string') c.answer = `${c.answer.slice(0, 160)}… (${j.answer.length} chars)`;
+  return c;
+}
+
+async function section(title, note, body, opts = {}) {
+  const r = await call(body, opts);
+  const keyLine = !('key' in opts)
+    ? 'authorization: Bearer sd_live_…            # a valid key, redacted'
+    : opts.key === null
+      ? '(no authorization header sent)'
+      : `authorization: Bearer ${opts.key}`;
+  say(`### ${title}`);
+  say();
+  if (note) { say(note); say(); }
+  say('```http');
+  say('POST https://api.serpdive.com/v1/search');
+  say(keyLine);
+  say('content-type: application/json');
+  say();
+  say(JSON.stringify(body));
+  say('```');
+  say();
+  if (r.aborted) {
+    say(`Client aborted after ${opts.abortAfterMs} ms → \`${r.err}\` raised locally; no response body.`);
+  } else {
+    say(`\`HTTP ${r.status}\` in ${r.ms} ms`);
+    say();
+    say('```json');
+    say(JSON.stringify(shape(r.json), null, 2));
+    say('```');
+  }
+  say();
+  return r;
+}
+
+const Q = 'best open source vector databases';
+
+say('# SERPdive API — contract evidence');
+say();
+say('Every block below is a real call against `https://api.serpdive.com/v1/search`, captured on '
+  + new Date().toISOString().slice(0, 10) + '. Reproduce any of them with your own key: the script that');
+say('generated this file is `evidence/contract-probe.mjs`. Page content is truncated to keep the file');
+say('readable — nothing else is edited, and the API key is redacted.');
+say();
+say('---');
+say();
+say('## 1. Default request and response shape');
+say();
+await section('Query only', 'The whole request surface is `query`, `model`, `answer`, `max_results`. Everything else is ignored.', { query: Q });
+
+say('## 2. Models');
+say();
+await section('krill — free tier', 'No answer synthesis on this tier: requesting one is ignored rather than refused (see §3).', { query: Q, model: 'krill' });
+await section('mako — 1 credit', null, { query: Q, model: 'mako' });
+await section('moby — 1.5 credits', 'Full readable page content; note the content lengths against mako above.', { query: Q, model: 'moby' });
+
+say('## 3. `answer`');
+say();
+await section('answer: true with mako', 'The `answer` key is present only when requested.', { query: Q, model: 'mako', answer: true });
+await section('answer: true with krill', 'Silently ignored on the free tier — no `answer` key, no error, still a complete result.', { query: Q, model: 'krill', answer: true });
+
+say('## 4. `max_results` is a cap, never a minimum');
+say();
+say('A cap, applied at the edge after the search. The engine still reads a full corpus, so a small');
+say('cap trims the response, not the work — and asking for more does not produce more.');
+say();
+for (const [n, note] of [
+  [1, null],
+  [3, null],
+  [10, 'The ceiling of the range. Fewer come back when fewer are judged relevant — see §1, where no cap returned 5.'],
+  [50, 'Above the range: clamped down to 10, silently. Never a 400.'],
+  [0, 'Below the range: clamped UP to 1, silently — it is the minimum of the range, NOT a way to say "no cap". One result comes back.'],
+  ['abc', 'Unparseable, and this is the asymmetry worth knowing: an out-of-range NUMBER is clamped into the range, but a value that is not a number at all drops the cap entirely and the default applies. Same for null or an absent field.'],
+]) {
+  await section(`max_results: ${JSON.stringify(n)}`, note, { query: Q, model: 'krill', max_results: n });
+}
+
+say('## 5. Errors');
+say();
+await section('Missing query', null, { model: 'krill' });
+await section('Invalid key', null, { query: Q }, { key: 'sd_live_not_a_real_key' });
+await section('No key at all', null, { query: Q }, { key: null });
+
+say('## 6. Abort');
+say();
+await section('Client aborts mid-flight', 'The request is cancellable at any point; the provider maps this to the framework abort path.', { query: Q, model: 'krill' }, { abortAfterMs: 300 });
+
+const path = new URL('./CONTRACT-EVIDENCE.md', import.meta.url).pathname;
+fs.writeFileSync(path, out.join('\n'));
+console.log(`written: ${path}`);
+console.log(`${out.join('\n').length} characters`);
+if (out.join('\n').includes(KEY)) console.error('!! THE API KEY APPEARS IN THE OUTPUT — not written');
+else console.log('verified: the key appears nowhere in the output');

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -10,10 +10,11 @@ import { isBraveAvailable, searchWithBrave } from "./brave.ts";
 import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
 import { isParallelAvailable, searchWithParallel } from "./parallel.ts";
 import { isTavilyAvailable, searchWithTavily } from "./tavily.ts";
+import { isSerpdiveAvailable, searchWithSerpdive } from "./serpdive.ts";
 import { isSearXNGAvailable, searchWithSearXNG } from "./searxng.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "searxng" | "perplexity" | "gemini" | "exa";
+export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "searxng" | "perplexity" | "gemini" | "exa" | "serpdive";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
 export type SearchProviderErrorKind =
 	| "transient"
@@ -261,6 +262,7 @@ async function searchWithResolvedProvider(
 	if (provider === "brave") return { ...(await searchWithBrave(query, options)), provider };
 	if (provider === "parallel") return { ...(await searchWithParallel(query, options)), provider };
 	if (provider === "tavily") return { ...(await searchWithTavily(query, options)), provider };
+	if (provider === "serpdive") return { ...(await searchWithSerpdive(query, options)), provider };
 	if (provider === "perplexity") return { ...(await searchWithPerplexity(query, options)), provider };
 	if (provider === "searxng") return { ...(await searchWithSearXNG(query, options)), provider };
 	if (provider === "gemini") {
@@ -384,6 +386,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		} catch (err) {
 			if (isAbortError(err)) throw err;
 			fallbackErrors.push(`Tavily: ${errorMessage(err)}`);
+		}
+	}
+
+	if (isSerpdiveAvailable()) {
+		try {
+			const result = await searchWithSerpdive(query, options);
+			return { ...result, provider: "serpdive" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`SERPdive: ${errorMessage(err)}`);
 		}
 	}
 

--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,7 @@ import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
 import { isParallelAvailable } from "./parallel.ts";
 import { isTavilyAvailable } from "./tavily.ts";
+import { isSerpdiveAvailable } from "./serpdive.ts";
 import { isSearXNGAvailable } from "./searxng.ts";
 import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
 import { loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
@@ -114,6 +115,7 @@ interface ProviderAvailability {
 	brave: boolean;
 	parallel: boolean;
 	tavily: boolean;
+	serpdive: boolean;
 	searxng: boolean;
 	perplexity: boolean;
 	exa: boolean;
@@ -221,7 +223,7 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini", "serpdive"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -269,6 +271,7 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 		brave: isBraveAvailable(),
 		parallel: isParallelAvailable(),
 		tavily: isTavilyAvailable(),
+		serpdive: isSerpdiveAvailable(),
 		searxng: isSearXNGAvailable(),
 		perplexity: isPerplexityAvailable(),
 		exa: isExaAvailable(),
@@ -305,6 +308,7 @@ function firstAvailableProvider(available: ProviderAvailability, preferOpenAI: b
 	if (available.brave) return "brave";
 	if (available.parallel) return "parallel";
 	if (available.tavily) return "tavily";
+	if (available.serpdive) return "serpdive";
 	if (available.perplexity) return "perplexity";
 	if (available.gemini) return "gemini";
 	return fallback;
@@ -339,6 +343,9 @@ function resolveProvider(
 	}
 	if (provider === "tavily" && !available.tavily) {
 		return firstAvailableProvider(available, preferOpenAI, "tavily");
+	}
+	if (provider === "serpdive" && !available.serpdive) {
+		return firstAvailableProvider(available, preferOpenAI, "serpdive");
 	}
 	if (provider === "searxng" && !available.searxng) {
 		return firstAvailableProvider(available, preferOpenAI, "searxng");
@@ -1378,7 +1385,7 @@ export default function (pi: ExtensionAPI) {
 			),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
 			provider: Type.Optional(
-				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini"], { description: "Search provider; omit this field (preferred) to use the configured provider, or use auto when none is configured" }),
+				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini", "serpdive"], { description: "Search provider; omit this field (preferred) to use the configured provider, or use auto when none is configured" }),
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review", "auto-summary"], {
@@ -1923,7 +1930,7 @@ export default function (pi: ExtensionAPI) {
 			fetchContent: Type.Optional(Type.Boolean({ description: "Fetch up to 5 result pages for exact passage extraction." })),
 			recencyFilter: Type.Optional(StringEnum(["day", "week", "month", "year"], { description: "Filter by recency." })),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains; prefix with - to exclude." })),
-			provider: Type.Optional(StringEnum(["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini"], { description: "Search provider." })),
+			provider: Type.Optional(StringEnum(["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini", "serpdive"], { description: "Search provider." })),
 		}),
 		async execute(_callId, params, signal, _onUpdate, ctx) {
 			const claim = typeof params.claim === "string" ? params.claim.trim() : "";

--- a/serpdive.ts
+++ b/serpdive.ts
@@ -1,0 +1,297 @@
+import { existsSync, readFileSync } from "node:fs";
+import { activityMonitor } from "./activity.ts";
+import type { ExtractedContent } from "./extract.ts";
+import type { SearchOptions, SearchResponse } from "./perplexity.ts";
+import { hasCredentialSource, redactCredential, resolveCredential } from "./credential-source.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const SERPDIVE_API_URL = "https://api.serpdive.com/v1/search";
+const CONFIG_PATH = getWebSearchConfigPath();
+const SEARCH_TIMEOUT_MS = 60_000;
+
+// Retrieval depth. The default is deliberately the free tier: this provider
+// ships inside someone else's framework, and installing it must never start
+// spending on a user's behalf without them choosing it.
+//   krill — free, fair use, no synthesized answer (see buildAnswer below)
+//   mako  — the fact-carrying sentences of each page, 1 credit
+//   moby  — the full readable content of every page, 1.5 credits
+// Pricing: https://serpdive.com/pricing
+const MODELS = ["krill", "mako", "moby"] as const;
+type SerpdiveModel = (typeof MODELS)[number];
+const DEFAULT_MODEL: SerpdiveModel = "krill";
+
+interface WebSearchConfig {
+	serpdiveApiKey?: unknown;
+	serpdiveModel?: unknown;
+}
+
+interface SerpdiveResult {
+	url?: string;
+	title?: string | null;
+	date?: string;
+	content?: string;
+}
+
+interface SerpdiveResponse {
+	query?: string;
+	model?: string;
+	answer?: string | null;
+	results?: SerpdiveResult[];
+}
+
+interface SerpdiveSearchOptions extends SearchOptions {
+	includeContent?: boolean;
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+async function getApiKey(signal?: AbortSignal): Promise<string | null> {
+	return resolveCredential({
+		provider: "SERPdive",
+		configuredValue: loadConfig().serpdiveApiKey,
+		environmentValue: process.env.SERPDIVE_API_KEY,
+		signal,
+	});
+}
+
+async function requireApiKey(signal?: AbortSignal): Promise<string> {
+	const apiKey = await getApiKey(signal);
+	if (!apiKey) {
+		throw new Error(
+			"SERPdive API key not found. Either:\n" +
+			`  1. Create ${CONFIG_PATH} with { "serpdiveApiKey": "your-key" }\n` +
+			"  2. Set SERPDIVE_API_KEY environment variable\n" +
+			"Get a key at https://serpdive.com/dashboard/keys",
+		);
+	}
+	return apiKey;
+}
+
+// An unknown value falls back to the free default rather than failing: a typo
+// in a config file must not cost the user money, and must not break search.
+function resolveModel(): SerpdiveModel {
+	const raw = process.env.SERPDIVE_MODEL ?? loadConfig().serpdiveModel;
+	if (typeof raw !== "string") return DEFAULT_MODEL;
+	const value = raw.trim().toLowerCase();
+	return (MODELS as readonly string[]).includes(value) ? value as SerpdiveModel : DEFAULT_MODEL;
+}
+
+function normalizeCount(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 5;
+	return Math.max(1, Math.min(Math.floor(value), 20));
+}
+
+function normalizeDomain(value: string): string | null {
+	let input = value.trim().toLowerCase();
+	if (!input) return null;
+	if (input.startsWith("-")) input = input.slice(1).trim();
+	if (!input) return null;
+	try {
+		const parsed = input.includes("://") ? new URL(input) : new URL(`https://${input}`);
+		input = parsed.hostname;
+	} catch {
+		input = input.split("/")[0]?.split(":")[0] ?? "";
+	}
+	input = input.replace(/^\.+|\.+$/g, "");
+	return /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(input) ? input : null;
+}
+
+interface DomainFilters {
+	include: string[];
+	exclude: string[];
+}
+
+function parseDomainFilter(domainFilter: string[] | undefined): DomainFilters {
+	const filters: DomainFilters = { include: [], exclude: [] };
+	if (!domainFilter?.length) return filters;
+	for (const raw of domainFilter) {
+		const domain = normalizeDomain(raw);
+		if (!domain) continue;
+		const target = raw.trim().startsWith("-") ? filters.exclude : filters.include;
+		if (!target.includes(domain)) target.push(domain);
+	}
+	return filters;
+}
+
+function domainMatches(hostname: string, domain: string): boolean {
+	return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+// SERPdive exposes no include/exclude domain parameter, so the filter is applied
+// here, on what came back. It can therefore only ever narrow a page of results —
+// it cannot ask the engine for more pages from a given domain.
+function passesDomainFilters(url: string, filters: DomainFilters): boolean {
+	if (filters.include.length === 0 && filters.exclude.length === 0) return true;
+	let hostname: string;
+	try {
+		hostname = new URL(url).hostname.toLowerCase();
+	} catch {
+		return false;
+	}
+	if (filters.exclude.some((domain) => domainMatches(hostname, domain))) return false;
+	if (filters.include.length === 0) return true;
+	return filters.include.some((domain) => domainMatches(hostname, domain));
+}
+
+// SERPdive has NO time-range parameter. Recency is expressed inside the question
+// and read by the engine, which biases ranking toward recent pages — it is a
+// hint, never a guaranteed freshness filter, and results outside the window can
+// still come back.
+function applyRecencyHint(query: string, recencyFilter: SearchOptions["recencyFilter"]): string {
+	if (!recencyFilter) return query;
+	const hints: Record<string, string> = {
+		day: "past 24 hours",
+		week: "past week",
+		month: "past month",
+		year: "past year",
+	};
+	const hint = hints[recencyFilter];
+	return hint ? `${query} ${hint}` : query;
+}
+
+function requestSignal(signal?: AbortSignal): AbortSignal {
+	const timeout = AbortSignal.timeout(SEARCH_TIMEOUT_MS);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function mapResults(
+	results: SerpdiveResult[] | undefined,
+	numResults: number,
+	filters: DomainFilters,
+): SearchResponse["results"] {
+	if (!Array.isArray(results)) return [];
+	const mapped: SearchResponse["results"] = [];
+	for (const item of results) {
+		if (!item?.url || !passesDomainFilters(item.url, filters)) continue;
+		mapped.push({
+			title: item.title || `Source ${mapped.length + 1}`,
+			url: item.url,
+			snippet: typeof item.content === "string" ? item.content.replace(/\s+/g, " ").trim() : "",
+		});
+		if (mapped.length >= numResults) break;
+	}
+	return mapped;
+}
+
+function mapInlineContent(results: SerpdiveResult[] | undefined, filters: DomainFilters): ExtractedContent[] {
+	if (!Array.isArray(results)) return [];
+	return results.flatMap((item) => {
+		if (!item?.url || !passesDomainFilters(item.url, filters)) return [];
+		if (typeof item.content !== "string" || item.content.trim().length === 0) return [];
+		return [{
+			url: item.url,
+			title: item.title || "",
+			content: item.content,
+			error: null,
+		}];
+	});
+}
+
+// The free krill tier returns extracted content but no synthesized answer, so
+// one is assembled from the sources — the same shape brave.ts and searxng.ts
+// produce for providers that do not synthesize. mako and moby ask the API for a
+// real answer and use it when it comes back.
+function buildAnswer(apiAnswer: string | null | undefined, results: SearchResponse["results"]): string {
+	if (typeof apiAnswer === "string" && apiAnswer.trim().length > 0) return apiAnswer;
+	return results
+		.map((result) => {
+			if (result.snippet) return `${result.snippet}\nSource: ${result.title} (${result.url})`;
+			return `Source: ${result.title} (${result.url})`;
+		})
+		.join("\n\n");
+}
+
+export function isSerpdiveAvailable(): boolean {
+	return hasCredentialSource({
+		provider: "SERPdive",
+		configuredValue: loadConfig().serpdiveApiKey,
+		environmentValue: process.env.SERPDIVE_API_KEY,
+	});
+}
+
+export async function searchWithSerpdive(query: string, options: SerpdiveSearchOptions = {}): Promise<SearchResponse> {
+	const apiKey = await requireApiKey(options.signal);
+	const numResults = normalizeCount(options.numResults);
+	const filters = parseDomainFilter(options.domainFilter);
+	const model = resolveModel();
+	const body: Record<string, unknown> = {
+		query: applyRecencyHint(query, options.recencyFilter),
+		model,
+		// max_results is a CAP, never a minimum: the engine returns what it
+		// judges relevant, up to this many. Asking for more does not produce more.
+		max_results: Math.min(numResults, 10),
+		// krill has no answer synthesis — asking for one there is silently ignored
+		// by the API, so it is not asked for at all.
+		...(model === "krill" ? {} : { answer: true }),
+	};
+
+	const activityId = activityMonitor.logStart({ type: "api", query });
+	let response: Response;
+	try {
+		response = await fetch(SERPDIVE_API_URL, {
+			method: "POST",
+			headers: {
+				"Authorization": `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(body),
+			signal: requestSignal(options.signal),
+		});
+	} catch (err) {
+		const message = errorMessage(err);
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
+		else activityMonitor.logError(activityId, redactedMessage);
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
+	}
+
+	if (!response.ok) {
+		activityMonitor.logComplete(activityId, response.status);
+		const errorText = redactCredential(await response.text(), apiKey);
+		throw new Error(`SERPdive API error ${response.status}: ${errorText.slice(0, 300)}`);
+	}
+
+	let data: SerpdiveResponse;
+	try {
+		data = await response.json() as SerpdiveResponse;
+	} catch (err) {
+		activityMonitor.logComplete(activityId, response.status);
+		throw new Error(`SERPdive API returned invalid JSON: ${errorMessage(err)}`);
+	}
+
+	activityMonitor.logComplete(activityId, response.status);
+	const results = mapResults(data.results, numResults, filters);
+	const result: SearchResponse = {
+		answer: buildAnswer(data.answer, results),
+		results,
+	};
+	if (options.includeContent) {
+		const inlineContent = mapInlineContent(data.results, filters);
+		if (inlineContent.length > 0) result.inlineContent = inlineContent;
+	}
+	return result;
+}

--- a/test/serpdive-provider.test.mjs
+++ b/test/serpdive-provider.test.mjs
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const serpdiveModuleUrl = new URL("../serpdive.ts", import.meta.url).href;
+
+function runChild(script, env) {
+	const childEnv = { ...process.env };
+	for (const key of ["PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME", "SERPDIVE_API_KEY", "SERPDIVE_MODEL"]) {
+		delete childEnv[key];
+	}
+	Object.assign(childEnv, env);
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+}
+
+// Renvoie le corps de la requête envoyée à l'API, plus le résultat mappé.
+function probe(extra = "") {
+	return `
+		let capturedUrl = "";
+		let capturedHeaders = null;
+		let capturedBody = null;
+		globalThis.fetch = async (url, init) => {
+			capturedUrl = String(url);
+			capturedHeaders = init.headers;
+			capturedBody = JSON.parse(init.body);
+			return new Response(JSON.stringify({
+				query: capturedBody.query,
+				model: capturedBody.model,
+				response_time_ms: 1200,
+				results: [
+					{ url: "https://github.com/nicobailon/pi-web-access", title: "Repo", content: "repo content" },
+					{ url: "https://gist.github.com/nicobailon/abc", title: "Gist", content: "gist content" },
+					{ url: "https://example.com/nope", title: "Example", content: "example content" },
+				],
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+		const { searchWithSerpdive } = await import(${JSON.stringify(serpdiveModuleUrl)});
+		${extra}
+	`;
+}
+
+test("le modèle par défaut est krill, et aucune synthèse n'est demandée", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-serpdive-"));
+	const child = runChild(probe(`
+		const result = await searchWithSerpdive("vector databases", { numResults: 3 });
+		console.log(JSON.stringify({ url: capturedUrl, body: capturedBody, auth: capturedHeaders.Authorization, answer: result.answer }));
+	`), { HOME: home, USERPROFILE: home, SERPDIVE_API_KEY: "serpdive-test-key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.url, "https://api.serpdive.com/v1/search");
+	assert.equal(output.auth, "Bearer serpdive-test-key");
+	// Le point central de la revue : installer ce provider ne doit RIEN dépenser.
+	assert.equal(output.body.model, "krill");
+	assert.equal("answer" in output.body, false); // krill ne synthétise pas
+	// …mais SearchResponse.answer reste rempli, assemblé depuis les sources,
+	// comme le font brave.ts et searxng.ts pour les providers sans synthèse.
+	assert.match(output.answer, /repo content/);
+	assert.match(output.answer, /Source: Repo/);
+});
+
+test("un modèle explicite demande la synthèse à l'API", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-serpdive-"));
+	const child = runChild(probe(`
+		await searchWithSerpdive("vector databases", {});
+		console.log(JSON.stringify({ body: capturedBody }));
+	`), { HOME: home, USERPROFILE: home, SERPDIVE_API_KEY: "k", SERPDIVE_MODEL: "moby" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.body.model, "moby");
+	assert.equal(output.body.answer, true);
+});
+
+test("un modèle inconnu retombe sur krill, jamais sur un modèle payant", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-serpdive-"));
+	const child = runChild(probe(`
+		await searchWithSerpdive("vector databases", {});
+		console.log(JSON.stringify({ body: capturedBody }));
+	`), { HOME: home, USERPROFILE: home, SERPDIVE_API_KEY: "k", SERPDIVE_MODEL: "MAKO-turbo" });
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(JSON.parse(child.stdout.trim()).body.model, "krill");
+});
+
+test("max_results est plafonné à 10 — l'API n'accepte pas plus", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-serpdive-"));
+	const child = runChild(probe(`
+		await searchWithSerpdive("vector databases", { numResults: 20 });
+		console.log(JSON.stringify({ body: capturedBody }));
+	`), { HOME: home, USERPROFILE: home, SERPDIVE_API_KEY: "k" });
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(JSON.parse(child.stdout.trim()).body.max_results, 10);
+});
+
+test("la récence est un indice de requête, pas un paramètre temporel", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-serpdive-"));
+	const child = runChild(probe(`
+		await searchWithSerpdive("ai news", { recencyFilter: "week" });
+		console.log(JSON.stringify({ body: capturedBody }));
+	`), { HOME: home, USERPROFILE: home, SERPDIVE_API_KEY: "k" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const body = JSON.parse(child.stdout.trim()).body;
+	assert.equal(body.query, "ai news past week"); // l'indice voyage DANS la question
+	for (const param of ["time_range", "recency", "start_date", "end_date", "days"]) {
+		assert.equal(param in body, false, `${param} n'existe pas dans l'API`);
+	}
+});
+
+test("le filtrage par domaine est appliqué côté client, sur ce qui revient", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-serpdive-"));
+	const child = runChild(probe(`
+		const result = await searchWithSerpdive("sdk docs", {
+			domainFilter: ["github.com", "-gist.github.com"],
+			numResults: 5,
+			includeContent: true,
+		});
+		console.log(JSON.stringify({
+			body: capturedBody,
+			urls: result.results.map((r) => r.url),
+			inline: (result.inlineContent ?? []).map((c) => c.url),
+		}));
+	`), { HOME: home, USERPROFILE: home, SERPDIVE_API_KEY: "k" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	// Aucun paramètre de domaine ne part : l'API n'en a pas.
+	for (const param of ["include_domains", "exclude_domains", "domains"]) {
+		assert.equal(param in output.body, false);
+	}
+	assert.deepEqual(output.urls, ["https://github.com/nicobailon/pi-web-access"]);
+	assert.deepEqual(output.inline, ["https://github.com/nicobailon/pi-web-access"]);
+});
+
+test("une erreur HTTP remonte le statut sans jamais laisser fuir la clé", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-serpdive-"));
+	const child = runChild(`
+		globalThis.fetch = async () => new Response(
+			JSON.stringify({ error: "invalid_api_key", message: "This API key is invalid or was revoked. key=serpdive-secret-key" }),
+			{ status: 401 },
+		);
+		const { searchWithSerpdive } = await import(${JSON.stringify(serpdiveModuleUrl)});
+		try {
+			await searchWithSerpdive("q", {});
+			console.log(JSON.stringify({ threw: false }));
+		} catch (err) {
+			console.log(JSON.stringify({ threw: true, message: err.message }));
+		}
+	`, { HOME: home, USERPROFILE: home, SERPDIVE_API_KEY: "serpdive-secret-key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.threw, true);
+	assert.match(output.message, /SERPdive API error 401/);
+	assert.match(output.message, /invalid_api_key/);
+	assert.equal(output.message.includes("serpdive-secret-key"), false); // redacted
+});
+
+// Répond directement à la revue : « uses the shared request-time
+// credential-source path ». La clé n'est pas lue au chargement du module mais
+// résolue au moment de la requête, par la même mécanique que les autres
+// providers — ici un `!command`, dont on prouve qu'il ne tourne QU'À l'appel.
+test("la clé passe par le chemin de credentials partagé, résolue à la requête", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-serpdive-cred-"));
+	const agentDir = join(home, "agent");
+	await mkdir(agentDir, { recursive: true });
+	const marker = join(home, "serpdive-resolver-ran");
+	await writeFile(
+		join(agentDir, "web-search.json"),
+		JSON.stringify({ serpdiveApiKey: `!touch ${marker} && printf serpdive-command-key` }) + "\n",
+		"utf8",
+	);
+
+	const child = runChild(`
+		import { existsSync } from "node:fs";
+		const { isSerpdiveAvailable, searchWithSerpdive } = await import(${JSON.stringify(serpdiveModuleUrl)});
+		const availableBefore = isSerpdiveAvailable();
+		const ranBefore = existsSync(${JSON.stringify(marker)});
+		let auth = null;
+		globalThis.fetch = async (url, init) => {
+			auth = Object.fromEntries(new Headers(init.headers)).authorization;
+			return new Response(JSON.stringify({ results: [] }), { status: 200 });
+		};
+		await searchWithSerpdive("q", { numResults: 1 });
+		console.log(JSON.stringify({ availableBefore, ranBefore, ranAfter: existsSync(${JSON.stringify(marker)}), auth }));
+	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: agentDir });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.availableBefore, true);   // disponible sans exécuter la commande
+	assert.equal(output.ranBefore, false);        // rien n'a tourné au chargement
+	assert.equal(output.ranAfter, true);          // résolue au moment de la requête
+	assert.equal(output.auth, "Bearer serpdive-command-key");
+});


### PR DESCRIPTION
## What

Adds [SERPdive](https://serpdive.com) as a search provider next to Tavily — `SERPDIVE_API_KEY` env var or `serpdiveApiKey` config, `provider: "serpdive"`, curator UI button, and a slot in the auto fallback chain right after Tavily.

SERPdive returns extracted, answer-ready page content per result instead of snippets. On a [public 1,000-question benchmark](https://github.com/edendalexis/serpdive-benchmark) it won 60.7% of decided quality duels against Tavily's default (basic) search while returning 20.2% fewer tokens (1,001 vs 1,255 per query on average) at the same speed; the advanced Tavily tier was not tested. Free tier, no card.

Full disclosure: I built SERPdive. If you'd rather not carry another provider, close away — no hard feelings.

## How

`serpdive.ts` mirrors `tavily.ts` structurally. Differences, forced by the API surface (`POST /v1/search` with only `query`, `model`, `answer`, `max_results`):

- `answer: true` maps to the tool's synthesized-answer field (included in the request price)
- `includeContent: true` requests the `moby` model (full readable page content) and maps results into `inlineContent`; default is `mako` (key sentences)
- `recencyFilter` becomes a query hint (the engine reads the query; there is no time-range parameter)
- `domainFilter` is applied client-side on returned result URLs
- `numResults` is capped at the API maximum of 10

## Testing

`npm test`: 72/72 passing, including three new tests (bearer auth + body shape + answer/inlineContent mapping, the 10-result cap, and auto-fallback reaching SERPdive after unavailable earlier providers). CHANGELOG entry added under Unreleased.
