### PR TITLE
Add source check research artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Added request-time `$ENV_VAR` and `!command` credential sources for Exa and Gemini API configuration, with bounded output, redacted failures, strict source precedence, and shell-local 1Password session forwarding limited to the resolver command. Thanks to Ezra Miller (@ezmill) for #137.
+- Added `source_check` machine-readable research artifacts with passage-level provenance, bounded page fetching, durable session retrieval, and conservative claim assessments. Thanks Clark Everson (@gr3enarr0w) for PR #111 and issue #108.
 
 ### Changed
 - Deferred the heavy content extraction module until the first `fetch_content` or `includeContent` search call, reducing extension startup work. Thanks Kaushik Gopal (@kaushikgopal) for PR #125.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ get_search_content({ responseId: "abc123", url: "https://...", offset: 30000 })
 get_search_content({ responseId: "abc123", query: "original query" })
 ```
 
+### source_check
+
+Check a claim and return a machine-readable artifact with exact passage citations. Search results are deduplicated and capped at 20 sources; `fetchContent` fetches at most 5 pages, while stored and retrieved content remains subject to the existing 30,000-character `offset`/`limit` bounds.
+
+```typescript
+source_check({ claim: "The API supports streaming responses" })
+source_check({
+  claim: "The API supports streaming responses",
+  queries: ["API streaming responses documentation", "API streaming limitations"],
+  fetchContent: true,
+  domainFilter: ["docs.example.com", "-old.example.com"]
+})
+```
+
+The artifact includes `supported`, `contradicted`, `unclear`, or `missing-evidence` claim status, source quality hints, SHA-256 content hashes, and passage IDs with exact source offsets. Search and fetch errors remain in the artifact instead of being silently discarded. Artifacts are stored with the session and retrieved through `get_search_content` using the returned `responseId`; paged artifact responses are JSON slices, so request the next `offset` when needed.
+
 ## Capabilities
 
 ### GitHub repos

--- a/index.ts
+++ b/index.ts
@@ -44,6 +44,13 @@ import { isParallelAvailable } from "./parallel.ts";
 import { isTavilyAvailable } from "./tavily.ts";
 import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
 import { loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
+import {
+	buildResearchArtifact,
+	withClaimAssessment,
+	storeResearchArtifact,
+	getResearchArtifact,
+	type ResearchArtifact,
+} from "./source-check.ts";
 
 const WEB_SEARCH_CONFIG_PATH = getWebSearchConfigPath();
 
@@ -55,6 +62,10 @@ async function fetchAllContent(
 ): Promise<ExtractedContent[]> {
 	const extractModule = await (extractModulePromise ??= import("./extract.ts"));
 	return extractModule.fetchAllContent(urls, signal, options);
+}
+
+function isAbortError(err: unknown): boolean {
+	return (err instanceof Error ? err.message : String(err)).toLowerCase().includes("abort");
 }
 
 /** Shared collapsed/expanded renderer for an error/cancel plan produced by
@@ -334,6 +345,26 @@ function formatSearchSummary(results: SearchResult[], answer: string): string {
 	let output = answer ? `${answer}\n\n---\n\n**Sources:**\n` : "";
 	output += results.map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}`).join("\n\n");
 	return output;
+}
+
+function formatSourceCheckResult(artifact: ResearchArtifact): string {
+	const assessment = artifact.claims?.[0];
+	const lines = [`# Source check: ${artifact.query}`, ""];
+	if (assessment) {
+		lines.push(`**Status:** ${assessment.status} (confidence ${assessment.confidence.toFixed(2)})`);
+		lines.push(`**Rationale:** ${assessment.rationale}`);
+		if (assessment.supporting_passages.length > 0) lines.push(`**Supporting passages:** ${assessment.supporting_passages.join(", ")}`);
+		if (assessment.contradicting_passages.length > 0) lines.push(`**Contradicting passages:** ${assessment.contradicting_passages.join(", ")}`);
+		lines.push("");
+	}
+	if (artifact.sources.length > 0) {
+		lines.push("## Sources");
+		for (const source of artifact.sources) lines.push(`${source.rank}. [${source.quality}] ${source.title}\n   ${source.url}`);
+		lines.push("");
+	}
+	if (artifact.errors?.length) lines.push(`Search errors: ${artifact.errors.map((entry) => `${entry.query}: ${entry.error}`).join("; ")}`);
+	lines.push(`Artifact responseId: ${artifact.id} (retrievable via get_search_content).`);
+	return lines.join("\n");
 }
 
 function duplicateQuerySet(results: QueryResultData[]): Set<string> {
@@ -1812,6 +1843,102 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
+	if (initConfig.webSearch?.enabled !== false) pi.registerTool({
+		name: "source_check",
+		label: "Source Check",
+		description: "Check a claim against web sources and return a bounded machine-readable research artifact with exact passage citations.",
+		promptSnippet: "Verify a claim with structured source evidence and passage-level citations.",
+		parameters: Type.Object({
+			claim: Type.String({ description: "The assertion to check against web sources." }),
+			queries: Type.Optional(Type.Array(Type.String(), { description: "Search queries (default: the claim)." })),
+			numResults: Type.Optional(Type.Number({ description: "Results per query (default: 5, max: 20)." })),
+			fetchContent: Type.Optional(Type.Boolean({ description: "Fetch up to 5 result pages for exact passage extraction." })),
+			recencyFilter: Type.Optional(StringEnum(["day", "week", "month", "year"], { description: "Filter by recency." })),
+			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains; prefix with - to exclude." })),
+			provider: Type.Optional(StringEnum(["auto", "openai", "brave", "parallel", "tavily", "exa", "perplexity", "gemini"], { description: "Search provider." })),
+		}),
+		async execute(_callId, params, signal, _onUpdate, ctx) {
+			const claim = typeof params.claim === "string" ? params.claim.trim() : "";
+			if (!claim) {
+				return { content: [{ type: "text", text: "Error: 'claim' is required." }], details: { error: "Missing claim" } };
+			}
+
+			const requestedQueries = Array.isArray(params.queries)
+				? params.queries.filter((query): query is string => typeof query === "string").map((query) => query.trim()).filter(Boolean)
+				: [];
+			const queries = (requestedQueries.length > 0 ? requestedQueries : [claim]).slice(0, 8);
+			const numResults = typeof params.numResults === "number" && Number.isFinite(params.numResults)
+				? Math.min(20, Math.max(1, Math.floor(params.numResults)))
+				: 5;
+			const domainFilter = Array.isArray(params.domainFilter)
+				? params.domainFilter.filter((domain): domain is string => typeof domain === "string")
+				: undefined;
+			const resultsByUrl = new Map<string, SearchResult>();
+			const summaries: string[] = [];
+			const errors: Array<{ query: string; error: string }> = [];
+			let provider: string | undefined;
+
+			for (const query of queries) {
+				if (signal?.aborted) break;
+				try {
+					const response = await search(query, {
+						provider: resolveRequestedProvider(params.provider),
+						numResults,
+						recencyFilter: params.recencyFilter,
+						domainFilter,
+						signal,
+						extensionContext: ctx,
+					});
+					if (signal?.aborted) break;
+					provider ??= response.provider;
+					if (response.answer) summaries.push(`${query}: ${response.answer}`);
+					for (const result of response.results) {
+						if (!resultsByUrl.has(result.url)) resultsByUrl.set(result.url, result);
+					}
+				} catch (err) {
+					if (signal?.aborted || isAbortError(err)) break;
+					errors.push({ query, error: err instanceof Error ? err.message : String(err) });
+				}
+			}
+
+			const results = [...resultsByUrl.values()].slice(0, 20).map((result, index) => ({ ...result, rank: index + 1 }));
+			let fetched: ExtractedContent[] = [];
+			if (params.fetchContent && results.length > 0) {
+				const urls = results.slice(0, 5).map((result) => result.url);
+				fetched = (await Promise.all(urls.map(async (url) => {
+					try {
+						const [page] = await fetchAllContent([url], signal);
+						return page;
+					} catch (err) {
+						if (signal?.aborted || isAbortError(err)) throw err;
+						return { url, title: "", content: "", error: err instanceof Error ? err.message : String(err) };
+					}
+				}))).filter((page): page is ExtractedContent => Boolean(page));
+			}
+			const artifact = withClaimAssessment(buildResearchArtifact({
+				query: claim,
+				provider,
+				summary: summaries.length > 0 ? summaries.join("\n\n") : undefined,
+				results,
+				fetched,
+				recency: params.recencyFilter,
+				domainFilter,
+			}), [claim]);
+			if (errors.length > 0) artifact.errors = errors;
+			storeResearchArtifact(artifact);
+			pi.appendEntry("web-search-results", {
+				id: artifact.id,
+				type: "research",
+				timestamp: artifact.timestamp,
+				artifact,
+			});
+			return {
+				content: [{ type: "text", text: formatSourceCheckResult(artifact) }],
+				details: { responseId: artifact.id, artifact, sourceCount: artifact.sources.length, passageCount: artifact.passages.length },
+			};
+		},
+	});
+
 	pi.registerTool({
 		name: "fetch_content",
 		label: "Fetch Content",
@@ -2085,6 +2212,35 @@ export default function (pi: ExtensionAPI) {
 				return {
 					content: [{ type: "text", text: `Error: No stored results for "${params.responseId}"` }],
 					details: { error: "Not found", responseId: params.responseId },
+				};
+			}
+
+			if (data.type === "research") {
+				const artifact = getResearchArtifact(params.responseId);
+				if (!artifact) {
+					return {
+						content: [{ type: "text", text: `Error: artifact ${params.responseId} not found` }],
+						details: { error: "Artifact not found", responseId: params.responseId },
+					};
+				}
+				const serialized = JSON.stringify(artifact, null, 2);
+				const offset = params.offset ?? 0;
+				const limit = params.limit ?? MAX_CONTENT_SLICE_LENGTH;
+				if (!Number.isInteger(offset) || offset < 0) {
+					return { content: [{ type: "text", text: "offset must be a non-negative integer" }], details: { error: "Invalid offset", offset } };
+				}
+				if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_CONTENT_SLICE_LENGTH) {
+					return { content: [{ type: "text", text: `limit must be an integer from 1 to ${MAX_CONTENT_SLICE_LENGTH}` }], details: { error: "Invalid limit", limit, maxLimit: MAX_CONTENT_SLICE_LENGTH } };
+				}
+				if (offset > serialized.length) {
+					return { content: [{ type: "text", text: `offset ${offset} is out of range (0-${serialized.length})` }], details: { error: "Offset out of range", offset, contentLength: serialized.length } };
+				}
+				const endOffset = Math.min(offset + limit, serialized.length);
+				const artifactSlice = serialized.slice(offset, endOffset);
+				const hasMore = endOffset < serialized.length;
+				return {
+					content: [{ type: "text", text: artifactSlice }],
+					details: { responseId: artifact.id, type: "research", contentLength: serialized.length, offset, limit, returnedChars: artifactSlice.length, nextOffset: hasMore ? endOffset : null, truncated: hasMore },
 				};
 			}
 

--- a/source-check.ts
+++ b/source-check.ts
@@ -1,0 +1,279 @@
+// Structured source checking and machine-readable research artifacts.
+import { createHash } from "node:crypto";
+import { generateId, getResult, storeResult } from "./storage.ts";
+import type { SearchResult } from "./perplexity.ts";
+import type { ExtractedContent } from "./extract.ts";
+
+export type SourceQuality = "official_docs" | "vendor_docs" | "repo_issue" | "blog" | "forum" | "news" | "unknown";
+export type ClaimStatus = "supported" | "contradicted" | "unclear" | "missing-evidence";
+export type RecencyFilter = "day" | "week" | "month" | "year";
+
+export interface ResearchSource {
+	rank: number;
+	url: string;
+	title: string;
+	snippet?: string;
+	fetch_timestamp?: number;
+	content_hash?: string;
+	quality: SourceQuality;
+	fetched?: boolean;
+	fetch_error?: string;
+}
+
+export interface ResearchPassage {
+	passage_id: string;
+	source_url: string;
+	source_rank: number;
+	text: string;
+	extraction_span?: { start: number; end: number };
+	content_hash?: string;
+}
+
+export interface ClaimAssessment {
+	claim: string;
+	status: ClaimStatus;
+	supporting_passages: string[];
+	contradicting_passages: string[];
+	rationale: string;
+	confidence: number;
+}
+
+export interface ResearchArtifact {
+	id: string;
+	type: "research";
+	timestamp: number;
+	query: string;
+	sources: ResearchSource[];
+	passages: ResearchPassage[];
+	claims?: ClaimAssessment[];
+	provider?: string;
+	summary?: string;
+	content_hash?: string;
+	filters?: { recency?: RecencyFilter; domain_include?: string[]; domain_exclude?: string[] };
+	errors?: Array<{ query: string; error: string }>;
+}
+
+export interface ResearchSearchRequest {
+	query: string;
+	numResults: number;
+	recencyFilter?: RecencyFilter;
+	domainFilter?: string[];
+}
+export interface ResearchSearchResult { url: string; title: string; snippet: string; rank: number }
+export interface ResearchSearchResponse { provider: string; results: ResearchSearchResult[]; summary?: string }
+export interface ResearchProvider { name: string; search(req: ResearchSearchRequest): Promise<ResearchSearchResponse> }
+
+const OFFICIAL_DOCS_HOSTS = /^(developers\.|docs\.|learn\.|reference\.)|\.github\.io$/i;
+const OFFICIAL_DOCS_PATHS = /\/(docs?|reference)(\/|\b)/i;
+const VENDOR_DOCS_PATHS = /\/(documentation|docs?)\//i;
+const REPO_ISSUE_PATHS = /\/(issues|pull|pulls)\//i;
+const BLOG_HOSTS = /(medium\.com|substack\.com|dev\.to|hashnode\.)/i;
+const BLOG_PATHS = /\/blogs?\//i;
+const FORUM_HOSTS = /(stackoverflow\.com|serverfault\.com|superuser\.com|discourse\.|community\.)/i;
+const FORUM_PATHS = /\/(forum|forums|threads)\//i;
+const NEWS_HOSTS = /(reuters\.com|bloomberg\.com|techcrunch\.com|theverge\.com|arstechnica\.com|wired\.com|cnet\.com|zdnet\.com)/i;
+const NEWS_PATHS = /\/news(\/|$)/i;
+
+export function classifySource(url: string): SourceQuality {
+	let host = "";
+	let path = "";
+	try {
+		const parsed = new URL(url);
+		host = parsed.hostname;
+		path = parsed.pathname;
+	} catch {
+		return "unknown";
+	}
+	if (REPO_ISSUE_PATHS.test(path)) return "repo_issue";
+	if (OFFICIAL_DOCS_HOSTS.test(host) || OFFICIAL_DOCS_PATHS.test(path)) return "official_docs";
+	if (VENDOR_DOCS_PATHS.test(path)) return "vendor_docs";
+	if (NEWS_HOSTS.test(host) || NEWS_PATHS.test(path)) return "news";
+	if (FORUM_HOSTS.test(host) || FORUM_PATHS.test(path)) return "forum";
+	if (BLOG_HOSTS.test(host) || BLOG_PATHS.test(path)) return "blog";
+	return "unknown";
+}
+
+export function hashContent(text: string): string {
+	return `sha256:${createHash("sha256").update(text, "utf8").digest("hex")}`;
+}
+
+interface Span { text: string; start: number; end: number }
+
+function tokenize(value: string): string[] {
+	return [...new Set(value.toLowerCase().split(/[^a-z0-9]+/).filter((term) => term.length > 3))];
+}
+
+function extractRelevantSpans(content: string, hint: string): Span[] {
+	const sentences: Span[] = [];
+	const sentencePattern = /[^.!?]+(?:[.!?]+(?=\s|$)|$)/g;
+	for (const match of content.matchAll(sentencePattern)) {
+		const raw = match[0];
+		const text = raw.trim();
+		if (text.length > 0 && text.length <= 400) {
+			const start = (match.index ?? 0) + raw.indexOf(text);
+			sentences.push({ text, start, end: start + text.length });
+		}
+	}
+	const terms = tokenize(hint);
+	if (terms.length === 0) return [];
+	return sentences
+		.map((sentence, index) => ({ sentence, index, score: terms.filter((term) => sentence.text.toLowerCase().includes(term)).length }))
+		.filter((item) => item.score > 0)
+		.sort((a, b) => b.score - a.score || a.index - b.index)
+		.slice(0, 3)
+		.map(({ sentence }) => sentence);
+}
+
+function passageId(sourceRank: number, index: number): string {
+	return `p-${sourceRank}-${index}`;
+}
+
+export function buildPassages(sources: ResearchSource[], fetched: ExtractedContent[] = [], hint = ""): ResearchPassage[] {
+	const passages: ResearchPassage[] = [];
+	const fetchedByUrl = new Map(fetched.map((item) => [item.url, item]));
+	for (const source of sources) {
+		if (source.snippet) {
+			passages.push({
+				passage_id: passageId(source.rank, 0),
+				source_url: source.url,
+				source_rank: source.rank,
+				text: source.snippet,
+				content_hash: hashContent(source.snippet),
+			});
+		}
+		const page = fetchedByUrl.get(source.url);
+		if (page && !page.error && page.content) {
+			const passageHint = source.snippet?.trim() || hint;
+			for (const [index, span] of extractRelevantSpans(page.content, passageHint).entries()) {
+				passages.push({
+					passage_id: passageId(source.rank, index + 1),
+					source_url: source.url,
+					source_rank: source.rank,
+					text: span.text,
+					extraction_span: { start: span.start, end: span.end },
+					content_hash: hashContent(span.text),
+				});
+			}
+		}
+	}
+	return passages;
+}
+
+const CONTRADICTION_MARKERS = ["not true", "false", "incorrect", "debunked", "retracted", "no longer", "never", "denied", "contrary", "misleading"];
+const SUPPORT_MARKERS = ["yes", "true", "correct", "confirmed", "according to", "shows that", "demonstrates", "reported", "verified", "established"];
+
+function containsPhrase(value: string, phrase: string): boolean {
+	const escaped = phrase.trim().toLowerCase().split(/\s+/).map((term) => term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("\\s+");
+	return new RegExp(`(?:^|[^a-z0-9])${escaped}(?=$|[^a-z0-9])`, "i").test(value);
+}
+
+function markerIsNegated(value: string, marker: string): boolean {
+	const escaped = marker.trim().toLowerCase().split(/\s+/).map((term) => term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("\\s+");
+	const markerPattern = new RegExp(`(?:^|[^a-z0-9])${escaped}(?=$|[^a-z0-9])`, "i");
+	const match = markerPattern.exec(value);
+	if (!match || match.index === undefined) return false;
+	const matchedMarker = match[0].replace(/^[^a-z0-9]+/i, "");
+	const beforeMarker = value.slice(0, match.index + match[0].length - matchedMarker.length);
+	return /(?:^|[^a-z0-9])(?:not|no|never|without)\s+$/i.test(beforeMarker);
+}
+
+function hasPolarityMarker(value: string, markers: string[], allowNegated = false): boolean {
+	return markers.some((marker) => containsPhrase(value, marker) && (allowNegated || !markerIsNegated(value, marker)));
+}
+
+export function assessClaim(claim: string, passages: ResearchPassage[]): ClaimAssessment {
+	const terms = tokenize(claim);
+	if (terms.length === 0 || passages.length === 0) {
+		return { claim, status: "missing-evidence", supporting_passages: [], contradicting_passages: [], rationale: "No passages available that discuss the claim's terms.", confidence: 0.2 };
+	}
+	const supporting: string[] = [];
+	const contradicting: string[] = [];
+	for (const passage of passages) {
+		const lower = passage.text.toLowerCase();
+		const overlap = terms.filter((term) => containsPhrase(lower, term)).length;
+		if (overlap < Math.max(2, Math.ceil(terms.length / 4))) continue;
+		const contra = hasPolarityMarker(lower, CONTRADICTION_MARKERS);
+		const support = hasPolarityMarker(lower, SUPPORT_MARKERS);
+		if (contra && !support) contradicting.push(passage.passage_id);
+		else if (support && !contra) supporting.push(passage.passage_id);
+	}
+	if (contradicting.length > 0 && supporting.length === 0) {
+		return { claim, status: "contradicted", supporting_passages: [], contradicting_passages: contradicting, rationale: `${contradicting.length} passage(s) contradict the claim; none support it.`, confidence: Math.min(0.85, 0.5 + contradicting.length * 0.1) };
+	}
+	if (supporting.length > 0 && contradicting.length === 0) {
+		return { claim, status: "supported", supporting_passages: supporting, contradicting_passages: [], rationale: `${supporting.length} passage(s) support the claim; none contradict it.`, confidence: Math.min(0.85, 0.5 + supporting.length * 0.1) };
+	}
+	if (supporting.length > 0 || contradicting.length > 0) {
+		return { claim, status: "unclear", supporting_passages: supporting, contradicting_passages: contradicting, rationale: `${supporting.length} supporting and ${contradicting.length} contradicting passage(s); evidence is mixed.`, confidence: 0.4 };
+	}
+	return { claim, status: "unclear", supporting_passages: [], contradicting_passages: [], rationale: "Passages mention the claim's terms but contain no clear support or contradiction markers.", confidence: 0.3 };
+}
+
+interface RankedSearchResult extends SearchResult {
+	rank?: number;
+}
+
+export interface BuildArtifactInput {
+	query: string;
+	provider?: string;
+	summary?: string;
+	results: RankedSearchResult[];
+	fetched?: ExtractedContent[];
+	recency?: RecencyFilter;
+	domainFilter?: string[];
+}
+
+export function buildResearchArtifact(input: BuildArtifactInput): ResearchArtifact {
+	const filters = input.domainFilter ?? [];
+	const fetchedByUrl = new Map((input.fetched ?? []).map((page) => [page.url, page]));
+	const sources: ResearchSource[] = [];
+	const seen = new Set<string>();
+	for (const [index, result] of input.results.entries()) {
+		if (seen.has(result.url)) continue;
+		seen.add(result.url);
+		const page = fetchedByUrl.get(result.url);
+		sources.push({
+			rank: result.rank ?? index + 1,
+			url: result.url,
+			title: result.title,
+			snippet: result.snippet,
+			quality: classifySource(result.url),
+			fetched: Boolean(page && !page.error),
+			fetch_timestamp: page ? Date.now() : undefined,
+			content_hash: page && !page.error ? hashContent(page.content) : undefined,
+			fetch_error: page?.error ?? undefined,
+		});
+	}
+	const passages = buildPassages(sources, input.fetched, input.query);
+	return {
+		id: generateId(),
+		type: "research",
+		timestamp: Date.now(),
+		query: input.query,
+		sources,
+		passages,
+		provider: input.provider,
+		summary: input.summary,
+		content_hash: passages.length > 0 ? hashContent(passages.map((passage) => passage.text).join("\n")) : undefined,
+		filters: {
+			recency: input.recency,
+			domain_include: filters.filter((domain) => !domain.startsWith("-")),
+			domain_exclude: filters.filter((domain) => domain.startsWith("-")).map((domain) => domain.slice(1)),
+		},
+	};
+}
+
+export function withClaimAssessment(artifact: ResearchArtifact, claims: string[]): ResearchArtifact {
+	return { ...artifact, claims: claims.map((claim) => assessClaim(claim, artifact.passages)) };
+}
+
+export function storeResearchArtifact(artifact: ResearchArtifact): void {
+	if (!artifact.id) throw new Error("Research artifact id must not be empty");
+	storeResult(artifact.id, { id: artifact.id, type: "research", timestamp: artifact.timestamp, artifact });
+}
+
+export function getResearchArtifact(id: string): ResearchArtifact | null {
+	const data = getResult(id);
+	if (!data || data.type !== "research" || !data.artifact || typeof data.artifact !== "object") return null;
+	return data.artifact as ResearchArtifact;
+}

--- a/storage.ts
+++ b/storage.ts
@@ -14,10 +14,11 @@ export interface QueryResultData {
 
 export interface StoredSearchData {
 	id: string;
-	type: "search" | "fetch";
+	type: "search" | "fetch" | "research";
 	timestamp: number;
 	queries?: QueryResultData[];
 	urls?: ExtractedContent[];
+	artifact?: unknown;
 }
 
 const storedResults = new Map<string, StoredSearchData>();
@@ -50,10 +51,11 @@ function isValidStoredData(data: unknown): data is StoredSearchData {
 	if (!data || typeof data !== "object") return false;
 	const d = data as Record<string, unknown>;
 	if (typeof d.id !== "string" || !d.id) return false;
-	if (d.type !== "search" && d.type !== "fetch") return false;
+	if (d.type !== "search" && d.type !== "fetch" && d.type !== "research") return false;
 	if (typeof d.timestamp !== "number") return false;
 	if (d.type === "search" && !Array.isArray(d.queries)) return false;
 	if (d.type === "fetch" && !Array.isArray(d.urls)) return false;
+	if (d.type === "research" && (!d.artifact || typeof d.artifact !== "object")) return false;
 	return true;
 }
 

--- a/test/lazy-extract-load.test.mjs
+++ b/test/lazy-extract-load.test.mjs
@@ -73,7 +73,7 @@ function buildChildScript(moduleUrl) {
 		initializeExtension(pi);
 		assert.deepEqual(
 			tools.map((tool) => tool.name),
-			["web_search", "fetch_content", "get_search_content"],
+			["web_search", "source_check", "fetch_content", "get_search_content"],
 		);
 		assert.ok(commands.includes("websearch"), "websearch command was not registered");
 		assert.ok(shortcuts.length > 0, "shortcuts were not registered");

--- a/test/source-check.test.mjs
+++ b/test/source-check.test.mjs
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import initializeExtension from "../index.ts";
+import {
+  assessClaim,
+  buildResearchArtifact,
+  buildPassages,
+  getResearchArtifact,
+  hashContent,
+  storeResearchArtifact,
+} from "../source-check.ts";
+import { clearResults } from "../storage.ts";
+
+const result = (url, snippet, rank = 1) => ({ url, title: "Example", snippet, rank });
+
+test("source-check creates a real SHA-256 hash and exact whitespace offsets", () => {
+  const content = "Intro.\n\nThe API\t supports streaming responses.\nTail.";
+  const passages = buildPassages(
+    [{ rank: 1, url: "https://docs.example.com/api", title: "API", snippet: "API supports streaming responses.", quality: "official_docs" }],
+    [{ url: "https://docs.example.com/api", title: "API", content, error: null }],
+  );
+  const pagePassage = passages.find((passage) => passage.extraction_span);
+  assert.ok(pagePassage);
+  assert.equal(pagePassage.text, "The API\t supports streaming responses.");
+  assert.equal(content.slice(pagePassage.extraction_span.start, pagePassage.extraction_span.end), pagePassage.text);
+  assert.equal(hashContent("abc"), "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+});
+
+test("fetched content supplies exact passages when the provider snippet is empty", () => {
+  const content = "The API supports streaming responses. Other details follow.";
+  const artifact = buildResearchArtifact({
+    query: "API supports streaming responses",
+    results: [result("https://docs.example.com/api", "")],
+    fetched: [{ url: "https://docs.example.com/api", title: "API", content, error: null }],
+  });
+  assert.deepEqual(artifact.passages.map((passage) => passage.text), ["The API supports streaming responses."]);
+  assert.deepEqual(artifact.passages[0].extraction_span, { start: 0, end: 37 });
+});
+
+test("artifact assembly handles omitted domain filters and failed fetches", () => {
+  const artifact = buildResearchArtifact({
+    query: "API claim",
+    results: [result("https://example.com/a", "The API is confirmed.")],
+    fetched: [{ url: "https://example.com/a", title: "Example", content: "", error: "blocked" }],
+  });
+  assert.equal(artifact.filters.domain_include.length, 0);
+  assert.equal(artifact.sources[0].fetched, false);
+  assert.equal(artifact.sources[0].fetch_error, "blocked");
+  assert.equal(artifact.sources[0].content_hash, undefined);
+});
+
+test("claim assessment references passage IDs and stores a non-empty artifact ID", () => {
+  clearResults();
+  const artifact = buildResearchArtifact({
+    query: "API claim",
+    results: [result("https://example.com/a", "According to the API documentation, the API is confirmed.")],
+  });
+  const assessed = { ...artifact, claims: [assessClaim("API documentation is confirmed", artifact.passages)] };
+  storeResearchArtifact(assessed);
+  assert.ok(assessed.id);
+  assert.deepEqual(getResearchArtifact(assessed.id), assessed);
+  assert.deepEqual(assessed.claims[0].supporting_passages, ["p-1-0"]);
+});
+
+test("claim assessment ignores polarity substrings, negated markers, and discourse words", () => {
+  const claim = "API supports streaming responses";
+  const passage = (passage_id, text) => ({ passage_id, source_url: "https://example.com/api", source_rank: 1, text });
+  for (const [passage_id, text] of [
+    ["p-yesterday", "Yesterday, the API documentation discussed streaming responses."],
+    ["p-unverified", "The API is unverified; documentation discusses streaming responses."],
+    ["p-however", "However, the API supports streaming responses."],
+  ]) {
+    const assessment = assessClaim(claim, [passage(passage_id, text)]);
+    assert.equal(assessment.status, "unclear", text);
+    assert.deepEqual(assessment.supporting_passages, [], text);
+    assert.deepEqual(assessment.contradicting_passages, [], text);
+  }
+});
+
+function registerSourceCheck() {
+  const tools = [];
+  const entries = [];
+  initializeExtension({
+    registerTool(tool) { tools.push(tool); },
+    registerCommand() {},
+    registerShortcut() {},
+    on() {},
+    appendEntry(type, data) { entries.push({ type, data }); },
+  });
+  return { tool: tools.find((candidate) => candidate.name === "source_check"), entries };
+}
+
+test("source_check executes a successful OpenAI provider response with runtime context", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "source-check-test-key";
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), "https://api.openai.com/v1/responses");
+    return new Response(JSON.stringify({
+      output: [
+        { type: "web_search_call", action: { sources: [{ title: "API docs", url: "https://docs.example.com/api" }] } },
+        { type: "message", content: [{ type: "output_text", text: "The API supports streaming responses." }] },
+      ],
+    }), { status: 200 });
+  };
+  try {
+    const { tool, entries } = registerSourceCheck();
+    const response = await tool.execute("call", { claim: "API supports streaming responses", provider: "openai" }, undefined, undefined, { modelRegistry: {} });
+    assert.equal(response.details.sourceCount, 1);
+    assert.equal(response.details.passageCount, 0);
+    assert.equal(entries[0].type, "web-search-results");
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousKey;
+  }
+});
+
+test("source_check stops on cancellation instead of continuing queries", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousKey = process.env.OPENAI_API_KEY;
+  let calls = 0;
+  const controller = new AbortController();
+  process.env.OPENAI_API_KEY = "source-check-test-key";
+  globalThis.fetch = async () => {
+    calls++;
+    controller.abort();
+    throw new Error("AbortError: canceled");
+  };
+  try {
+    const { tool } = registerSourceCheck();
+    const response = await tool.execute("call", { claim: "cancel this", queries: ["first", "second"], provider: "openai" }, controller.signal, undefined, { modelRegistry: {} });
+    assert.equal(calls, 1);
+    assert.equal(response.details.sourceCount, 0);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousKey;
+  }
+});
+
+test("source_check retains a rejected page fetch in the artifact", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "source-check-test-key";
+  globalThis.fetch = async (url) => {
+    if (String(url) === "https://api.openai.com/v1/responses") {
+      return new Response(JSON.stringify({
+        output: [{ type: "web_search_call", action: { sources: [{ title: "API docs", url: "https://example.com/api" }] } }],
+      }), { status: 200 });
+    }
+    throw new Error("fetch rejected");
+  };
+  try {
+    const { tool } = registerSourceCheck();
+    const response = await tool.execute("call", { claim: "API docs", provider: "openai", fetchContent: true }, undefined, undefined, { modelRegistry: {} });
+    assert.equal(response.details.sourceCount, 1);
+    assert.match(response.details.artifact.sources[0].fetch_error, /^fetch rejected/);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousKey;
+  }
+});
+
+test("registered source_check validates the claim at runtime", async () => {
+  const tools = [];
+  initializeExtension({
+    registerTool(tool) { tools.push(tool); },
+    registerCommand() {},
+    registerShortcut() {},
+    on() {},
+  });
+  const tool = tools.find((candidate) => candidate.name === "source_check");
+  assert.ok(tool);
+  const response = await tool.execute("call", { claim: "   " });
+  assert.equal(response.details.error, "Missing claim");
+});


### PR DESCRIPTION
Closes #108. Supersedes #111.

This adds a bounded `source_check` tool and machine-readable research artifacts. The tool searches with the same provider/context behavior as `web_search`, builds a conservative claim assessment, stores bounded provenance artifacts, and lets `get_search_content` retrieve those artifacts in slices with the existing offset/limit controls.

The replacement keeps the useful direction from #111 but avoids the stale branch problems: it passes the Pi execution context through provider calls, preserves configured-provider semantics for omitted/auto providers, stops on cancellation, retains query/fetch errors in the artifact, handles empty provider snippets with fetched-page passages, uses real SHA-256 hashes, and avoids substring polarity false positives.

Validation:
- `node --test test/source-check.test.mjs test/lazy-extract-load.test.mjs`
- `npm test` (125 tests)
- `git diff --check`
- `npm pack --dry-run`
- fresh reviewer approved with non-blocking follow-up nits
