### PR TITLE
Render OpenAI answers without sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Returned fetched URL content from `get_search_content` in bounded slices with explicit `offset`/`limit` continuation metadata, preventing large stored pages from overflowing the next model request. Thanks @manfredlift for reporting #112.
 - Kept oversized local videos recognizable for ffmpeg frame/timestamp extraction while preserving the Gemini analysis upload size limit. Thanks @Xandaar for reporting #135.
 - Declared `typebox` as a regular runtime dependency so clean/global installs can load the extension without relying on Pi or Feynman to provide that peer. Thanks @DuskyElf, @tonytziorvas, and @53able for reporting #59, #63, and #66.
+- Preserved OpenAI/Codex answers even when the provider returns no source citations instead of replacing them with `No results found`. Thanks AstroHan (@Astro-Han) for reporting #117.
 - Added a focused SSRF error hint for TUN/fake-IP `198.18.0.0/15` addresses that points users to the existing `ssrf.allowRanges` opt-in. Thanks Aaron (@BenjaminAaron196) for PR #141 and AstroHan (@Astro-Han) for reporting #134.
 - Registered the web activity widget as a Pi component factory instead of passing a `Text` instance directly. Thanks Trey Hoover (@treyhoover) for PR #132.
 

--- a/index.ts
+++ b/index.ts
@@ -320,6 +320,9 @@ function stripThumbnails(results: ExtractedContent[]): ExtractedContent[] {
 }
 
 function formatSearchSummary(results: SearchResult[], answer: string): string {
+	if (results.length === 0) {
+		return answer ? `${answer}\n\n---\n\n**Sources:**\nNo sources returned.` : "No results found.";
+	}
 	let output = answer ? `${answer}\n\n---\n\n**Sources:**\n` : "";
 	output += results.map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}`).join("\n\n");
 	return output;
@@ -877,7 +880,6 @@ export default function (pi: ExtensionAPI) {
 						: `## Query: "${query}"\n\n`;
 				}
 				if (error) output += `Error: ${error}\n\n`;
-				else if (results.length === 0) output += "No results found.\n\n";
 				else output += formatSearchSummary(results, answer) + "\n\n";
 			}
 		}

--- a/test/web-search-answer-render.test.mjs
+++ b/test/web-search-answer-render.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const indexUrl = new URL("../index.ts", import.meta.url).href;
+
+function runChild(script, env) {
+	const childEnv = { ...process.env };
+	for (const key of [
+		"PI_CODING_AGENT_DIR",
+		"XDG_CONFIG_HOME",
+		"OPENAI_API_KEY",
+		"BRAVE_API_KEY",
+		"PARALLEL_API_KEY",
+		"TAVILY_API_KEY",
+		"EXA_API_KEY",
+		"PERPLEXITY_API_KEY",
+		"GEMINI_API_KEY",
+	]) {
+		delete childEnv[key];
+	}
+	Object.assign(childEnv, env);
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+}
+
+test("web_search preserves OpenAI answers even when no sources are returned", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-openai-answer-"));
+	const child = runChild(`
+		globalThis.fetch = async () => new Response(JSON.stringify({
+			output: [{
+				type: "message",
+				content: [{ type: "output_text", text: "Direct answer without citations." }],
+			}],
+		}), { status: 200, headers: { "content-type": "application/json" } });
+
+		const { default: initializeExtension } = await import(${JSON.stringify(indexUrl)});
+		const tools = [];
+		initializeExtension({
+			registerTool(tool) { tools.push(tool); },
+			registerCommand() {},
+			registerShortcut() {},
+			on() {},
+			appendEntry() {},
+			sendMessage() {},
+			exec() { return { code: 0 }; },
+		});
+		const webSearch = tools.find((tool) => tool.name === "web_search");
+		const result = await webSearch.execute("call", {
+			query: "answer only",
+			provider: "openai",
+			workflow: "none",
+		});
+		console.log(JSON.stringify({ text: result.content[0].text, details: result.details }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: home,
+		OPENAI_API_KEY: "openai-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.match(output.text, /Direct answer without citations\./);
+	assert.match(output.text, /No sources returned\./);
+	assert.doesNotMatch(output.text, /No results found/);
+	assert.equal(output.details.successfulQueries, 1);
+	assert.equal(output.details.totalResults, 0);
+});


### PR DESCRIPTION
Fixes #117.

OpenAI/Codex can return a valid answer without source citations. The provider parser already preserves that as `{ answer, results: [] }`, but `web_search` rendered any empty result list as `No results found`, discarding the answer. This routes all successful search returns through the summary formatter and shows the answer with a clear `No sources returned.` note when citations are absent.

Validation:
- `node --test test/web-search-answer-render.test.mjs`
- `npm test` (81 tests)
- `git diff --check`
- `npm pack --dry-run`
- fresh reviewer approved