### PR TITLE
Harden curator summary generation deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Send direct Gemini API credentials in `x-goog-api-key` headers for generate, upload, status, and delete requests instead of URL query parameters.
 
 ### Fixed
+- Bounded curator summary-model generation and returned a deterministic, phase-labeled fallback when a draft exceeds its deadline, while preserving caller cancellation and model-resolution errors. Thanks torn1147 (@torn1147) for reporting #43.
 - Updated the `librarian` skill to use verified, session-scoped clone paths returned by `fetch_content` instead of assuming `/tmp/pi-github-repos`, and to refetch missing clones. Thanks mcwalrus (@mcwalrus) for #136 and gravewhisper (@gravewhisper) for #23.
 - Used `gemini-2.5-flash` as the Gemini API grounded-search default while preserving configured `searchModel` values and the shared URL/video defaults. Thanks lajarre for reporting #11.
 - Used the configured search provider when tool calls omit `provider` or emit the schema's `auto` default, while preserving explicit provider overrides and auto fallback without configuration. Thanks Pavlo (@fxposter) for reporting #17.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
 }
 ```
 
-In `auto` mode (default), `web_search` tries OpenAI when suitable and available, then Exa (direct API if keyed, MCP if not), Brave, Parallel, Tavily, Perplexity, Gemini API, then Gemini Web when browser-cookie access is enabled.
+In `auto` mode (default), `web_search` tries OpenAI when suitable and available, then Exa (direct API if keyed, MCP if not), Brave, Parallel, Tavily, Perplexity, Gemini API, then Gemini Web when browser-cookie access is enabled. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
 
 For sandboxed networks that provide outbound proxy transport through environment variables, set `ssrf.trustEnvProxy` to `true` to skip local DNS preflight for proxied hostnames:
 

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -1935,7 +1935,9 @@ const SCRIPT = `(function() {
           ? "Summarizing " + selLabel + " with " + summaryPendingModel + "…"
           : "Summarizing " + selLabel + "…";
       } else if (summaryMeta && summaryMeta.fallbackUsed) {
-        summarySubtitle.textContent = "Fallback summary of " + selLabel + ".";
+        var fallbackLabel = summaryMeta.phase === "deterministic-fallback" ? "Deterministic fallback summary" : "Fallback summary";
+        var fallbackReason = summaryMeta.fallbackReason ? " Reason: " + summaryMeta.fallbackReason + "." : "";
+        summarySubtitle.textContent = fallbackLabel + " of " + selLabel + "." + fallbackReason;
       } else {
         summarySubtitle.textContent = "Summary of " + selLabel + ". Edit directly, regenerate with feedback, or approve.";
       }
@@ -2826,6 +2828,7 @@ const SCRIPT = `(function() {
       tokenEstimate: typeof meta.tokenEstimate === "number" && Number.isFinite(meta.tokenEstimate) && meta.tokenEstimate >= 0 ? meta.tokenEstimate : 0,
       fallbackUsed: meta.fallbackUsed === true,
       fallbackReason: typeof meta.fallbackReason === "string" ? meta.fallbackReason : undefined,
+      phase: meta.phase === "summary-model" || meta.phase === "deterministic-fallback" ? meta.phase : undefined,
       edited: !!edited,
     };
   }

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -147,6 +147,9 @@ function normalizeSummaryMeta(value: unknown): SummaryMeta | null {
 	const fallbackReason = meta.fallbackReason;
 	if (fallbackReason !== undefined && typeof fallbackReason !== "string") return null;
 
+	const phase = meta.phase;
+	if (phase !== undefined && phase !== "summary-model" && phase !== "deterministic-fallback") return null;
+
 	const edited = meta.edited;
 	if (edited !== undefined && typeof edited !== "boolean") return null;
 
@@ -156,6 +159,7 @@ function normalizeSummaryMeta(value: unknown): SummaryMeta | null {
 		tokenEstimate,
 		fallbackUsed,
 		fallbackReason,
+		phase,
 		edited,
 	};
 }

--- a/index.ts
+++ b/index.ts
@@ -668,6 +668,7 @@ export default function (pi: ExtensionAPI) {
 				: (normalizedText.length > 0 ? Math.max(1, Math.ceil(normalizedText.length / 4)) : 0),
 			fallbackUsed: meta.fallbackUsed === true,
 			fallbackReason: meta.fallbackReason,
+			phase: meta.phase,
 			edited: meta.edited === true,
 		};
 	}
@@ -949,6 +950,7 @@ export default function (pi: ExtensionAPI) {
 							tokenEstimate: opts.summaryMeta?.tokenEstimate ?? 0,
 							fallbackUsed: opts.summaryMeta?.fallbackUsed === true,
 							fallbackReason: opts.summaryMeta?.fallbackReason,
+							phase: opts.summaryMeta?.phase,
 							edited: opts.summaryMeta?.edited === true,
 						},
 					}
@@ -1617,6 +1619,7 @@ export default function (pi: ExtensionAPI) {
 					tokenEstimate: number;
 					fallbackUsed: boolean;
 					fallbackReason?: string;
+					phase?: "summary-model" | "deterministic-fallback";
 					edited?: boolean;
 				};
 			};
@@ -1697,12 +1700,13 @@ export default function (pi: ExtensionAPI) {
 					`duration=${details.summary.durationMs}ms`,
 					`tokens~${details.summary.tokenEstimate}`,
 					details.summary.fallbackUsed ? "fallback=true" : "fallback=false",
+					details.summary.phase ? `phase=${details.summary.phase}` : "",
 					details.summary.edited ? "edited=true" : "edited=false",
 				];
 				if (details.summary.fallbackReason) {
 					metaParts.push(`reason=${details.summary.fallbackReason}`);
 				}
-				lines.push(theme.fg("dim", "  " + metaParts.join(" · ")));
+				lines.push(theme.fg("dim", "  " + metaParts.filter(Boolean).join(" · ")));
 			}
 
 			const queryDetails = details?.curatedQueries;

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -8,12 +8,15 @@ const PREFERRED_SUMMARY_MODELS = [
 	{ provider: "openai-codex", id: "gpt-5.3-codex-spark" },
 ] as const;
 
+export const SUMMARY_GENERATION_DEADLINE_MS = 30_000;
+
 export interface SummaryMeta {
 	model: string | null;
 	durationMs: number;
 	tokenEstimate: number;
 	fallbackUsed: boolean;
 	fallbackReason?: string;
+	phase?: "summary-model" | "deterministic-fallback";
 	edited?: boolean;
 }
 
@@ -173,6 +176,7 @@ export function buildDeterministicSummary(results: QueryResultData[]): { summary
 			tokenEstimate: estimateTokens(nonEmptySummary),
 			fallbackUsed: true,
 			fallbackReason: "deterministic-submit-fallback",
+			phase: "deterministic-fallback",
 			edited: false,
 		},
 	};
@@ -226,12 +230,17 @@ async function resolveSummaryModelCandidates(
 	return { candidates, errors };
 }
 
-function buildFallbackSummary(results: QueryResultData[], fallbackReason: string): { summary: string; meta: SummaryMeta } {
+function buildFallbackSummary(
+	results: QueryResultData[],
+	fallbackReason: string,
+	durationMs = 0,
+): { summary: string; meta: SummaryMeta } {
 	const deterministic = buildDeterministicSummary(results);
 	return {
 		summary: deterministic.summary,
 		meta: {
 			...deterministic.meta,
+			durationMs,
 			fallbackReason,
 		},
 	};
@@ -264,63 +273,127 @@ export async function generateSummaryDraft(
 	signal?: AbortSignal,
 	modelOverride?: string,
 	feedback?: string,
+	completeFn: typeof complete = complete,
+	deadlineMs = SUMMARY_GENERATION_DEADLINE_MS,
 ): Promise<{ summary: string; meta: SummaryMeta }> {
 	if (!ctx || !ctx.modelRegistry) {
 		throw new Error("Summary generation context unavailable");
 	}
 
-	const prompt = buildSummaryPrompt(results, feedback);
-	let resolved: Awaited<ReturnType<typeof resolveSummaryModelCandidates>>;
-	try {
-		resolved = await resolveSummaryModelCandidates(ctx, modelOverride);
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		return buildFallbackSummary(results, `summary-model-settings-error: ${message}`);
-	}
+	const generationStartedAt = Date.now();
+	const deadlineController = new AbortController();
+	const deadlineMarker = Symbol("summary-generation-deadline");
+	let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+	let resolveDeadline!: () => void;
+	const deadlinePromise = new Promise<typeof deadlineMarker>(resolve => {
+		resolveDeadline = () => resolve(deadlineMarker);
+		deadlineTimer = setTimeout(() => {
+			deadlineController.abort();
+			resolveDeadline();
+		}, deadlineMs);
+	});
 
-	let lastError = resolved.errors.at(-1);
-	for (const { model, apiKey, headers } of resolved.candidates) {
-		const startedAt = Date.now();
-		try {
-			const userMessage: Message = {
-				role: "user",
-				content: [{ type: "text", text: prompt }],
-				timestamp: Date.now(),
-			};
+	let callerAbortListener: (() => void) | undefined;
+	const callerAbortPromise = signal
+		? new Promise<never>((_, reject) => {
+			callerAbortListener = () => reject(new Error("Aborted"));
+			if (signal.aborted) callerAbortListener();
+			else signal.addEventListener("abort", callerAbortListener, { once: true });
+		})
+		: undefined;
+	const completionSignal = signal
+		? AbortSignal.any([signal, deadlineController.signal])
+		: deadlineController.signal;
 
-			const response = await complete(model, { messages: [userMessage] }, { apiKey, headers, signal });
-			if (response.stopReason === "aborted") {
-				throw new Error("Aborted");
-			}
-
-			const contentParts = Array.isArray(response.content) ? response.content : [];
-			const summary = contentParts
-				.map(part => getTextFromContentPart(part))
-				.filter(text => text.trim().length > 0)
-				.join("\n")
-				.trim();
-
-			if (summary.length === 0) {
-				const partTypes = contentParts.map(part => getContentPartType(part));
-				const typesLabel = partTypes.length > 0 ? partTypes.join(", ") : "none";
-				throw new Error(`Summary model returned empty response (content parts: ${typesLabel})`);
-			}
-
-			return {
-				summary,
-				meta: {
-					model: `${model.provider}/${model.id}`,
-					durationMs: Math.max(0, Date.now() - startedAt),
-					tokenEstimate: estimateTokens(summary),
-					fallbackUsed: false,
-					edited: false,
-				},
-			};
-		} catch (err) {
-			if (isAbortError(err)) throw err;
-			lastError = err instanceof Error ? err.message : String(err);
+	async function raceSummaryOperation<T>(operation: Promise<T>): Promise<T> {
+		// A provider may ignore AbortSignal and never settle; observe it before racing so
+		// its eventual rejection cannot become an unhandled promise rejection.
+		void operation.then(() => undefined, () => undefined);
+		const contenders: Promise<unknown>[] = [operation, deadlinePromise];
+		if (callerAbortPromise) contenders.push(callerAbortPromise);
+		const result = await Promise.race(contenders);
+		if (result === deadlineMarker) {
+			if (signal?.aborted) throw new Error("Aborted");
+			throw deadlineMarker;
 		}
+		return result as T;
 	}
 
-	return buildFallbackSummary(results, lastError ? `summary-model-unavailable: ${lastError}` : "summary-model-unavailable");
+	try {
+		if (signal?.aborted) throw new Error("Aborted");
+		const prompt = buildSummaryPrompt(results, feedback);
+		let resolved: Awaited<ReturnType<typeof resolveSummaryModelCandidates>>;
+		try {
+			resolved = await raceSummaryOperation(resolveSummaryModelCandidates(ctx, modelOverride));
+		} catch (err) {
+			if (signal?.aborted) throw new Error("Aborted");
+			if (err === deadlineMarker || deadlineController.signal.aborted) {
+				return buildFallbackSummary(results, "summary-generation-timeout", Date.now() - generationStartedAt);
+			}
+			const message = err instanceof Error ? err.message : String(err);
+			return buildFallbackSummary(results, `summary-model-settings-error: ${message}`, Date.now() - generationStartedAt);
+		}
+
+		let lastError = resolved.errors.at(-1);
+		for (const { model, apiKey, headers } of resolved.candidates) {
+			const startedAt = Date.now();
+			try {
+				const userMessage: Message = {
+					role: "user",
+					content: [{ type: "text", text: prompt }],
+					timestamp: Date.now(),
+				};
+
+				const response = await raceSummaryOperation(Promise.resolve(completeFn(
+					model,
+					{ messages: [userMessage] },
+					{ apiKey, headers, signal: completionSignal },
+				)));
+				if (response.stopReason === "aborted") {
+					throw new Error("Aborted");
+				}
+
+				const contentParts = Array.isArray(response.content) ? response.content : [];
+				const summary = contentParts
+					.map(part => getTextFromContentPart(part))
+					.filter(text => text.trim().length > 0)
+					.join("\n")
+					.trim();
+
+				if (summary.length === 0) {
+					const partTypes = contentParts.map(part => getContentPartType(part));
+					const typesLabel = partTypes.length > 0 ? partTypes.join(", ") : "none";
+					throw new Error(`Summary model returned empty response (content parts: ${typesLabel})`);
+				}
+
+				return {
+					summary,
+					meta: {
+						model: `${model.provider}/${model.id}`,
+						durationMs: Math.max(0, Date.now() - startedAt),
+						tokenEstimate: estimateTokens(summary),
+						fallbackUsed: false,
+						phase: "summary-model",
+						edited: false,
+					},
+				};
+			} catch (err) {
+				if (signal?.aborted) throw new Error("Aborted");
+				if (err === deadlineMarker || deadlineController.signal.aborted) {
+					return buildFallbackSummary(results, "summary-generation-timeout", Date.now() - generationStartedAt);
+				}
+				if (isAbortError(err)) throw err;
+				lastError = err instanceof Error ? err.message : String(err);
+			}
+		}
+
+		return buildFallbackSummary(
+			results,
+			lastError ? `summary-model-unavailable: ${lastError}` : "summary-model-unavailable",
+			Date.now() - generationStartedAt,
+		);
+	} finally {
+		if (deadlineTimer) clearTimeout(deadlineTimer);
+		if (signal && callerAbortListener) signal.removeEventListener("abort", callerAbortListener);
+	}
 }

--- a/test/summary-model-scope.test.mjs
+++ b/test/summary-model-scope.test.mjs
@@ -3,12 +3,107 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import { after, test } from "node:test";
 
 import { loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "../summary-model-scope.ts";
+import { generateSummaryDraft, SUMMARY_GENERATION_DEADLINE_MS } from "../summary-review.ts";
 
 const indexSrc = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
 const summarySrc = readFileSync(new URL("../summary-review.ts", import.meta.url), "utf8");
+
+function summaryContext() {
+	const model = { provider: "anthropic", id: "claude-haiku-4-5" };
+	return {
+		modelRegistry: {
+			find: () => model,
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-key" }),
+		},
+		cwd: process.cwd(),
+		isProjectTrusted: () => false,
+	};
+}
+
+const summaryResults = [{
+	query: "test query",
+	answer: "A test answer.",
+	results: [{ title: "Test source", url: "https://example.com" }],
+	error: null,
+	provider: "test",
+}];
+
+const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+const testAgentDir = await mkdtemp(join(tmpdir(), "pi-web-access-summary-deadline-"));
+await writeFile(join(testAgentDir, "settings.json"), JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }));
+process.env.PI_CODING_AGENT_DIR = testAgentDir;
+after(() => {
+	if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+});
+
+test("never-settling summary completion returns a deterministic deadline fallback", async () => {
+	let completionSignal;
+	const neverSettles = new Promise(() => {});
+	const startedAt = Date.now();
+	const result = await generateSummaryDraft(
+		summaryResults,
+		summaryContext(),
+		undefined,
+		undefined,
+		undefined,
+		(_model, _request, options) => {
+			completionSignal = options.signal;
+			return neverSettles;
+		},
+		20,
+	);
+
+	assert.ok(Date.now() - startedAt < 500);
+	assert.equal(result.meta.fallbackUsed, true);
+	assert.equal(result.meta.fallbackReason, "summary-generation-timeout");
+	assert.equal(result.meta.phase, "deterministic-fallback");
+	assert.equal(completionSignal.aborted, true);
+});
+
+test("model resolution errors after the deadline return timeout fallback", async () => {
+	const context = summaryContext();
+	context.modelRegistry.getApiKeyAndHeaders = async () => {
+		await new Promise(resolve => setTimeout(resolve, 30));
+		throw new Error("late auth failure");
+	};
+
+	const result = await generateSummaryDraft(
+		summaryResults,
+		context,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		10,
+	);
+
+	assert.equal(result.meta.fallbackUsed, true);
+	assert.equal(result.meta.fallbackReason, "summary-generation-timeout");
+	assert.equal(result.meta.phase, "deterministic-fallback");
+});
+
+test("caller abort takes precedence over a pending summary completion", async () => {
+	const controller = new AbortController();
+	const neverSettles = new Promise(() => {});
+	setTimeout(() => controller.abort(), 10);
+
+	await assert.rejects(
+		() => generateSummaryDraft(
+			summaryResults,
+			summaryContext(),
+			controller.signal,
+			undefined,
+			undefined,
+			() => neverSettles,
+			1000,
+		),
+		/Aborted/,
+	);
+});
 
 test("summary model scope matches nested provider model ids and thinking suffixes", () => {
 	assert.equal(
@@ -59,6 +154,13 @@ test("enabledModels loading uses trusted project settings over global settings",
 			process.env.PI_CODING_AGENT_DIR = previous;
 		}
 	}
+});
+
+test("summary generation has a hard deadline and preserves caller cancellation", () => {
+	assert.equal(SUMMARY_GENERATION_DEADLINE_MS, 30_000);
+	assert.match(summarySrc, /Promise\.race\(contenders\)/);
+	assert.match(summarySrc, /deadlineController\.abort\(\)/);
+	assert.match(summarySrc, /void operation\.then\(\(\) => undefined, \(\) => undefined\)/);
 });
 
 test("summary generation no longer uses catalog fallback or first available model", () => {


### PR DESCRIPTION
Fixes #43.

This makes curator summary generation use a hard 30-second deadline for the full draft operation. The deadline starts before model resolution, races model resolution and provider completion, aborts provider work when it fires, and returns the deterministic fallback without waiting for providers that ignore abort. Caller cancellation still wins over local timeout, and normal settings/auth/model errors keep their existing fallback context.

The curator UI now surfaces deterministic fallback phase/reason metadata so users can tell whether a model summary or fallback summary was approved.

Validation:
- `node --test test/summary-model-scope.test.mjs test/curator-server-timeout.test.mjs`
- `npm test` (116 tests)
- `git diff --check`
- `npm pack --dry-run`
- fresh reviewer blocked one model-resolution deadline race; fixed with a regression before landing
