### PR TITLE
feat: resolve provider API key sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added request-time `$ENV_VAR` and `!command` credential sources for every provider API-key field, including escaped `$$` and `$!` literals, while preserving legacy environment precedence for literal config values. Thanks to Eugene Strizhok (@estrizhok) for #159.
 - Added request-time `$ENV_VAR` and `!command` credential sources for Exa and Gemini API configuration, with bounded output, redacted failures, strict source precedence, and shell-local 1Password session forwarding limited to the resolver command. Thanks to Ezra Miller (@ezmill) for #137.
 - Added `source_check` machine-readable research artifacts with passage-level provenance, bounded page fetching, durable session retrieval, and conservative claim assessments. Thanks Clark Everson (@gr3enarr0w) for PR #111 and issue #108.
 

--- a/README.md
+++ b/README.md
@@ -319,14 +319,18 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
 }
 ```
 
-`exaApiKey` and `geminiApiKey` also accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time:
+All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `tavilyApiKey`, `exaApiKey`, `perplexityApiKey`, `geminiApiKey`, and `cloudflareApiKey`) accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time. Escape `$$` as a literal leading `$` and `$!` as a literal leading `!`:
 
 ```json
 {
-  "exaApiKey": "!/absolute/path/to/secret-manager read exa",
-  "geminiApiKey": "${SCOPED_GEMINI_API_KEY}"
+  "openaiApiKey": "!/absolute/path/to/secret-manager read openai",
+  "braveApiKey": "${SCOPED_BRAVE_API_KEY}",
+  "exaApiKey": "$$literal-key",
+  "geminiApiKey": "$!literal-command"
 }
 ```
+
+This syntax applies to provider credentials only; other configuration fields are not interpolated.
 
 A command source is not run while the extension loads or registers tools. Each selected provider request runs it again with a five-second timeout, a 16 KiB output limit, a minimized environment, and a one-line non-empty stdout requirement. Command text and stderr are omitted from errors. These commands are trusted local configuration, not a same-user process isolation boundary; use absolute executable paths and protect the config file. `OP_SESSION_*` variables are forwarded to trusted resolver commands so shell-local 1Password sessions can be reused without storing them in config. An explicit source overrides legacy provider environment variables and fails that provider locally rather than falling back with a stale credential. Direct Google Gemini API requests send the resolved key only in the `x-goog-api-key` header, never in the URL.
 

--- a/brave.ts
+++ b/brave.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { activityMonitor } from "./activity.ts";
 import type { SearchOptions, SearchResult, SearchResponse } from "./perplexity.ts";
+import { hasCredentialSource, redactCredential, resolveCredential } from "./credential-source.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
 const BRAVE_API_URL = "https://api.search.brave.com/res/v1/web/search";
@@ -35,14 +36,13 @@ function loadConfig(): WebSearchConfig {
 	}
 }
 
-function normalizeApiKey(value: unknown): string | null {
-	if (typeof value !== "string") return null;
-	const normalized = value.trim();
-	return normalized.length > 0 ? normalized : null;
-}
-
-function getApiKey(): string | null {
-	return normalizeApiKey(process.env.BRAVE_API_KEY) ?? normalizeApiKey(loadConfig().braveApiKey);
+async function getApiKey(signal?: AbortSignal): Promise<string | null> {
+	return resolveCredential({
+		provider: "Brave",
+		configuredValue: loadConfig().braveApiKey,
+		environmentValue: process.env.BRAVE_API_KEY,
+		signal,
+	});
 }
 
 function normalizeCount(value: number | undefined): number {
@@ -118,14 +118,18 @@ function matchesDomainFilters(url: string, filters: NormalizedDomainFilters): bo
 }
 
 export function isBraveAvailable(): boolean {
-	return !!getApiKey();
+	return hasCredentialSource({
+		provider: "Brave",
+		configuredValue: loadConfig().braveApiKey,
+		environmentValue: process.env.BRAVE_API_KEY,
+	});
 }
 
 export async function searchWithBrave(
 	query: string,
 	options: SearchOptions = {},
 ): Promise<SearchResponse> {
-	const apiKey = getApiKey();
+	const apiKey = await getApiKey(options.signal);
 	if (!apiKey) {
 		throw new Error(
 			"Brave Search API key not found. Either:\n" +
@@ -170,7 +174,7 @@ export async function searchWithBrave(
 
 		if (!response.ok) {
 			activityMonitor.logError(activityId, `HTTP ${response.status}`);
-			const errorText = await response.text();
+			const errorText = redactCredential(await response.text(), apiKey);
 			throw new Error(`Brave Search API error ${response.status}: ${errorText.slice(0, 300)}`);
 		}
 
@@ -200,11 +204,15 @@ export async function searchWithBrave(
 		return { answer, results };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		if (message.toLowerCase().includes("abort")) {
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage.toLowerCase().includes("abort")) {
 			activityMonitor.logComplete(activityId, 0);
 		} else {
-			activityMonitor.logError(activityId, message);
+			activityMonitor.logError(activityId, redactedMessage);
 		}
-		throw err;
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
 	}
 }

--- a/credential-source.ts
+++ b/credential-source.ts
@@ -103,8 +103,13 @@ function explicitEnvironmentName(source: string): string | null {
 	return match ? match[1] ?? match[2] : null;
 }
 
+function escapedSource(source: string): string | null {
+	if (source.startsWith("$$") || source.startsWith("$!")) return source.slice(1);
+	return null;
+}
+
 function isMalformedExplicitSource(source: string): boolean {
-	return source.startsWith("$") && explicitEnvironmentName(source) === null;
+	return source.startsWith("$") && escapedSource(source) === null && explicitEnvironmentName(source) === null;
 }
 
 async function defaultRunCommand(
@@ -141,6 +146,8 @@ export function hasCredentialSource(options: CredentialOptions): boolean {
 
 export async function resolveCredential(options: CredentialOptions): Promise<string | null> {
 	const source = configuredSource(options);
+	const escaped = source ? escapedSource(source) : null;
+	if (escaped !== null) return escaped;
 	if (source?.startsWith("!")) {
 		const command = source.slice(1).trim();
 		if (!command) throw new CredentialResolutionError(options.provider, "invalid-source");

--- a/gemini-api.ts
+++ b/gemini-api.ts
@@ -75,18 +75,48 @@ export function getVersionedApiBase(): string {
 	return `${getApiHost()}/${API_VERSION}`;
 }
 
-export function getCloudflareApiKey(): string | null {
+function getLegacyCloudflareApiKey(): string | null {
 	return normalizeApiKey(process.env.CLOUDFLARE_API_KEY) ?? normalizeApiKey(loadConfig().cloudflareApiKey);
 }
 
-export function isGatewayConfigured(): boolean {
-	return isCloudflareGateway() && getCloudflareApiKey() !== null;
+async function resolveCloudflareApiKey(signal?: AbortSignal): Promise<string | null> {
+	return resolveCredential({
+		provider: "Cloudflare",
+		configuredValue: loadConfig().cloudflareApiKey,
+		environmentValue: process.env.CLOUDFLARE_API_KEY,
+		signal,
+	});
 }
 
-export function buildAuthHeaders(apiKey: string | null = null): Record<string, string> {
+export function getCloudflareApiKey(): string | null {
+	return getLegacyCloudflareApiKey();
+}
+
+export function isGatewayConfigured(): boolean {
+	return isCloudflareGateway() && hasCredentialSource({
+		provider: "Cloudflare",
+		configuredValue: loadConfig().cloudflareApiKey,
+		environmentValue: process.env.CLOUDFLARE_API_KEY,
+	});
+}
+
+export function buildAuthHeaders(apiKey: string | null = null, cloudflareApiKey: string | null = getLegacyCloudflareApiKey()): Record<string, string> {
 	if (!isCloudflareGateway()) return apiKey ? { "x-goog-api-key": apiKey } : {};
-	const cloudflareApiKey = getCloudflareApiKey();
 	return cloudflareApiKey ? { "cf-aig-authorization": `Bearer ${cloudflareApiKey}` } : {};
+}
+
+function redactGeminiCredentials(text: string, apiKey: string | null | undefined, cloudflareApiKey: string | null | undefined): string {
+	return redactCredential(redactCredential(text, apiKey), cloudflareApiKey);
+}
+
+const responseCredentials = new WeakMap<Response, {
+	apiKey: string | null | undefined;
+	cloudflareApiKey: string | null | undefined;
+}>();
+
+export function redactGeminiApiResponse(response: Response, text: string, apiKey?: string | null): string {
+	const credentials = responseCredentials.get(response);
+	return redactGeminiCredentials(text, credentials?.apiKey ?? apiKey, credentials?.cloudflareApiKey);
 }
 
 export async function fetchGeminiApi(
@@ -101,6 +131,7 @@ export async function fetchGeminiApi(
 		}
 	}
 	const resolvedApiKey = apiKey === undefined ? await getApiKey(init.signal ?? undefined) : apiKey;
+	const cloudflareApiKey = isCloudflareGateway() ? await resolveCloudflareApiKey(init.signal ?? undefined) : null;
 	const allowedOrigins = new Set([
 		new URL(getApiHost()).origin,
 		new URL(DEFAULT_API_HOST).origin,
@@ -111,14 +142,16 @@ export async function fetchGeminiApi(
 	const headers = new Headers(init.headers);
 	headers.delete("x-goog-api-key");
 	headers.delete("cf-aig-authorization");
-	for (const [name, value] of Object.entries(buildAuthHeaders(resolvedApiKey))) {
+	for (const [name, value] of Object.entries(buildAuthHeaders(resolvedApiKey, cloudflareApiKey))) {
 		headers.set(name, value);
 	}
 	try {
-		return await fetch(parsedUrl, { ...init, headers });
+		const response = await fetch(parsedUrl, { ...init, headers });
+		responseCredentials.set(response, { apiKey: resolvedApiKey, cloudflareApiKey });
+		return response;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		const redactedMessage = redactCredential(message, resolvedApiKey);
+		const redactedMessage = redactGeminiCredentials(message, resolvedApiKey, cloudflareApiKey);
 		if (redactedMessage === message) throw error;
 		const redactedError = new Error(redactedMessage);
 		if (error instanceof Error) redactedError.name = error.name;
@@ -183,7 +216,7 @@ export async function queryGeminiApiWithVideo(
 	}, apiKey);
 
 	if (!res.ok) {
-		const errorText = redactCredential(await res.text(), apiKey);
+		const errorText = redactGeminiApiResponse(res, await res.text(), apiKey);
 		throw new Error(`Gemini API error ${res.status}: ${errorText.slice(0, 300)}`);
 	}
 

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { activityMonitor } from "./activity.ts";
-import { CredentialResolutionError, redactCredential } from "./credential-source.ts";
-import { getApiKey, getVersionedApiBase, fetchGeminiApi, isGatewayConfigured } from "./gemini-api.ts";
+import { CredentialResolutionError } from "./credential-source.ts";
+import { getApiKey, getVersionedApiBase, fetchGeminiApi, isGatewayConfigured, redactGeminiApiResponse } from "./gemini-api.ts";
 import { getGeminiWebAvailabilityDiagnostic, isGeminiWebAvailable, queryWithCookies } from "./gemini-web.ts";
 import { isPerplexityAvailable, searchWithPerplexity, type SearchResult, type SearchResponse, type SearchOptions } from "./perplexity.ts";
 import { hasExaApiKey, isExaAvailable, searchWithExa } from "./exa.ts";
@@ -288,7 +288,7 @@ async function searchWithGeminiApi(query: string, options: SearchOptions = {}): 
 		}, apiKey);
 
 		if (!res.ok) {
-			const errorText = redactCredential(await res.text(), apiKey);
+			const errorText = redactGeminiApiResponse(res, await res.text(), apiKey);
 			throw new Error(`Gemini API error ${res.status}: ${errorText.slice(0, 300)}`);
 		}
 

--- a/openai-search.ts
+++ b/openai-search.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { activityMonitor } from "./activity.ts";
 import type { SearchOptions, SearchResponse, SearchResult } from "./perplexity.ts";
+import { hasCredentialSource, redactCredential, resolveCredential } from "./credential-source.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
 const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
@@ -47,12 +48,6 @@ function loadConfig(): WebSearchConfig {
 		const message = err instanceof Error ? err.message : String(err);
 		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
 	}
-}
-
-function normalizeApiKey(value: unknown): string | null {
-	if (typeof value !== "string") return null;
-	const normalized = value.trim();
-	return normalized.length > 0 ? normalized : null;
 }
 
 function normalizeDomain(value: string): string | null {
@@ -115,37 +110,61 @@ function extractAccountId(token: string): string | undefined {
 	return typeof id === "string" && id.trim().length > 0 ? id.trim() : undefined;
 }
 
-export async function resolveOpenAIAuth(ctx?: ExtensionContext): Promise<OpenAIAuth | undefined> {
-	if (ctx) {
-		const { getModel } = await import("@earendil-works/pi-ai/compat");
-		for (const candidate of AUTH_MODEL_CANDIDATES) {
-			for (const modelId of candidate.models) {
-				const model = getModel(candidate.provider, modelId);
-				if (!model) continue;
-				try {
-					const resolved = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-					if (resolved.ok && resolved.apiKey) {
-						return {
-							provider: candidate.provider,
-							apiKey: resolved.apiKey,
-							model: modelId,
-							headers: resolved.headers ?? {},
-						};
-					}
-				} catch {
+async function resolvePiAuth(ctx: ExtensionContext): Promise<OpenAIAuth | undefined> {
+	const { getModel } = await import("@earendil-works/pi-ai/compat");
+	for (const candidate of AUTH_MODEL_CANDIDATES) {
+		for (const modelId of candidate.models) {
+			const model = getModel(candidate.provider, modelId);
+			if (!model) continue;
+			try {
+				const resolved = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+				if (resolved.ok && resolved.apiKey) {
+					return {
+						provider: candidate.provider,
+						apiKey: resolved.apiKey,
+						model: modelId,
+						headers: resolved.headers ?? {},
+					};
 				}
+			} catch {
 			}
 		}
 	}
+	return undefined;
+}
 
-	const apiKey = normalizeApiKey(process.env.OPENAI_API_KEY) ?? normalizeApiKey(loadConfig().openaiApiKey);
+export async function resolveOpenAIAuth(ctx?: ExtensionContext, signal?: AbortSignal): Promise<OpenAIAuth | undefined> {
+	if (ctx) {
+		const auth = await resolvePiAuth(ctx);
+		if (auth) return auth;
+	}
+
+	const config = loadConfig();
+	const hasSource = hasCredentialSource({
+		provider: "OpenAI",
+		configuredValue: config.openaiApiKey,
+		environmentValue: process.env.OPENAI_API_KEY,
+	});
+	if (!hasSource) return undefined;
+	const apiKey = await resolveCredential({
+		provider: "OpenAI",
+		configuredValue: config.openaiApiKey,
+		environmentValue: process.env.OPENAI_API_KEY,
+		signal,
+	});
 	return apiKey
 		? { provider: "openai", apiKey, model: "gpt-5.4", headers: {} }
 		: undefined;
 }
 
 export async function isOpenAISearchAvailable(ctx?: ExtensionContext): Promise<boolean> {
-	return !!(await resolveOpenAIAuth(ctx));
+	if (ctx && await resolvePiAuth(ctx)) return true;
+	const config = loadConfig();
+	return hasCredentialSource({
+		provider: "OpenAI",
+		configuredValue: config.openaiApiKey,
+		environmentValue: process.env.OPENAI_API_KEY,
+	});
 }
 
 function buildInstructions(options: SearchOptions): string {
@@ -324,7 +343,7 @@ export async function searchWithOpenAI(
 	options: SearchOptions = {},
 	ctx?: ExtensionContext,
 ): Promise<SearchResponse> {
-	const auth = await resolveOpenAIAuth(ctx);
+	const auth = await resolveOpenAIAuth(ctx, options.signal);
 	if (!auth) {
 		throw new Error(
 			"OpenAI web search unavailable. Either:\n" +
@@ -372,7 +391,7 @@ export async function searchWithOpenAI(
 
 		if (!response.ok) {
 			activityMonitor.logError(activityId, `HTTP ${response.status}`);
-			const errorText = await response.text();
+			const errorText = redactCredential(await response.text(), auth.apiKey);
 			throw new Error(`OpenAI API error ${response.status}: ${errorText.slice(0, 300)}`);
 		}
 
@@ -389,11 +408,15 @@ export async function searchWithOpenAI(
 		return { answer, results };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		if (message.toLowerCase().includes("abort")) {
+		const redactedMessage = redactCredential(message, auth.apiKey);
+		if (redactedMessage.toLowerCase().includes("abort")) {
 			activityMonitor.logComplete(activityId, 0);
 		} else {
-			activityMonitor.logError(activityId, message);
+			activityMonitor.logError(activityId, redactedMessage);
 		}
-		throw err;
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
 	}
 }

--- a/parallel.ts
+++ b/parallel.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { activityMonitor } from "./activity.ts";
 import type { ExtractedContent, ExtractOptions } from "./extract.ts";
 import type { SearchOptions, SearchResponse } from "./perplexity.ts";
+import { hasCredentialSource, redactCredential, resolveCredential } from "./credential-source.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
 const PARALLEL_SEARCH_URL = "https://api.parallel.ai/v1/search";
@@ -83,18 +84,39 @@ function isPlaceholderApiKey(key: string): boolean {
 	return normalized.length < MIN_PARALLEL_API_KEY_LENGTH || PLACEHOLDER_API_KEY_DENYLIST.has(normalized.toLowerCase());
 }
 
-function resolveApiKey(): string | null {
+async function resolveApiKey(signal?: AbortSignal): Promise<string | null> {
+	const configKey = normalizeApiKey(loadConfig().parallelApiKey);
+	if (configKey?.startsWith("$") || configKey?.startsWith("!")) {
+		const resolved = await resolveCredential({
+			provider: "Parallel",
+			configuredValue: configKey,
+			environmentValue: process.env.PARALLEL_API_KEY,
+			signal,
+		});
+		return resolved && !isPlaceholderApiKey(resolved) ? resolved : null;
+	}
+
 	const envKey = normalizeApiKey(process.env.PARALLEL_API_KEY);
 	if (envKey && !isPlaceholderApiKey(envKey)) return envKey;
-
-	const configKey = normalizeApiKey(loadConfig().parallelApiKey);
 	if (configKey && !isPlaceholderApiKey(configKey)) return configKey;
-
 	return null;
 }
 
-function getApiKey(): string {
-	const key = resolveApiKey();
+function hasConfiguredApiKey(): boolean {
+	const configKey = normalizeApiKey(loadConfig().parallelApiKey);
+	if (configKey?.startsWith("$") || configKey?.startsWith("!")) {
+		return hasCredentialSource({
+			provider: "Parallel",
+			configuredValue: configKey,
+			environmentValue: process.env.PARALLEL_API_KEY,
+		});
+	}
+	const envKey = normalizeApiKey(process.env.PARALLEL_API_KEY);
+	return (envKey !== null && !isPlaceholderApiKey(envKey)) || (configKey !== null && !isPlaceholderApiKey(configKey));
+}
+
+async function getApiKey(signal?: AbortSignal): Promise<string> {
+	const key = await resolveApiKey(signal);
 	if (!key) {
 		throw new Error(
 			"Parallel API key not found. Either:\n" +
@@ -107,7 +129,7 @@ function getApiKey(): string {
 }
 
 export function hasParallelApiKey(): boolean {
-	return !!resolveApiKey();
+	return hasConfiguredApiKey();
 }
 
 export function isParallelAvailable(): boolean {
@@ -323,7 +345,7 @@ async function parallelFetch(
 	body: Record<string, unknown>,
 	signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
-	const apiKey = getApiKey();
+	const apiKey = await getApiKey(signal);
 	const activityId = activityMonitor.logStart(activityContext(url, body));
 	let response: Response;
 	try {
@@ -338,14 +360,18 @@ async function parallelFetch(
 		});
 	} catch (err) {
 		const message = errorMessage(err);
-		if (message.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
-		else activityMonitor.logError(activityId, message);
-		throw err;
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
+		else activityMonitor.logError(activityId, redactedMessage);
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
 	}
 
 	if (!response.ok) {
 		activityMonitor.logComplete(activityId, response.status);
-		const errorText = await response.text();
+		const errorText = redactCredential(await response.text(), apiKey);
 		throw new Error(`Parallel API error ${response.status}: ${errorText.slice(0, 300)}`);
 	}
 

--- a/perplexity.ts
+++ b/perplexity.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { activityMonitor } from "./activity.ts";
 import type { ExtractedContent } from "./extract.ts";
+import { hasCredentialSource, redactCredential, resolveCredential } from "./credential-source.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
 const PERPLEXITY_API_URL = "https://api.perplexity.ai/chat/completions";
@@ -55,15 +56,13 @@ function loadConfig(): WebSearchConfig {
 	}
 }
 
-function normalizeApiKey(value: unknown): string | null {
-	if (typeof value !== "string") return null;
-	const normalized = value.trim();
-	return normalized.length > 0 ? normalized : null;
-}
-
-function getApiKey(): string {
-	const config = loadConfig();
-	const key = normalizeApiKey(process.env.PERPLEXITY_API_KEY) ?? normalizeApiKey(config.perplexityApiKey);
+async function getApiKey(signal?: AbortSignal): Promise<string> {
+	const key = await resolveCredential({
+		provider: "Perplexity",
+		configuredValue: loadConfig().perplexityApiKey,
+		environmentValue: process.env.PERPLEXITY_API_KEY,
+		signal,
+	});
 	if (!key) {
 		throw new Error(
 			"Perplexity API key not found. Either:\n" +
@@ -99,8 +98,11 @@ function validateDomainFilter(domains: string[]): string[] {
 }
 
 export function isPerplexityAvailable(): boolean {
-	const config = loadConfig();
-	return !!(normalizeApiKey(process.env.PERPLEXITY_API_KEY) ?? normalizeApiKey(config.perplexityApiKey));
+	return hasCredentialSource({
+		provider: "Perplexity",
+		configuredValue: loadConfig().perplexityApiKey,
+		environmentValue: process.env.PERPLEXITY_API_KEY,
+	});
 }
 
 export async function searchWithPerplexity(query: string, options: SearchOptions = {}): Promise<SearchResponse> {
@@ -115,7 +117,7 @@ export async function searchWithPerplexity(query: string, options: SearchOptions
 		windowMs: RATE_LIMIT.windowMs,
 	});
 
-	const apiKey = getApiKey();
+	const apiKey = await getApiKey(options.signal);
 	const numResults = Math.min(options.numResults ?? 5, 20);
 
 	const requestBody: Record<string, unknown> = {
@@ -149,17 +151,21 @@ export async function searchWithPerplexity(query: string, options: SearchOptions
 		});
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		if (message.toLowerCase().includes("abort")) {
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage.toLowerCase().includes("abort")) {
 			activityMonitor.logComplete(activityId, 0);
 		} else {
-			activityMonitor.logError(activityId, message);
+			activityMonitor.logError(activityId, redactedMessage);
 		}
-		throw err;
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
 	}
 
 	if (!response.ok) {
 		activityMonitor.logComplete(activityId, response.status);
-		const errorText = await response.text();
+		const errorText = redactCredential(await response.text(), apiKey);
 		throw new Error(`Perplexity API error ${response.status}: ${errorText}`);
 	}
 

--- a/tavily.ts
+++ b/tavily.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { activityMonitor } from "./activity.ts";
 import type { ExtractedContent } from "./extract.ts";
 import type { SearchOptions, SearchResponse } from "./perplexity.ts";
+import { hasCredentialSource, redactCredential, resolveCredential } from "./credential-source.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
 const TAVILY_API_URL = "https://api.tavily.com/search";
@@ -47,18 +48,17 @@ function loadConfig(): WebSearchConfig {
 	}
 }
 
-function normalizeApiKey(value: unknown): string | null {
-	if (typeof value !== "string") return null;
-	const normalized = value.trim();
-	return normalized.length > 0 ? normalized : null;
+async function getApiKey(signal?: AbortSignal): Promise<string | null> {
+	return resolveCredential({
+		provider: "Tavily",
+		configuredValue: loadConfig().tavilyApiKey,
+		environmentValue: process.env.TAVILY_API_KEY,
+		signal,
+	});
 }
 
-function getApiKey(): string | null {
-	return normalizeApiKey(process.env.TAVILY_API_KEY) ?? normalizeApiKey(loadConfig().tavilyApiKey);
-}
-
-function requireApiKey(): string {
-	const apiKey = getApiKey();
+async function requireApiKey(signal?: AbortSignal): Promise<string> {
+	const apiKey = await getApiKey(signal);
 	if (!apiKey) {
 		throw new Error(
 			"Tavily API key not found. Either:\n" +
@@ -144,10 +144,15 @@ function mapInlineContent(results: TavilyResult[] | undefined): ExtractedContent
 }
 
 export function isTavilyAvailable(): boolean {
-	return !!getApiKey();
+	return hasCredentialSource({
+		provider: "Tavily",
+		configuredValue: loadConfig().tavilyApiKey,
+		environmentValue: process.env.TAVILY_API_KEY,
+	});
 }
 
 export async function searchWithTavily(query: string, options: TavilySearchOptions = {}): Promise<SearchResponse> {
+	const apiKey = await requireApiKey(options.signal);
 	const numResults = normalizeCount(options.numResults);
 	const body: Record<string, unknown> = {
 		query,
@@ -165,7 +170,7 @@ export async function searchWithTavily(query: string, options: TavilySearchOptio
 		response = await fetch(TAVILY_API_URL, {
 			method: "POST",
 			headers: {
-				"Authorization": `Bearer ${requireApiKey()}`,
+				"Authorization": `Bearer ${apiKey}`,
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify(body),
@@ -173,14 +178,18 @@ export async function searchWithTavily(query: string, options: TavilySearchOptio
 		});
 	} catch (err) {
 		const message = errorMessage(err);
-		if (message.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
-		else activityMonitor.logError(activityId, message);
-		throw err;
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
+		else activityMonitor.logError(activityId, redactedMessage);
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
 	}
 
 	if (!response.ok) {
 		activityMonitor.logComplete(activityId, response.status);
-		const errorText = await response.text();
+		const errorText = redactCredential(await response.text(), apiKey);
 		throw new Error(`Tavily API error ${response.status}: ${errorText.slice(0, 300)}`);
 	}
 

--- a/test/credential-source.test.mjs
+++ b/test/credential-source.test.mjs
@@ -102,6 +102,12 @@ test("command failures are categorized and redact command output", async () => {
 	}
 });
 
+test("escaped source prefixes remain literal and override legacy environment values", async () => {
+	assert.equal(await resolveCredential(options("$$OPENAI_API_KEY", "legacy-value")), "$OPENAI_API_KEY");
+	assert.equal(await resolveCredential(options("$!literal-command", "legacy-value")), "!literal-command");
+	assert.equal(hasCredentialSource(options("$$OPENAI_API_KEY", undefined)), true);
+});
+
 test("malformed explicit sources fail closed instead of becoming literals", async () => {
 	for (const source of ["!", "$BAD-NAME", "${UNCLOSED"]) {
 		await assert.rejects(

--- a/test/provider-credential-source.test.mjs
+++ b/test/provider-credential-source.test.mjs
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const braveModuleUrl = new URL("../brave.ts", import.meta.url).href;
+const geminiApiModuleUrl = new URL("../gemini-api.ts", import.meta.url).href;
+const openaiModuleUrl = new URL("../openai-search.ts", import.meta.url).href;
+const parallelModuleUrl = new URL("../parallel.ts", import.meta.url).href;
+const perplexityModuleUrl = new URL("../perplexity.ts", import.meta.url).href;
+const tavilyModuleUrl = new URL("../tavily.ts", import.meta.url).href;
+
+async function createHome(config) {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-credential-source-"));
+	const agentDir = join(home, "agent");
+	await mkdir(agentDir, { recursive: true });
+	await writeFile(join(agentDir, "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	return { home, agentDir };
+}
+
+function runChild(script, env) {
+	const childEnv = { ...process.env };
+	for (const key of [
+		"PI_CODING_AGENT_DIR",
+		"XDG_CONFIG_HOME",
+		"BRAVE_API_KEY",
+		"CLOUDFLARE_API_KEY",
+		"GEMINI_API_KEY",
+		"GOOGLE_GEMINI_BASE_URL",
+		"OPENAI_API_KEY",
+		"PARALLEL_API_KEY",
+		"PERPLEXITY_API_KEY",
+		"TAVILY_API_KEY",
+	]) delete childEnv[key];
+	Object.assign(childEnv, env);
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+}
+
+test("previously unsupported providers resolve explicit env and command sources lazily", async () => {
+	const tavilyMarker = join(await mkdtemp(join(tmpdir(), "pi-web-access-credential-marker-")), "tavily-ran");
+	const openaiMarker = join(await mkdtemp(join(tmpdir(), "pi-web-access-credential-marker-")), "openai-ran");
+	const { home, agentDir } = await createHome({
+		braveApiKey: "${BRAVE_SCOPED_KEY}",
+		openaiApiKey: `!touch ${openaiMarker} && printf openai-command-key`,
+		tavilyApiKey: `!touch ${tavilyMarker} && printf tavily-command-key`,
+	});
+	const child = runChild(`
+		import { existsSync } from "node:fs";
+		const { isBraveAvailable, searchWithBrave } = await import(${JSON.stringify(braveModuleUrl)});
+		const { isOpenAISearchAvailable, searchWithOpenAI } = await import(${JSON.stringify(openaiModuleUrl)});
+		const { isTavilyAvailable, searchWithTavily } = await import(${JSON.stringify(tavilyModuleUrl)});
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			calls.push({ url: String(url), headers: Object.fromEntries(new Headers(init.headers)) });
+			return new Response(JSON.stringify({ web: { results: [{ title: "Brave", url: "https://example.com/brave", description: "result" }] } }), { status: 200 });
+		};
+		const availableBefore = {
+			brave: isBraveAvailable(),
+			openai: await isOpenAISearchAvailable(),
+			tavily: isTavilyAvailable(),
+			openaiMarker: existsSync(${JSON.stringify(openaiMarker)}),
+			tavilyMarker: existsSync(${JSON.stringify(tavilyMarker)}),
+		};
+		await searchWithBrave("brave", { numResults: 1 });
+		globalThis.fetch = async (url, init = {}) => {
+			calls.push({ url: String(url), headers: Object.fromEntries(new Headers(init.headers)) });
+			return new Response(JSON.stringify({
+				output: [{ type: "message", content: [{ type: "output_text", text: "OpenAI answer" }] }],
+			}), { status: 200 });
+		};
+		await searchWithOpenAI("openai", { numResults: 1 });
+		globalThis.fetch = async (url, init = {}) => {
+			calls.push({ url: String(url), headers: Object.fromEntries(new Headers(init.headers)) });
+			return new Response(JSON.stringify({ results: [{ title: "Tavily", url: "https://example.com/tavily", content: "result" }] }), { status: 200 });
+		};
+		await searchWithTavily("tavily", { numResults: 1 });
+		console.log(JSON.stringify({
+			availableBefore,
+			openaiMarkerAfter: existsSync(${JSON.stringify(openaiMarker)}),
+			tavilyMarkerAfter: existsSync(${JSON.stringify(tavilyMarker)}),
+			calls,
+		}));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: agentDir,
+		BRAVE_SCOPED_KEY: "brave-scoped-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.availableBefore, {
+		brave: true,
+		openai: true,
+		tavily: true,
+		openaiMarker: false,
+		tavilyMarker: false,
+	});
+	assert.equal(output.openaiMarkerAfter, true);
+	assert.equal(output.tavilyMarkerAfter, true);
+	assert.equal(output.calls[0].headers["x-subscription-token"], "brave-scoped-key");
+	assert.equal(output.calls[1].headers.authorization, "Bearer openai-command-key");
+	assert.equal(output.calls[2].headers.authorization, "Bearer tavily-command-key");
+});
+
+test("provider API errors redact resolved credential-source values", async () => {
+	const { home, agentDir } = await createHome({
+		braveApiKey: "${BRAVE_SCOPED_KEY}",
+		cloudflareApiKey: "${CLOUDFLARE_SCOPED_KEY}",
+		geminiBaseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/google-ai-studio",
+		openaiApiKey: "!printf openai-redaction-secret",
+		parallelApiKey: "!printf parallel-redaction-secret",
+		perplexityApiKey: "!printf perplexity-redaction-secret",
+		tavilyApiKey: "!printf tavily-redaction-secret",
+	});
+	const child = runChild(`
+		const modules = {
+			brave: await import(${JSON.stringify(braveModuleUrl)}),
+			geminiApi: await import(${JSON.stringify(geminiApiModuleUrl)}),
+			openai: await import(${JSON.stringify(openaiModuleUrl)}),
+			parallel: await import(${JSON.stringify(parallelModuleUrl)}),
+			perplexity: await import(${JSON.stringify(perplexityModuleUrl)}),
+			tavily: await import(${JSON.stringify(tavilyModuleUrl)}),
+		};
+		const attempts = [
+			["brave", "brave-redaction-secret", () => modules.brave.searchWithBrave("query")],
+			["openai", "openai-redaction-secret", () => modules.openai.searchWithOpenAI("query")],
+			["parallel", "parallel-redaction-secret", () => modules.parallel.searchWithParallel("query")],
+			["perplexity", "perplexity-redaction-secret", () => modules.perplexity.searchWithPerplexity("query")],
+			["tavily", "tavily-redaction-secret", () => modules.tavily.searchWithTavily("query")],
+			["cloudflare", "cf-redaction-secret", () => modules.geminiApi.queryGeminiApiWithVideo("prompt", "files/synthetic")],
+		];
+		const messages = {};
+		for (const [name, secret, run] of attempts) {
+			globalThis.fetch = async () => new Response(JSON.stringify({ error: secret }), { status: 400 });
+			try {
+				await run();
+				messages[name] = "NO_ERROR";
+			} catch (error) {
+				messages[name] = error instanceof Error ? error.message : String(error);
+			}
+		}
+		console.log(JSON.stringify({ messages, secrets: Object.fromEntries(attempts.map(([name, secret]) => [name, secret])) }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: agentDir,
+		BRAVE_SCOPED_KEY: "brave-redaction-secret",
+		CLOUDFLARE_SCOPED_KEY: "cf-redaction-secret",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	for (const [provider, message] of Object.entries(output.messages)) {
+		assert.notEqual(message, "NO_ERROR", provider);
+		assert.match(message, /\[redacted\]/, provider);
+		assert.equal(message.includes(output.secrets[provider]), false, provider);
+	}
+});
+
+test("Cloudflare gateway response redacts the credential used by the request", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-cloudflare-redaction-"));
+	const countPath = join(root, "count");
+	const resolverPath = join(root, "cloudflare-key.mjs");
+	await writeFile(resolverPath, `
+		import { existsSync, readFileSync, writeFileSync } from "node:fs";
+		const countPath = ${JSON.stringify(countPath)};
+		const current = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) : 0;
+		const next = current + 1;
+		writeFileSync(countPath, String(next));
+		process.stdout.write("cf-rotating-secret-" + next);
+	`, "utf8");
+	const { home, agentDir } = await createHome({
+		cloudflareApiKey: `!${JSON.stringify(process.execPath)} ${JSON.stringify(resolverPath)}`,
+		geminiBaseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/google-ai-studio",
+	});
+	const child = runChild(`
+		import { readFileSync } from "node:fs";
+		const { queryGeminiApiWithVideo } = await import(${JSON.stringify(geminiApiModuleUrl)});
+		let leaked = false;
+		let redacted = false;
+		globalThis.fetch = async (url, init = {}) => {
+			const sent = new Headers(init.headers).get("cf-aig-authorization")?.replace(/^Bearer /, "") ?? "missing";
+			return new Response(JSON.stringify({ error: sent }), { status: 400 });
+		};
+		try {
+			await queryGeminiApiWithVideo("prompt", "files/synthetic");
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			leaked = message.includes("cf-rotating-secret-1");
+			redacted = message.includes("[redacted]");
+		}
+		console.log(JSON.stringify({ leaked, redacted, count: readFileSync(${JSON.stringify(countPath)}, "utf8") }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: agentDir,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output, { leaked: false, redacted: true, count: "1" });
+});

--- a/video-extract.ts
+++ b/video-extract.ts
@@ -3,9 +3,8 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { resolve, extname, basename, join, dirname } from "node:path";
 import { activityMonitor } from "./activity.ts";
-import { redactCredential } from "./credential-source.ts";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.ts";
-import { queryGeminiApiWithVideo, getApiKey, fetchGeminiApi, API_BASE } from "./gemini-api.ts";
+import { queryGeminiApiWithVideo, getApiKey, fetchGeminiApi, API_BASE, redactGeminiApiResponse } from "./gemini-api.ts";
 import { extractHeadingTitle, type ExtractedContent, type ExtractOptions, type FrameResult } from "./extract.ts";
 import { readExecError, trimErrorText, mapFfmpegError, getWebSearchConfigPath } from "./utils.ts";
 
@@ -326,7 +325,7 @@ async function uploadToFilesApi(
 	}, apiKey);
 
 	if (!initRes.ok) {
-		const text = redactCredential(await initRes.text(), apiKey);
+		const text = redactGeminiApiResponse(initRes, await initRes.text(), apiKey);
 		throw new Error(`File upload init failed: ${initRes.status} (${text.slice(0, 200)})`);
 	}
 
@@ -346,7 +345,7 @@ async function uploadToFilesApi(
 	}, apiKey);
 
 	if (!uploadRes.ok) {
-		const text = redactCredential(await uploadRes.text(), apiKey);
+		const text = redactGeminiApiResponse(uploadRes, await uploadRes.text(), apiKey);
 		throw new Error(`File upload failed: ${uploadRes.status} (${text.slice(0, 200)})`);
 	}
 


### PR DESCRIPTION
Fixes #159.

This extends the existing request-time credential-source resolver beyond Exa/Gemini so every provider API-key field in `web-search.json` supports `$ENV_VAR`, `${ENV_VAR}`, and trusted `!command` values. Escaped `$$` and `$!` prefixes remain literal, explicit sources override stale legacy environment values, and availability checks stay lazy so command sources are not executed during registration.

The change also keeps provider error handling from leaking resolved secrets. API response and transport errors now redact the exact resolved provider credential, including Cloudflare AI Gateway credentials bound to the Gemini `Response` that used them.

Thanks to Eugene Strizhok (@estrizhok) for #159.

Validation:
- `node --test test/provider-credential-source.test.mjs test/gemini-api-transport.test.mjs test/search-providers.test.mjs`
- `npm test` (138/138)
- `git diff --check`
- `npm pack --dry-run`
- Fresh review: initial blocker fixed, final Cloudflare follow-up approved