### PR TITLE
Support Promise.try and quiet PDF.js extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Deferred the heavy content extraction module until the first `fetch_content` or `includeContent` search call, reducing extension startup work. Thanks Kaushik Gopal (@kaushikgopal) for PR #125.
 
 ### Fixed
+- Kept PDF extraction compatible with runtimes without native `Promise.try` and limited PDF.js output to errors. Thanks Guido Witt-Dörring (@guwidoe) for PRs #33 and #34.
 - Returned fetched URL content from `get_search_content` in bounded slices with explicit `offset`/`limit` continuation metadata, preventing large stored pages from overflowing the next model request. Thanks @manfredlift for reporting #112.
 - Kept oversized local videos recognizable for ffmpeg frame/timestamp extraction while preserving the Gemini analysis upload size limit. Thanks @Xandaar for reporting #135.
 - Declared `typebox` as a regular runtime dependency so clean/global installs can load the extension without relying on Pi or Feynman to provide that peer. Thanks @DuskyElf, @tonytziorvas, and @53able for reporting #59, #63, and #66.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@mozilla/readability": "^0.6.0",
     "linkedom": "^0.16.0",
     "p-limit": "^6.1.0",
+    "promise.try": "^2.0.1",
     "turndown": "^7.2.0",
     "typebox": "^1.1.38",
     "unpdf": "^1.6.2"

--- a/pdf-extract.ts
+++ b/pdf-extract.ts
@@ -5,7 +5,6 @@
  * Uses unpdf (pdfjs-dist wrapper) for text extraction.
  */
 
-import { getDocumentProxy } from "unpdf";
 import { writeFile, mkdir } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { homedir } from "node:os";
@@ -26,6 +25,21 @@ export interface PDFExtractOptions {
 const DEFAULT_MAX_PAGES = 100;
 const DEFAULT_OUTPUT_DIR = join(homedir(), "Downloads");
 
+async function getUnpdf() {
+  if (typeof (Promise as PromiseConstructor & { try?: unknown }).try !== "function") {
+    const { default: promiseTry } = await import("promise.try");
+    promiseTry.shim();
+  }
+
+  const [unpdf, pdfjs] = await Promise.all([
+    import("unpdf"),
+    import("unpdf/pdfjs"),
+  ]);
+  const { VerbosityLevel } = pdfjs as typeof pdfjs & { VerbosityLevel: { ERRORS: number } };
+
+  return { getDocumentProxy: unpdf.getDocumentProxy, VerbosityLevel };
+}
+
 /**
  * Extract text from a PDF buffer and save to markdown file
  */
@@ -44,7 +58,10 @@ export async function extractPDFToMarkdown(
     ? Math.max(1, Math.floor(maxPages))
     : DEFAULT_MAX_PAGES;
 
-  const pdf = await getDocumentProxy(new Uint8Array(buffer));
+  const { getDocumentProxy, VerbosityLevel } = await getUnpdf();
+  const pdf = await getDocumentProxy(new Uint8Array(buffer), {
+    verbosity: VerbosityLevel.ERRORS,
+  });
   const metadata = await pdf.getMetadata();
   const metadataInfo = metadata.info && typeof metadata.info === "object"
     ? metadata.info as Record<string, unknown>

--- a/test/pdf-extract.test.mjs
+++ b/test/pdf-extract.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { test } from "node:test";
+
+const require = createRequire(import.meta.url);
 
 const extractorUrl = new URL("../pdf-extract.ts", import.meta.url).href;
 
@@ -20,7 +27,66 @@ test("extractPDFToMarkdown works on Node 22 without native Promise.try", () => {
   assert.match(child.stdout, /Hello PDF/);
 });
 
-function buildChildScript(moduleUrl) {
+test("extractPDFToMarkdown passes PDF.js errors-only verbosity", () => {
+  const loaderDir = mkdtempSync(join(tmpdir(), "pi-web-access-pdf-loader-"));
+  const loaderPath = join(loaderDir, "unpdf-loader.mjs");
+  writeFileSync(loaderPath, buildUnpdfLoader());
+
+  try {
+    const child = spawnSync(
+      process.execPath,
+      ["--experimental-loader", loaderPath, "--input-type=module"],
+      {
+        input: buildChildScript(extractorUrl, true),
+        encoding: "utf8",
+        maxBuffer: 2 * 1024 * 1024,
+      },
+    );
+
+    assert.equal(
+      child.status,
+      0,
+      "PDF verbosity assertion failed in a child process. stderr summary:\n" + errorSummary(child.stderr),
+    );
+
+    const options = JSON.parse(child.stdout.trim().split("\n").at(-1));
+    assert.equal(options.verbosity, 0);
+  } finally {
+    rmSync(loaderDir, { recursive: true, force: true });
+  }
+});
+
+function buildUnpdfLoader() {
+  const unpdfUrl = pathToFileURL(require.resolve("unpdf")).href;
+  return `
+    const unpdfUrl = ${JSON.stringify(unpdfUrl)};
+
+    export function resolve(specifier, context, nextResolve) {
+      if (specifier === "unpdf") {
+        return { url: "pi-web-access:test-unpdf", shortCircuit: true };
+      }
+      return nextResolve(specifier, context);
+    }
+
+    export async function load(url, context, nextLoad) {
+      if (url === "pi-web-access:test-unpdf") {
+        return {
+          format: "module",
+          shortCircuit: true,
+          source:
+            "import * as unpdf from " + JSON.stringify(unpdfUrl) + ";" +
+            "export const getDocumentProxy = (...args) => {" +
+            "  globalThis.__piWebAccessUnpdfOptions = args[1];" +
+            "  return unpdf.getDocumentProxy(...args);" +
+            "};",
+        };
+      }
+      return nextLoad(url, context);
+    }
+  `;
+}
+
+function buildChildScript(moduleUrl, printOptions = false) {
   return `
     import { mkdtemp, readFile } from "node:fs/promises";
     import { tmpdir } from "node:os";
@@ -50,6 +116,7 @@ function buildChildScript(moduleUrl) {
     );
 
     console.log(await readFile(result.outputPath, "utf8"));
+    ${printOptions ? "console.log(JSON.stringify(globalThis.__piWebAccessUnpdfOptions));" : ""}
 
     function makePdf(text) {
       const content = "BT /F1 24 Tf 72 720 Td (" + text + ") Tj ET";


### PR DESCRIPTION
Supersedes #33 and #34.

This combines the two PDF fixes on current main without taking the stale package/test-runner changes from the original branches:

- shim `Promise.try` before loading `unpdf` so runtimes without native `Promise.try` can still extract PDFs
- pass PDF.js `VerbosityLevel.ERRORS` into `getDocumentProxy` to suppress noisy warnings
- keep the existing `node --test` suite and package policy, adding only the `promise.try` runtime dependency

Validation:
- `node --test test/pdf-extract.test.mjs`
- `npx --yes tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --allowImportingTsExtensions --skipLibCheck pdf-extract.ts`
- `npm test` (83 tests)
- `git diff --check origin/main...HEAD`
- `npm pack --dry-run`
- fresh reviewer approved; follow-up nits were addressed before publication