### PR TITLE
fix(ssrf): add actionable hint for TUN/fake-IP addresses

### DIFF
--- a/ssrf-protection.ts
+++ b/ssrf-protection.ts
@@ -108,11 +108,19 @@ function assertPublicAddress(address: string, hostname: string, allowRanges: Par
 	// users exempt synthetic ranges produced by TUN/fake-IP proxies (e.g. 198.18/15).
 	if (isInAllowedRange(normalized, ipVersion, allowRanges)) return;
 	if (ipVersion === 4 && isBlockedIPv4(normalized)) {
-		throw new Error(`Blocked internal address for ${hostname}: ${normalized}`);
+		const hint = isFakeIpProxyAddress(normalized)
+			? '. This address is in 198.18.0.0/15, commonly used by TUN/fake-IP proxies. If that matches your setup, configure ssrf.allowRanges with ["198.18.0.0/15"] in web-search.json.'
+			: "";
+		throw new Error(`Blocked internal address for ${hostname}: ${normalized}${hint}`);
 	}
 	if (ipVersion === 6 && isBlockedIPv6(normalized)) {
 		throw new Error(`Blocked internal address for ${hostname}: ${normalized}`);
 	}
+}
+
+function isFakeIpProxyAddress(address: string): boolean {
+	const [a, b] = address.split(".").map(part => Number(part));
+	return a === 198 && (b === 18 || b === 19);
 }
 
 function isBlockedIPv4(address: string): boolean {
@@ -126,7 +134,7 @@ function isBlockedIPv4(address: string): boolean {
 		(a === 169 && b === 254) ||
 		(a === 172 && b >= 16 && b <= 31) ||
 		(a === 192 && b === 168) ||
-		(a === 198 && (b === 18 || b === 19)) ||
+		isFakeIpProxyAddress(address) ||
 		a >= 224;
 }
 

--- a/test/ssrf-protection.test.mjs
+++ b/test/ssrf-protection.test.mjs
@@ -92,6 +92,15 @@ test("fetchRemoteUrl follows validated public redirects manually", async () => {
 	assert.deepEqual(requested, ["https://example.com/start", "https://example.com/next"]);
 });
 
+test("fake-IP block errors point to the allowRanges opt-in", async () => {
+	const fakeIpLookup = async () => [{ address: "198.18.0.56", family: 4 }];
+
+	await assert.rejects(
+		validateRemoteUrl("https://example.test/", { lookup: fakeIpLookup }),
+		/Blocked internal address for example\.test: 198\.18\.0\.56\..*TUN\/fake-IP proxies.*ssrf\.allowRanges.*198\.18\.0\.0\/15/,
+	);
+});
+
 test("allowRanges exempts a synthetic fake-IP range (e.g. 198.18.0.0/15)", async () => {
 	const fakeIpLookup = async () => [{ address: "198.18.0.56", family: 4 }];
 


### PR DESCRIPTION
## Summary

- detect blocked addresses in `198.18.0.0/15`, a range commonly used by TUN/fake-IP proxies
- point affected users to the existing `ssrf.allowRanges` configuration
- preserve the secure default and existing errors for all other private/reserved ranges
- add a regression test for the actionable error message

## Testing

- `npm test` (70 tests passed)

Closes #134