### PR TITLE
Land small ready backlog fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 bun.lock
 package-lock.json
+.pi-subagents/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Deferred the heavy content extraction module until the first `fetch_content` or `includeContent` search call, reducing extension startup work. Thanks Kaushik Gopal (@kaushikgopal) for PR #125.
+
+### Fixed
+- Added a focused SSRF error hint for TUN/fake-IP `198.18.0.0/15` addresses that points users to the existing `ssrf.allowRanges` opt-in. Thanks Aaron (@BenjaminAaron196) for PR #141 and AstroHan (@Astro-Han) for reporting #134.
+- Registered the web activity widget as a Pi component factory instead of passing a `Text` instance directly. Thanks Trey Hoover (@treyhoover) for PR #132.
+
 ## [0.13.0] - 2026-06-25
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { Box, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { StringEnum, complete, type Model } from "@earendil-works/pi-ai/compat";
-import { fetchAllContent, type ExtractedContent } from "./extract.ts";
+import type { ExtractedContent, ExtractOptions } from "./extract.ts";
 import { normalizeFetchContentParams } from "./fetch-params.ts";
 import { clearCloneCache } from "./github-extract.ts";
 import { search, type SearchProvider, type ResolvedSearchProvider } from "./gemini-search.ts";
@@ -46,6 +46,16 @@ import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } f
 import { loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 
 const WEB_SEARCH_CONFIG_PATH = getWebSearchConfigPath();
+
+let extractModulePromise: Promise<typeof import("./extract.ts")> | undefined;
+async function fetchAllContent(
+	urls: string[],
+	signal?: AbortSignal,
+	options?: ExtractOptions,
+): Promise<ExtractedContent[]> {
+	const extractModule = await (extractModulePromise ??= import("./extract.ts"));
+	return extractModule.fetchAllContent(urls, signal, options);
+}
 
 /** Shared collapsed/expanded renderer for an error/cancel plan produced by
  * buildSearchErrorPlan(). Used by every tool renderResult's error branch so

--- a/index.ts
+++ b/index.ts
@@ -499,7 +499,7 @@ function updateWidget(ctx: ExtensionContext): void {
 			(resetMs > 0 ? theme.fg("dim", ` (resets in ${resetSec}s)`) : ""),
 	);
 
-	ctx.ui.setWidget("web-activity", new Text(lines.join("\n"), 0, 0));
+	ctx.ui.setWidget("web-activity", () => new Text(lines.join("\n"), 0, 0));
 }
 
 function formatEntryLine(

--- a/ssrf-protection.ts
+++ b/ssrf-protection.ts
@@ -108,11 +108,19 @@ function assertPublicAddress(address: string, hostname: string, allowRanges: Par
 	// users exempt synthetic ranges produced by TUN/fake-IP proxies (e.g. 198.18/15).
 	if (isInAllowedRange(normalized, ipVersion, allowRanges)) return;
 	if (ipVersion === 4 && isBlockedIPv4(normalized)) {
-		throw new Error(`Blocked internal address for ${hostname}: ${normalized}`);
+		const hint = isFakeIpProxyAddress(normalized)
+			? '. This address is in 198.18.0.0/15, commonly used by TUN/fake-IP proxies. If that matches your setup, configure ssrf.allowRanges with ["198.18.0.0/15"] in web-search.json.'
+			: "";
+		throw new Error(`Blocked internal address for ${hostname}: ${normalized}${hint}`);
 	}
 	if (ipVersion === 6 && isBlockedIPv6(normalized)) {
 		throw new Error(`Blocked internal address for ${hostname}: ${normalized}`);
 	}
+}
+
+function isFakeIpProxyAddress(address: string): boolean {
+	const [a, b] = address.split(".").map(part => Number(part));
+	return a === 198 && (b === 18 || b === 19);
 }
 
 function isBlockedIPv4(address: string): boolean {
@@ -126,7 +134,7 @@ function isBlockedIPv4(address: string): boolean {
 		(a === 169 && b === 254) ||
 		(a === 172 && b >= 16 && b <= 31) ||
 		(a === 192 && b === 168) ||
-		(a === 198 && (b === 18 || b === 19)) ||
+		isFakeIpProxyAddress(address) ||
 		a >= 224;
 }
 

--- a/test/lazy-extract-load.test.mjs
+++ b/test/lazy-extract-load.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const indexUrl = new URL("../index.ts", import.meta.url).href;
+
+test("registers eagerly and loads content extraction on first use", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(indexUrl),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+		timeout: 30_000,
+	});
+
+	assert.equal(
+		child.status,
+		0,
+		"Lazy extraction regression child failed:\n" + errorSummary(child.stderr),
+	);
+});
+
+function buildChildScript(moduleUrl) {
+	return `
+		import assert from "node:assert/strict";
+		import { existsSync } from "node:fs";
+		import { mkdtemp, writeFile } from "node:fs/promises";
+		import { createServer } from "node:http";
+		import { register } from "node:module";
+		import { tmpdir } from "node:os";
+		import { join } from "node:path";
+
+		const tempDir = await mkdtemp(join(tmpdir(), "pi-web-access-lazy-"));
+		const markerPath = join(tempDir, "extract-loaded");
+		process.env.PI_CODING_AGENT_DIR = tempDir;
+		await writeFile(
+			join(tempDir, "web-search.json"),
+			JSON.stringify({ ssrf: { allowRanges: ["127.0.0.0/8"] } }),
+		);
+
+		const hookSource = \`
+			import { appendFileSync } from "node:fs";
+			let markerPath;
+			export function initialize(data) { markerPath = data.markerPath; }
+			export async function load(url, context, nextLoad) {
+				if (new URL(url).pathname.endsWith("/extract.ts")) {
+					appendFileSync(markerPath, url + "\\\\n");
+				}
+				return nextLoad(url, context);
+			}
+		\`;
+		register("data:text/javascript," + encodeURIComponent(hookSource), {
+			parentURL: import.meta.url,
+			data: { markerPath },
+		});
+
+		const { default: initializeExtension } = await import(${JSON.stringify(moduleUrl)});
+		assert.equal(existsSync(markerPath), false, "extract.ts loaded during extension import");
+
+		const tools = [];
+		const commands = [];
+		const shortcuts = [];
+		const events = [];
+		const pi = new Proxy({}, {
+			get(_target, property) {
+				if (property === "registerTool") return (tool) => tools.push(tool);
+				if (property === "registerCommand") return (name) => commands.push(name);
+				if (property === "registerShortcut") return (name) => shortcuts.push(name);
+				if (property === "on") return (name) => events.push(name);
+				return () => {};
+			},
+		});
+
+		initializeExtension(pi);
+		assert.deepEqual(
+			tools.map((tool) => tool.name),
+			["web_search", "fetch_content", "get_search_content"],
+		);
+		assert.ok(commands.includes("websearch"), "websearch command was not registered");
+		assert.ok(shortcuts.length > 0, "shortcuts were not registered");
+		assert.ok(events.includes("session_start"), "session handlers were not registered");
+		assert.equal(existsSync(markerPath), false, "extract.ts loaded during registration");
+
+		const articleText = "Lazy loading keeps extension startup responsive while preserving first-use extraction. ";
+		const html = \`<!doctype html><html><head><title>Lazy extraction</title></head><body>
+			<article><h1>Lazy extraction works</h1><p>\${articleText.repeat(20)}</p></article>
+		</body></html>\`;
+		const server = createServer((_request, response) => {
+			response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			response.end(html);
+		});
+		await new Promise((resolve, reject) => {
+			server.once("error", reject);
+			server.listen(0, "127.0.0.1", resolve);
+		});
+
+		try {
+			const address = server.address();
+			assert.ok(address && typeof address === "object");
+			const fetchTool = tools.find((tool) => tool.name === "fetch_content");
+			const result = await fetchTool.execute(
+				"lazy-load-regression",
+				{ url: \`http://127.0.0.1:\${address.port}/article\` },
+				undefined,
+				() => {},
+			);
+
+			assert.equal(existsSync(markerPath), true, "extract.ts did not load on first use");
+			assert.equal(result.details.successful, 1);
+			assert.match(result.content.at(-1).text, /preserving first-use extraction/);
+		} finally {
+			await new Promise((resolve) => server.close(resolve));
+		}
+	`;
+}
+
+function errorSummary(value, size = 2000) {
+	return value.length > size ? value.slice(-size) : value;
+}

--- a/test/ssrf-protection.test.mjs
+++ b/test/ssrf-protection.test.mjs
@@ -92,6 +92,15 @@ test("fetchRemoteUrl follows validated public redirects manually", async () => {
 	assert.deepEqual(requested, ["https://example.com/start", "https://example.com/next"]);
 });
 
+test("fake-IP block errors point to the allowRanges opt-in", async () => {
+	const fakeIpLookup = async () => [{ address: "198.18.0.56", family: 4 }];
+
+	await assert.rejects(
+		validateRemoteUrl("https://example.test/", { lookup: fakeIpLookup }),
+		/Blocked internal address for example\.test: 198\.18\.0\.56\..*TUN\/fake-IP proxies.*ssrf\.allowRanges.*198\.18\.0\.0\/15/,
+	);
+});
+
 test("allowRanges exempts a synthetic fake-IP range (e.g. 198.18.0.0/15)", async () => {
 	const fakeIpLookup = async () => [{ address: "198.18.0.56", family: 4 }];
 

--- a/test/tool-registration-config.test.mjs
+++ b/test/tool-registration-config.test.mjs
@@ -18,6 +18,17 @@ test("fetch tools remain registered outside the web_search gate", () => {
 	assert.match(indexSrc, /\n\t}\);\n\n\tpi\.registerTool\(\{\n\t\tname: "fetch_content"/);
 });
 
+test("web activity widget uses a supported component factory", () => {
+	assert.match(
+		indexSrc,
+		/ctx\.ui\.setWidget\("web-activity", \(\) => new Text\(lines\.join\("\\n"\), 0, 0\)\);/,
+	);
+	assert.doesNotMatch(
+		indexSrc,
+		/ctx\.ui\.setWidget\("web-activity", new Text/,
+	);
+});
+
 test("README documents webSearch.enabled", () => {
 	assert.match(readmeSrc, /"webSearch": \{\n    "enabled": true\n  \}/);
 	assert.match(readmeSrc, /webSearch\.enabled` to `false` to unregister the `web_search` tool/);


### PR DESCRIPTION
This lands the three small ready PRs together and adds visible changelog credit before merging:

- #141 fake-IP SSRF hint, preserving the deny-by-default SSRF guard and pointing TUN/fake-IP users to `ssrf.allowRanges`. Closes #134.
- #132 web activity widget registration as a Pi component factory.
- #125 lazy extraction module loading while keeping tool registration eager and first-use extraction covered.

Validation on the exact candidate head:

- `npm test` passed, 72 tests.
- `git diff --check main...HEAD` passed.
- `npm pack --dry-run` passed and confirmed local `.pi-subagents/` artifacts are excluded.
- Fresh read-only review approved the combined candidate with no blockers.

Thanks Aaron (@BenjaminAaron196), AstroHan (@Astro-Han), Trey Hoover (@treyhoover), and Kaushik Gopal (@kaushikgopal).
