### PR TITLE
Cover disabled GitHub extraction specialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Updated the `librarian` skill to use verified, session-scoped clone paths returned by `fetch_content` instead of assuming `/tmp/pi-github-repos`, and to refetch missing clones. Thanks mcwalrus (@mcwalrus) for #136 and gravewhisper (@gravewhisper) for #23.
 - Used `gemini-2.5-flash` as the Gemini API grounded-search default while preserving configured `searchModel` values and the shared URL/video defaults. Thanks lajarre for reporting #11.
 - Used the configured search provider when tool calls omit `provider` or emit the schema's `auto` default, while preserving explicit provider overrides and auto fallback without configuration. Thanks Pavlo (@fxposter) for reporting #17.
+- Clarified that `githubClone.enabled: false` disables GitHub clone/API specialization while leaving generic URL extraction available. Thanks Carlos Peralta (@cperalt) for issue #26.
 - Kept PDF extraction compatible with runtimes without native `Promise.try` and limited PDF.js output to errors. Thanks Guido Witt-Dörring (@guwidoe) for PRs #33 and #34.
 - Returned fetched URL content from `get_search_content` in bounded slices with explicit `offset`/`limit` continuation metadata, preventing large stored pages from overflowing the next model request. Thanks @manfredlift for reporting #112.
 - Kept oversized local videos recognizable for ffmpeg frame/timestamp extraction while preserving the Gemini analysis upload size limit. Thanks @Xandaar for reporting #135.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ get_search_content({ responseId: "abc123", query: "original query" })
 
 GitHub URLs are cloned locally instead of scraped. The agent gets real file contents and a local path to explore with `read` and `bash`. Root URLs return the repo tree + README, `/tree/` paths return directory listings, `/blob/` paths return file contents.
 
-Repos over 350MB get a lightweight API-based view instead of a full clone (override with `forceClone: true`). Commit SHA URLs are handled via the API. Clones are cached for the session and wiped on session change. Private repos require the `gh` CLI.
+Repos over 350MB get a lightweight API-based view instead of a full clone (override with `forceClone: true`). Commit SHA URLs are handled via the API. Clones are cached for the session and wiped on session change. Private repos require the `gh` CLI. Set `githubClone.enabled` to `false` to skip this GitHub-specific clone/API handling; `fetch_content` remains available, so the URL can continue through the normal HTTP extraction path.
 
 ### YouTube videos
 
@@ -307,7 +307,7 @@ Both shortcuts are configurable via `~/.pi/web-search.json`:
 
 Values use the same format as pi keybindings (e.g. `ctrl+s`, `ctrl+shift+s`, `alt+r`). Changes take effect on next pi restart.
 
-Set `"enabled": false` under any feature to disable it. Config changes require a Pi restart.
+Set `"enabled": false` under any feature to disable it. For GitHub specifically, `githubClone.enabled: false` only skips clone/API specialization; it does not unregister `fetch_content` or block generic URL extraction. Config changes require a Pi restart.
 
 Rate limits: Perplexity is capped at 10 requests/minute (client-side). Content fetches run 3 concurrent with a 30s timeout per URL.
 

--- a/test/github-extract.test.mjs
+++ b/test/github-extract.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const extractModuleUrl = new URL("../github-extract.ts", import.meta.url).href;
+
+test("githubClone.enabled false skips GitHub clone/API specialization", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-github-disabled-"));
+	const agentDir = join(root, "agent-dir");
+	await mkdir(agentDir, { recursive: true });
+	await writeFile(
+		join(agentDir, "web-search.json"),
+		JSON.stringify({ githubClone: { enabled: false } }),
+		"utf8",
+	);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/owner/repo");
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: {
+			...process.env,
+			PI_CODING_AGENT_DIR: agentDir,
+		},
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(JSON.parse(child.stdout), null);
+});


### PR DESCRIPTION
Fixes #26.

This adds a regression test for `githubClone.enabled: false` and clarifies the README boundary: the setting disables GitHub clone/API specialization, but `fetch_content` stays registered and generic URL extraction can still handle GitHub URLs.

This does not implement opensrc support from #36; that should remain separate.

Validation:
- `node --test test/github-extract.test.mjs`
- `npm test` (92 tests)
- `git diff --check`
- `npm pack --dry-run`
- fresh reviewer approved after rebasing the stale changelog hunk
