### PR TITLE
Bundle typebox as a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Returned fetched URL content from `get_search_content` in bounded slices with explicit `offset`/`limit` continuation metadata, preventing large stored pages from overflowing the next model request. Thanks @manfredlift for reporting #112.
 - Kept oversized local videos recognizable for ffmpeg frame/timestamp extraction while preserving the Gemini analysis upload size limit. Thanks @Xandaar for reporting #135.
+- Declared `typebox` as a regular runtime dependency so clean/global installs can load the extension without relying on Pi or Feynman to provide that peer. Thanks @DuskyElf, @tonytziorvas, and @53able for reporting #59, #63, and #66.
 - Added a focused SSRF error hint for TUN/fake-IP `198.18.0.0/15` addresses that points users to the existing `ssrf.allowRanges` opt-in. Thanks Aaron (@BenjaminAaron196) for PR #141 and AstroHan (@Astro-Han) for reporting #134.
 - Registered the web activity widget as a Pi component factory instead of passing a `Text` instance directly. Thanks Trey Hoover (@treyhoover) for PR #132.
 

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "linkedom": "^0.16.0",
     "p-limit": "^6.1.0",
     "turndown": "^7.2.0",
+    "typebox": "^1.1.38",
     "unpdf": "^1.6.2"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*",
-    "typebox": "*"
+    "@earendil-works/pi-tui": "*"
   },
   "pi": {
     "extensions": [

--- a/test/package-typebox-dependency.test.mjs
+++ b/test/package-typebox-dependency.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { test } from "node:test";
+
+const repoRoot = resolve(new URL("..", import.meta.url).pathname);
+
+test("packed installs include typebox without peer dependencies", async () => {
+	const tempDir = await mkdtemp(join(tmpdir(), "pi-web-access-pack-install-"));
+	try {
+		const packOutput = execFileSync("npm", ["pack", "--json", "--pack-destination", tempDir], {
+			cwd: repoRoot,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const [{ filename }] = JSON.parse(packOutput);
+		const tarball = join(tempDir, filename);
+
+		execFileSync("npm", ["install", "--omit=peer", "--ignore-scripts", "--no-audit", "--no-fund", tarball], {
+			cwd: tempDir,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		const packageRequire = createRequire(join(tempDir, "node_modules", "pi-web-access", "package.json"));
+		const installedManifest = packageRequire("pi-web-access/package.json");
+		assert.equal(installedManifest.peerDependencies?.typebox, undefined);
+		assert.match(installedManifest.dependencies?.typebox, /^\^1\./);
+		assert.match(packageRequire.resolve("typebox").replaceAll("\\", "/"), /node_modules\/typebox\//);
+	} finally {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
This fixes #59, #63, and #66 by making `typebox` a regular runtime dependency instead of relying on Pi/Feynman/global installs to provide it as a peer.

`index.ts` imports `typebox` unconditionally during extension load, so clean installs need it in `dependencies`. The Pi packages remain peers.

Validation on the exact candidate head:

- `node --test test/package-typebox-dependency.test.mjs` passed.
- `npm test` passed, 80 tests.
- `git diff --check` passed.
- `npm pack --dry-run` passed and did not include local `.pi-subagents/` artifacts.
- Fresh read-only review approved the package contract; its path-separator test nit was fixed and validation was rerun.

Thanks @DuskyElf, @tonytziorvas, and @53able for reporting #59, #63, and #66.

Closes #59.
Closes #63.
Closes #66.
