### PR TITLE
Bound stored content retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Deferred the heavy content extraction module until the first `fetch_content` or `includeContent` search call, reducing extension startup work. Thanks Kaushik Gopal (@kaushikgopal) for PR #125.
 
 ### Fixed
+- Returned fetched URL content from `get_search_content` in bounded slices with explicit `offset`/`limit` continuation metadata, preventing large stored pages from overflowing the next model request. Thanks @manfredlift for reporting #112.
 - Added a focused SSRF error hint for TUN/fake-IP `198.18.0.0/15` addresses that points users to the existing `ssrf.allowRanges` opt-in. Thanks Aaron (@BenjaminAaron196) for PR #141 and AstroHan (@Astro-Han) for reporting #134.
 - Registered the web activity widget as a Pi component factory instead of passing a `Text` instance directly. Thanks Trey Hoover (@treyhoover) for PR #132.
 

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ fetch_content({ url: "https://youtube.com/watch?v=abc", timestamp: "23:41-25:00"
 
 ### get_search_content
 
-Retrieve stored content from previous searches or fetches. Content over 30,000 chars is truncated in tool responses but stored in full for retrieval here.
+Retrieve stored content from previous searches or fetches. Fetched URL content is stored in full, but `get_search_content` returns bounded slices by default so large pages do not overflow the next model request. Use `offset` and `limit` to page through long content intentionally.
 
 ```typescript
 get_search_content({ responseId: "abc123", urlIndex: 0 })
-get_search_content({ responseId: "abc123", url: "https://..." })
+get_search_content({ responseId: "abc123", url: "https://...", offset: 30000 })
 get_search_content({ responseId: "abc123", query: "original query" })
 ```
 

--- a/index.ts
+++ b/index.ts
@@ -312,6 +312,8 @@ interface PendingCurate {
 
 
 const MAX_INLINE_CONTENT = 30000; // Content returned directly to agent
+const DEFAULT_CONTENT_SLICE_LENGTH = MAX_INLINE_CONTENT;
+const MAX_CONTENT_SLICE_LENGTH = MAX_INLINE_CONTENT;
 
 function stripThumbnails(results: ExtractedContent[]): ExtractedContent[] {
 	return results.map(({ thumbnail, frames, ...rest }) => rest);
@@ -1871,7 +1873,7 @@ export default function (pi: ExtensionAPI) {
 
 				if (truncated) {
 					output += `\n\n---\nShowing ${MAX_INLINE_CONTENT} of ${fullLength} chars. ` +
-						`Use get_search_content({ responseId: "${responseId}", urlIndex: 0 }) for full content.`;
+						`Use get_search_content({ responseId: "${responseId}", urlIndex: 0, offset: ${MAX_INLINE_CONTENT} }) for the next slice.`;
 				}
 
 				const content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> = [];
@@ -1915,7 +1917,7 @@ export default function (pi: ExtensionAPI) {
 					output += `- ${title || url} (${content.length} chars)\n`;
 				}
 			}
-			output += `\n---\nUse get_search_content({ responseId: "${responseId}", urlIndex: 0 }) to retrieve full content.`;
+			output += `\n---\nUse get_search_content({ responseId: "${responseId}", urlIndex: 0 }) to retrieve bounded content slices.`;
 
 			return {
 				content: [{ type: "text", text: output }],
@@ -2050,15 +2052,17 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "get_search_content",
 		label: "Get Search Content",
-		description: "Retrieve full content from a previous web_search or fetch_content call.",
+		description: "Retrieve bounded content slices from a previous web_search or fetch_content call.",
 		promptSnippet:
-			"Use after web_search/fetch_content when full stored content is needed via responseId plus query/url selectors.",
+			"Use after web_search/fetch_content to retrieve stored content via responseId plus query/url selectors. Fetched URL content is returned in bounded slices; use offset/limit to continue.",
 		parameters: Type.Object({
 			responseId: Type.String({ description: "The responseId from web_search or fetch_content" }),
 			query: Type.Optional(Type.String({ description: "Get content for this query (web_search)" })),
 			queryIndex: Type.Optional(Type.Number({ description: "Get content for query at index" })),
 			url: Type.Optional(Type.String({ description: "Get content for this URL" })),
 			urlIndex: Type.Optional(Type.Number({ description: "Get content for URL at index" })),
+			offset: Type.Optional(Type.Number({ description: "Character offset for fetched URL content slices (default 0)" })),
+			limit: Type.Optional(Type.Number({ description: `Maximum characters to return for fetched URL content slices (default/max ${MAX_CONTENT_SLICE_LENGTH})` })),
 		}),
 
 		async execute(_toolCallId, params) {
@@ -2113,9 +2117,11 @@ export default function (pi: ExtensionAPI) {
 
 			if (data.type === "fetch" && data.urls) {
 				let urlData: ExtractedContent | undefined;
+				let selectedUrlIndex = -1;
 
 				if (params.url !== undefined) {
-					urlData = data.urls.find((u) => u.url === params.url);
+					selectedUrlIndex = data.urls.findIndex((u) => u.url === params.url);
+					urlData = data.urls[selectedUrlIndex];
 					if (!urlData) {
 						const available = data.urls.map((u) => u.url).join("\n  ");
 						return {
@@ -2124,7 +2130,8 @@ export default function (pi: ExtensionAPI) {
 						};
 					}
 				} else if (params.urlIndex !== undefined) {
-					urlData = data.urls[params.urlIndex];
+					selectedUrlIndex = params.urlIndex;
+					urlData = data.urls[selectedUrlIndex];
 					if (!urlData) {
 						return {
 							content: [{ type: "text", text: `Index ${params.urlIndex} out of range (0-${data.urls.length - 1})` }],
@@ -2146,9 +2153,50 @@ export default function (pi: ExtensionAPI) {
 					};
 				}
 
+				const offset = params.offset ?? 0;
+				const limit = params.limit ?? DEFAULT_CONTENT_SLICE_LENGTH;
+				if (!Number.isInteger(offset) || offset < 0) {
+					return {
+						content: [{ type: "text", text: "offset must be a non-negative integer" }],
+						details: { error: "Invalid offset", offset },
+					};
+				}
+				if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_CONTENT_SLICE_LENGTH) {
+					return {
+						content: [{ type: "text", text: `limit must be an integer from 1 to ${MAX_CONTENT_SLICE_LENGTH}` }],
+						details: { error: "Invalid limit", limit, maxLimit: MAX_CONTENT_SLICE_LENGTH },
+					};
+				}
+				if (offset > urlData.content.length) {
+					return {
+						content: [{ type: "text", text: `offset ${offset} is out of range (0-${urlData.content.length})` }],
+						details: { error: "Offset out of range", offset, contentLength: urlData.content.length },
+					};
+				}
+
+				const endOffset = Math.min(offset + limit, urlData.content.length);
+				const contentSlice = urlData.content.slice(offset, endOffset);
+				const hasMore = endOffset < urlData.content.length;
+				let text = `# ${urlData.title || urlData.url}\n\n${contentSlice}`;
+				if (hasMore || offset > 0) {
+					text += `\n\n---\nShowing chars ${offset}-${endOffset} of ${urlData.content.length}.`;
+					if (hasMore) {
+						text += ` Use get_search_content({ responseId: "${params.responseId}", urlIndex: ${selectedUrlIndex}, offset: ${endOffset}, limit: ${limit} }) for the next slice.`;
+					}
+				}
+
 				return {
-					content: [{ type: "text", text: `# ${urlData.title}\n\n${urlData.content}` }],
-					details: { url: urlData.url, title: urlData.title, contentLength: urlData.content.length },
+					content: [{ type: "text", text }],
+					details: {
+						url: urlData.url,
+						title: urlData.title,
+						contentLength: urlData.content.length,
+						offset,
+						limit,
+						returnedChars: contentSlice.length,
+						nextOffset: hasMore ? endOffset : null,
+						truncated: hasMore,
+					},
 				};
 			}
 
@@ -2159,18 +2207,20 @@ export default function (pi: ExtensionAPI) {
 		},
 
 		renderCall(args, theme) {
-			const { responseId, query, queryIndex, url, urlIndex } = args as {
+			const { responseId, query, queryIndex, url, urlIndex, offset } = args as {
 				responseId: string;
 				query?: string;
 				queryIndex?: number;
 				url?: string;
 				urlIndex?: number;
+				offset?: number;
 			};
 			let target = "";
 			if (query) target = `query="${query}"`;
 			else if (queryIndex !== undefined) target = `queryIndex=${queryIndex}`;
 			else if (url) target = url.length > 30 ? url.slice(0, 27) + "..." : url;
 			else if (urlIndex !== undefined) target = `urlIndex=${urlIndex}`;
+			if (offset !== undefined) target += target ? ` @ ${offset}` : `offset=${offset}`;
 			return new Text(theme.fg("toolTitle", theme.bold("get_content ")) + theme.fg("accent", target || responseId.slice(0, 8)), 0, 0);
 		},
 
@@ -2182,6 +2232,9 @@ export default function (pi: ExtensionAPI) {
 				title?: string;
 				resultCount?: number;
 				contentLength?: number;
+				offset?: number;
+				returnedChars?: number;
+				nextOffset?: number | null;
 			};
 
 			if (details?.error) {
@@ -2198,7 +2251,13 @@ export default function (pi: ExtensionAPI) {
 			if (details?.query) {
 				statusLine = theme.fg("success", `"${details.query}"`) + theme.fg("muted", ` (${details.resultCount} results)`);
 			} else {
-				statusLine = theme.fg("success", details?.title || "Content") + theme.fg("muted", ` (${details?.contentLength ?? 0} chars)`);
+				const start = details?.offset ?? 0;
+				const returned = details?.returnedChars ?? details?.contentLength ?? 0;
+				const end = start + returned;
+				const slice = details?.nextOffset !== undefined || start > 0
+					? `, showing ${start}-${end}`
+					: "";
+				statusLine = theme.fg("success", details?.title || "Content") + theme.fg("muted", ` (${details?.contentLength ?? 0} chars${slice})`);
 			}
 
 			if (!expanded) {

--- a/test/get-search-content.test.mjs
+++ b/test/get-search-content.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import initializeExtension from "../index.ts";
+import { clearResults, storeResult } from "../storage.ts";
+
+function getContentTool() {
+	clearResults();
+	const tools = [];
+	initializeExtension({
+		registerTool(tool) { tools.push(tool); },
+		registerCommand() {},
+		registerShortcut() {},
+		on() {},
+	});
+	const tool = tools.find((registered) => registered.name === "get_search_content");
+	assert.ok(tool, "get_search_content tool was not registered");
+	return tool;
+}
+
+function storeFetchedContent(content) {
+	storeResult("large-fetch", {
+		id: "large-fetch",
+		type: "fetch",
+		timestamp: Date.now(),
+		urls: [{
+			url: "https://example.com/large",
+			title: "Large Page",
+			content,
+			error: null,
+		}],
+	});
+}
+
+test("get_search_content returns a bounded first slice for large fetched content", async () => {
+	const tool = getContentTool();
+	storeFetchedContent("A".repeat(30_000) + "TAIL");
+
+	const result = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0 });
+	const text = result.content[0].text;
+
+	assert.equal(result.details.contentLength, 30_004);
+	assert.equal(result.details.offset, 0);
+	assert.equal(result.details.returnedChars, 30_000);
+	assert.equal(result.details.nextOffset, 30_000);
+	assert.equal(result.details.truncated, true);
+	assert.match(text, /Showing chars 0-30000 of 30004/);
+	assert.match(text, /offset: 30000/);
+	assert.doesNotMatch(text, /TAIL/);
+});
+
+test("get_search_content returns requested fetched content slices", async () => {
+	const tool = getContentTool();
+	storeFetchedContent("A".repeat(30_000) + "BCDEFGHIJ");
+
+	const result = await tool.execute("call", {
+		responseId: "large-fetch",
+		url: "https://example.com/large",
+		offset: 30_000,
+		limit: 5,
+	});
+	const text = result.content[0].text;
+
+	assert.equal(result.details.offset, 30_000);
+	assert.equal(result.details.limit, 5);
+	assert.equal(result.details.returnedChars, 5);
+	assert.equal(result.details.nextOffset, 30_005);
+	assert.match(text, /BCDEF/);
+	assert.doesNotMatch(text, /GHIJ/);
+	assert.match(text, /urlIndex: 0, offset: 30005, limit: 5/);
+});
+
+test("get_search_content rejects unsafe fetched content ranges", async () => {
+	const tool = getContentTool();
+	storeFetchedContent("short content");
+
+	const tooLarge = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, limit: 30_001 });
+	assert.equal(tooLarge.details.error, "Invalid limit");
+	assert.match(tooLarge.content[0].text, /limit must be an integer from 1 to 30000/);
+
+	const invalidOffset = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, offset: 1.5 });
+	assert.equal(invalidOffset.details.error, "Invalid offset");
+
+	const outOfRange = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, offset: 99 });
+	assert.equal(outOfRange.details.error, "Offset out of range");
+});
+
+test("get_search_content returns small fetched content without continuation noise", async () => {
+	const tool = getContentTool();
+	storeFetchedContent("small content");
+
+	const result = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0 });
+	const text = result.content[0].text;
+
+	assert.equal(result.details.returnedChars, "small content".length);
+	assert.equal(result.details.nextOffset, null);
+	assert.match(text, /small content/);
+	assert.doesNotMatch(text, /Showing chars/);
+});


### PR DESCRIPTION
This fixes #112 by changing `get_search_content` fetch-result retrieval from unbounded full-page output to bounded slices.

The full extracted content still stays in storage, but fetched URL retrieval now defaults to a 30,000-character slice and requires explicit `offset`/`limit` pagination for longer pages. Caller-supplied limits are capped at the same maximum so the overflow cannot be recreated by asking for a huge slice.

Validation on the exact candidate head:

- `node --test test/get-search-content.test.mjs` passed.
- `npm test` passed, 76 tests.
- `git diff --check` passed.
- `npm pack --dry-run` passed and did not include local `.pi-subagents/` artifacts.
- Fresh read-only review approved the candidate.

Thanks @manfredlift for reporting #112.

Closes #112.
