### PR TITLE
Fix activity widget shortcut crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Preserved OpenAI/Codex answers even when the provider returns no source citations instead of replacing them with `No results found`. Thanks AstroHan (@Astro-Han) for reporting #117.
 - Prevented browser auto-open failures from crashing the curator fallback path with `ReferenceError: sendCuratorFallbackUpdate is not defined`. Thanks Nisarg Patel (@pnisarg) for PR #121; Apostol Apostolov (@apoapostolov), @2seoik, and Demetre Dzmanashvili (@demetere) for related PRs #133, #120, and #114; and @ruanlinxin, @bluewatercg, @tonydiep, and @pinion05 for reports #103, #116, #126, and #127.
 - Added a focused SSRF error hint for TUN/fake-IP `198.18.0.0/15` addresses that points users to the existing `ssrf.allowRanges` opt-in. Thanks Aaron (@BenjaminAaron196) for PR #141 and AstroHan (@Astro-Han) for reporting #134.
+- Registered the web activity widget with Pi's supported string-array API to prevent `content is not a function` crashes when toggling non-default shortcuts. Thanks @llllllllqq for reporting #158.
 - Registered the web activity widget as a Pi component factory instead of passing a `Text` instance directly. Thanks Trey Hoover (@treyhoover) for PR #132.
 
 ## [0.13.0] - 2026-06-25

--- a/index.ts
+++ b/index.ts
@@ -553,7 +553,7 @@ function updateWidget(ctx: ExtensionContext): void {
 			(resetMs > 0 ? theme.fg("dim", ` (resets in ${resetSec}s)`) : ""),
 	);
 
-	ctx.ui.setWidget("web-activity", () => new Text(lines.join("\n"), 0, 0));
+	ctx.ui.setWidget("web-activity", lines);
 }
 
 function formatEntryLine(

--- a/test/tool-registration-config.test.mjs
+++ b/test/tool-registration-config.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
+import initializeExtension from "../index.ts";
 
 const indexSrc = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
 const readmeSrc = readFileSync(new URL("../README.md", import.meta.url), "utf8");
@@ -18,15 +19,31 @@ test("fetch tools remain registered outside the web_search gate", () => {
 	assert.match(indexSrc, /\n\t}\);\n\n\tpi\.registerTool\(\{\n\t\tname: "fetch_content"/);
 });
 
-test("web activity widget uses a supported component factory", () => {
-	assert.match(
-		indexSrc,
-		/ctx\.ui\.setWidget\("web-activity", \(\) => new Text\(lines\.join\("\\n"\), 0, 0\)\);/,
-	);
-	assert.doesNotMatch(
-		indexSrc,
-		/ctx\.ui\.setWidget\("web-activity", new Text/,
-	);
+test("web activity shortcut renders through the supported string-array API", async () => {
+	const shortcuts = [];
+	initializeExtension({
+		registerTool() {},
+		registerCommand() {},
+		registerShortcut(name, shortcut) { shortcuts.push({ name, shortcut }); },
+		on() {},
+	});
+
+	const activityShortcut = shortcuts.find(({ shortcut }) => shortcut.description === "Toggle web search activity");
+	assert.ok(activityShortcut, "activity shortcut was not registered");
+	const widgets = [];
+	const ctx = {
+		ui: {
+			theme: { fg: (_color, text) => text },
+			setWidget(key, content) { widgets.push({ key, content }); },
+		},
+	};
+
+	await activityShortcut.shortcut.handler(ctx);
+	assert.equal(widgets[0].key, "web-activity");
+	assert.ok(Array.isArray(widgets[0].content), "activity widget content must be a string array");
+	assert.ok(widgets[0].content.length > 0);
+
+	await activityShortcut.shortcut.handler(ctx);
 });
 
 test("README documents webSearch.enabled", () => {


### PR DESCRIPTION
Fixes #158.

The activity widget shortcut now passes the widget content through Pi's supported `string[]` widget API instead of handing `setWidget` a component factory. That avoids the `content is not a function` crash reported when the shortcut actually reaches Pi, for example with a non-terminal-reserved binding like `ctrl+alt+w`.

The regression exercises the production registration path, invokes the activity shortcut handler, and asserts that the rendered widget payload is a non-empty string array. The changelog credits @llllllllqq for the report.

Validation:
- `node --test test/tool-registration-config.test.mjs`
- `npm test`
- `git diff --check`
- `npm pack --dry-run`
- fresh read-only review approved exact commit `36fafb5febb33ce365fb7abe5c96e655339ea14d`
