### PR TITLE
Hoist curator fallback helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Kept oversized local videos recognizable for ffmpeg frame/timestamp extraction while preserving the Gemini analysis upload size limit. Thanks @Xandaar for reporting #135.
 - Declared `typebox` as a regular runtime dependency so clean/global installs can load the extension without relying on Pi or Feynman to provide that peer. Thanks @DuskyElf, @tonytziorvas, and @53able for reporting #59, #63, and #66.
 - Preserved OpenAI/Codex answers even when the provider returns no source citations instead of replacing them with `No results found`. Thanks AstroHan (@Astro-Han) for reporting #117.
+- Prevented browser auto-open failures from crashing the curator fallback path with `ReferenceError: sendCuratorFallbackUpdate is not defined`. Thanks Nisarg Patel (@pnisarg) for PR #121; Apostol Apostolov (@apoapostolov), @2seoik, and Demetre Dzmanashvili (@demetere) for related PRs #133, #120, and #114; and @ruanlinxin, @bluewatercg, @tonydiep, and @pinion05 for reports #103, #116, #126, and #127.
 - Added a focused SSRF error hint for TUN/fake-IP `198.18.0.0/15` addresses that points users to the existing `ssrf.allowRanges` opt-in. Thanks Aaron (@BenjaminAaron196) for PR #141 and AstroHan (@Astro-Han) for reporting #134.
 - Registered the web activity widget as a Pi component factory instead of passing a `Text` instance directly. Thanks Trey Hoover (@treyhoover) for PR #132.
 

--- a/index.ts
+++ b/index.ts
@@ -978,6 +978,20 @@ export default function (pi: ExtensionAPI) {
 	async function openCuratorBrowser(callId: string, pc: PendingCurate, searchesComplete = true): Promise<void> {
 		if (pendingCurates.get(callId) !== pc) return;
 		let handle: CuratorServerHandle | null = null;
+		const sendCuratorFallbackUpdate = (message: string) => {
+			if (!handle) return;
+			pc.onUpdate?.({
+				content: [{ type: "text", text: `${message}\nOpen manually: ${handle.url}` }],
+				details: {
+					phase: "curator-fallback",
+					progress: searchesComplete ? 1 : 0.5,
+					curatorUrl: handle.url,
+					timeoutSeconds: pc.timeoutSeconds,
+					shortcut: curateKey,
+					browserOpenError: pc.browserOpenError,
+				},
+			});
+		};
 		try {
 			pc.phase = "curating";
 
@@ -1149,20 +1163,6 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 			if (searchesComplete) handle.searchesDone();
-
-			const sendCuratorFallbackUpdate = (message: string) => {
-				pc.onUpdate?.({
-					content: [{ type: "text", text: `${message}\nOpen manually: ${handle.url}` }],
-					details: {
-						phase: "curator-fallback",
-						progress: searchesComplete ? 1 : 0.5,
-						curatorUrl: handle.url,
-						timeoutSeconds: pc.timeoutSeconds,
-						shortcut: curateKey,
-						browserOpenError: pc.browserOpenError,
-					},
-				});
-			};
 
 			pc.onUpdate?.({
 				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],

--- a/test/curator-fallback.test.mjs
+++ b/test/curator-fallback.test.mjs
@@ -14,6 +14,19 @@ test("web_search curator auto-open failures keep the curator alive with a manual
 	assert.doesNotMatch(indexSrc, /Failed to open curator UI: \$\{message\}`\);\n\t\t\tif \(pendingCurates\.get\(callId\) === pc \|\| \(handle && activeCurators\.get\(callId\) === handle\)\) \{\n\t\t\t\tcloseCurator\(callId\);/);
 });
 
+test("curator fallback helper is visible to the browser-open catch block", () => {
+	const functionIndex = indexSrc.indexOf("async function openCuratorBrowser");
+	const declarationIndex = indexSrc.indexOf("const sendCuratorFallbackUpdate", functionIndex);
+	const tryIndex = indexSrc.indexOf("\n\t\ttry {\n\t\t\tpc.phase = \"curating\";", functionIndex);
+	const catchCallIndex = indexSrc.indexOf("sendCuratorFallbackUpdate(\"Search curator is running, but the browser did not open automatically.\")", tryIndex);
+
+	assert.ok(functionIndex >= 0);
+	assert.ok(declarationIndex > functionIndex);
+	assert.ok(tryIndex > declarationIndex, "fallback helper must be declared before the try block so catch can call it");
+	assert.ok(catchCallIndex > tryIndex);
+	assert.match(indexSrc.slice(declarationIndex, tryIndex), /if \(!handle\) return;/);
+});
+
 test("cancel diagnostics include curator URL and browser-open error", () => {
 	assert.match(indexSrc, /curatorUrl\?: string;/);
 	assert.match(indexSrc, /browserOpenError\?: string;/);


### PR DESCRIPTION
Fixes #103, #116, #126, and #127. Supersedes #114, #120, #121, and #133.

The browser-open fallback path started the curator server successfully, then crashed in the recovery branch because `sendCuratorFallbackUpdate` was scoped inside the `try` block but called from the sibling `catch`. This hoists the helper to the `openCuratorBrowser` function scope, keeps a null guard for setup failures, and adds a regression test that fails if the helper is no longer visible to the catch block.

Validation:
- `node --test test/curator-fallback.test.mjs`
- `npm test` (82 tests)
- `git diff --check`
- `npm pack --dry-run`
- fresh reviewer approved