### PR TITLE
Keep oversized local videos frame-extractable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Returned fetched URL content from `get_search_content` in bounded slices with explicit `offset`/`limit` continuation metadata, preventing large stored pages from overflowing the next model request. Thanks @manfredlift for reporting #112.
+- Kept oversized local videos recognizable for ffmpeg frame/timestamp extraction while preserving the Gemini analysis upload size limit. Thanks @Xandaar for reporting #135.
 - Added a focused SSRF error hint for TUN/fake-IP `198.18.0.0/15` addresses that points users to the existing `ssrf.allowRanges` opt-in. Thanks Aaron (@BenjaminAaron196) for PR #141 and AstroHan (@Astro-Han) for reporting #134.
 - Registered the web activity widget as a Pi component factory instead of passing a `Text` instance directly. Thanks Trey Hoover (@treyhoover) for PR #132.
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Fallback: Gemini Web when browser cookies are enabled → Gemini API → Perplex
 
 ### Local video files
 
-Pass a file path (`/`, `./`, `../`, or `file://` prefix) to analyze video content via Gemini. Supports MP4, MOV, WebM, AVI, and other common formats up to 50MB. Pass a `prompt` to ask about specific content. If ffmpeg is installed, a thumbnail frame is included alongside the analysis.
+Pass a file path (`/`, `./`, `../`, or `file://` prefix) to analyze video content via Gemini. Supports MP4, MOV, WebM, AVI, and other common formats up to 50MB for Gemini analysis. Pass a `prompt` to ask about specific content. If ffmpeg is installed, a thumbnail frame is included alongside the analysis. Timestamp/frame extraction uses ffmpeg directly and can still operate on larger local files.
 
 Fallback: Gemini API (Files API upload) → Gemini Web when browser cookies are enabled.
 

--- a/test/local-video-oversize.test.mjs
+++ b/test/local-video-oversize.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, truncate, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const extractUrl = new URL("../extract.ts", import.meta.url).href;
+
+async function runOversizeProbe(expression) {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-oversize-video-"));
+	const videoPath = join(root, "oversized.mp4");
+	await writeFile(videoPath, "");
+	await truncate(videoPath, 50 * 1024 * 1024 + 1);
+	try {
+		const child = spawnSync(process.execPath, ["--input-type=module"], {
+			input: `
+				process.env.PI_CODING_AGENT_DIR = ${JSON.stringify(root)};
+				const { extractContent } = await import(${JSON.stringify(extractUrl)});
+				const result = await (${expression})(extractContent, ${JSON.stringify(videoPath)});
+				console.log(JSON.stringify({ title: result.title, content: result.content, error: result.error }));
+			`,
+			encoding: "utf8",
+			timeout: 30_000,
+		});
+		assert.equal(child.status, 0, child.stderr);
+		return JSON.parse(child.stdout);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+test("oversized local videos are still recognized for frame extraction", async () => {
+	const result = await runOversizeProbe(`(extractContent, videoPath) => extractContent(videoPath, undefined, { frames: 1 })`);
+
+	assert.notEqual(result.error, "Frame extraction only works with YouTube and local video files");
+	assert.match(result.error, /ffprobe|Cannot determine video duration|failed|not installed/i);
+});
+
+test("oversized local videos are still recognized for timestamp extraction", async () => {
+	const result = await runOversizeProbe(`(extractContent, videoPath) => extractContent(videoPath, undefined, { timestamp: "1" })`);
+
+	assert.notEqual(result.error, "Timestamp extraction only works with YouTube and local video files");
+	assert.match(result.error, /ffmpeg|failed|not installed/i);
+});
+
+test("oversized local video analysis reports the upload size limit", async () => {
+	const result = await runOversizeProbe(`(extractContent, videoPath) => extractContent(videoPath, undefined, { prompt: "summarize" })`);
+
+	assert.match(result.error, /above configured video\.maxSizeMB/);
+	assert.match(result.error, /timestamp\/frames/);
+});

--- a/video-extract.ts
+++ b/video-extract.ts
@@ -41,6 +41,8 @@ interface VideoFileInfo {
 	absolutePath: string;
 	mimeType: string;
 	sizeBytes: number;
+	maxSizeBytes: number;
+	withinUploadLimit: boolean;
 }
 
 interface VideoConfig {
@@ -129,9 +131,13 @@ export function isVideoFile(input: string): VideoFileInfo | null {
 	if (!stat.isFile()) return null;
 
 	const maxBytes = config.maxSizeMB * 1024 * 1024;
-	if (stat.size > maxBytes) return null;
-
-	return { absolutePath, mimeType, sizeBytes: stat.size };
+	return {
+		absolutePath,
+		mimeType,
+		sizeBytes: stat.size,
+		maxSizeBytes: maxBytes,
+		withinUploadLimit: stat.size <= maxBytes,
+	};
 }
 
 function resolveFilePath(filePath: string): string | null {
@@ -164,6 +170,12 @@ export async function extractVideo(
 	const effectivePrompt = options?.prompt ?? DEFAULT_VIDEO_PROMPT;
 	const effectiveModel = options?.model ?? config.preferredModel;
 	const displayName = basename(info.absolutePath);
+	if (!info.withinUploadLimit) {
+		const sizeMB = (info.sizeBytes / 1024 / 1024).toFixed(1);
+		const maxSizeMB = (info.maxSizeBytes / 1024 / 1024).toFixed(1);
+		const error = `Local video ${displayName} is ${sizeMB} MiB, above configured video.maxSizeMB (${maxSizeMB} MiB) for Gemini analysis. Use timestamp/frames for ffmpeg frame extraction, increase video.maxSizeMB, or compress the file.`;
+		return { url: info.absolutePath, title: displayName, content: error, error };
+	}
 	const activityId = activityMonitor.logStart({ type: "fetch", url: `video:${displayName}` });
 
 	const result = await tryVideoGeminiApi(info, effectivePrompt, effectiveModel, signal)


### PR DESCRIPTION
This fixes #135 by separating local video recognition from Gemini upload eligibility.

Supported local video paths are now recognized even when they exceed `video.maxSizeMB`, so `timestamp` and `frames` requests reach the ffmpeg/ffprobe path instead of reporting that the file is unsupported. Full Gemini analysis still refuses over-limit files before any Gemini API/Web attempt and returns an actionable size-limit message.

Validation on the exact candidate head:

- `node --test test/local-video-oversize.test.mjs test/fetch-params.test.mjs test/youtube-extract-errors.test.mjs` passed, 11 tests.
- `npm test` passed, 79 tests.
- `git diff --check` passed.
- `npm pack --dry-run` passed and did not include local `.pi-subagents/` artifacts.
- Fresh read-only review approved the candidate; one wording nit was fixed and validations were rerun.

Thanks @Xandaar for reporting #135.

Closes #135.
