### PR TITLE
fix: harden unreleased TypeScript boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ All notable changes to this project will be documented in this file.
 - Added `source_check` machine-readable research artifacts with passage-level provenance, bounded page fetching, durable session retrieval, and conservative claim assessments. Thanks Clark Everson (@gr3enarr0w) for PR #111 and issue #108.
 
 ### Changed
+- Limited the published package contents to runtime files, skills, docs, and declared assets, keeping internal tests out of the npm tarball.
 - Deferred the heavy content extraction module until the first `fetch_content` or `includeContent` search call, reducing extension startup work. Thanks Kaushik Gopal (@kaushikgopal) for PR #125.
 - Send direct Gemini API credentials in `x-goog-api-key` headers for generate, upload, status, and delete requests instead of URL query parameters.
 
 ### Fixed
+- Hardened unreleased config/result boundaries by rejecting malformed config roots, reporting malformed SSRF JSON, normalizing invalid Perplexity result counts, and rejecting contradictory curator summary metadata.
 - Reworked opt-in Gemini Web browser-cookie extraction to scan non-default Chromium profiles, preflight required cookie names before Keychain/secret-tool access, and cache encryption passwords only in-process. Thanks Kevin Truong (@kevinQTruong) for the originating PR #14, Jessica Black (@jssblck) for reporting #9, János Veres (@jveres) for reporting #2, and RimuruW (@RimuruW) for reporting #15.
 - Added read-only `sqlite3` CLI and Python stdlib fallbacks when `node:sqlite` is unavailable, with sanitized actionable diagnostics instead of silently reporting Gemini Web as unavailable.
 - Bounded curator summary-model generation and returned a deterministic, phase-labeled fallback when a draft exceeds its deadline, while preserving caller cancellation and model-resolution errors. Thanks torn1147 (@torn1147) for reporting #43.

--- a/chrome-cookies.ts
+++ b/chrome-cookies.ts
@@ -306,10 +306,9 @@ async function importSqlite(): Promise<typeof import("node:sqlite") | null> {
 	return sqliteModule;
 }
 
-interface QueryResult {
-	rows: SqliteRow[] | null;
-	failure?: SqliteFailure;
-}
+type QueryResult =
+	| { rows: SqliteRow[] }
+	| { rows: null; failure: SqliteFailure };
 
 async function runSqliteQuery(dbPath: string, sql: string): Promise<QueryResult> {
 	const sqlite = await importSqlite();
@@ -342,7 +341,7 @@ function runSqliteCli(dbPath: string, sql: string): Promise<QueryResult> {
 			if (err) { resolve({ rows: null, failure: err.code === "ENOENT" ? "unavailable" : "query" }); return; }
 			try {
 				const parsed = JSON.parse(stdout || "[]");
-				resolve({ rows: Array.isArray(parsed) ? parsed as SqliteRow[] : null, failure: Array.isArray(parsed) ? undefined : "query" });
+				resolve(Array.isArray(parsed) ? { rows: parsed as SqliteRow[] } : { rows: null, failure: "query" });
 			} catch {
 				resolve({ rows: null, failure: "query" });
 			}
@@ -357,7 +356,7 @@ function runPythonSqlite(dbPath: string, sql: string): Promise<QueryResult> {
 			if (err) { resolve({ rows: null, failure: err.code === "ENOENT" ? "unavailable" : "query" }); return; }
 			try {
 				const parsed = JSON.parse(stdout || "[]");
-				resolve({ rows: Array.isArray(parsed) ? parsed as SqliteRow[] : null, failure: Array.isArray(parsed) ? undefined : "query" });
+				resolve(Array.isArray(parsed) ? { rows: parsed as SqliteRow[] } : { rows: null, failure: "query" });
 			} catch {
 				resolve({ rows: null, failure: "query" });
 			}

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -149,6 +149,8 @@ function normalizeSummaryMeta(value: unknown): SummaryMeta | null {
 
 	const phase = meta.phase;
 	if (phase !== undefined && phase !== "summary-model" && phase !== "deterministic-fallback") return null;
+	if (phase === "deterministic-fallback" && fallbackUsed !== true) return null;
+	if (phase === "summary-model" && fallbackUsed !== false) return null;
 
 	const edited = meta.edited;
 	if (edited !== undefined && typeof edited !== "boolean") return null;
@@ -158,9 +160,9 @@ function normalizeSummaryMeta(value: unknown): SummaryMeta | null {
 		durationMs,
 		tokenEstimate,
 		fallbackUsed,
-		fallbackReason,
-		phase,
-		edited,
+		...(fallbackReason !== undefined ? { fallbackReason } : {}),
+		...(phase !== undefined ? { phase } : {}),
+		...(edited !== undefined ? { edited } : {}),
 	};
 }
 
@@ -423,7 +425,7 @@ export function startCuratorServer(
 						ok: true,
 						queryIndex: qi,
 						error: message,
-						provider: typeof provider === "string" && provider.length > 0 ? provider : undefined,
+						...(typeof provider === "string" && provider.length > 0 ? { provider } : {}),
 					});
 				}
 				return;
@@ -564,7 +566,12 @@ export function startCuratorServer(
 				}
 				const rawResults = (body as { rawResults?: unknown }).rawResults === true;
 				sendJson(res, 200, { ok: true });
-				setImmediate(() => callbacks.onSubmit({ selectedQueryIndices: parsed.indices, summary, summaryMeta, rawResults }));
+				setImmediate(() => callbacks.onSubmit({
+					selectedQueryIndices: parsed.indices,
+					...(summary !== undefined ? { summary } : {}),
+					...(summaryMeta !== undefined ? { summaryMeta } : {}),
+					rawResults,
+				}));
 				return;
 			}
 

--- a/extract.ts
+++ b/extract.ts
@@ -33,14 +33,23 @@ interface SsrfConfig {
  * weakened.
  */
 export function loadSsrfConfig(): SsrfConfig {
-	let ssrf: unknown;
+	if (!existsSync(WEB_SEARCH_CONFIG_PATH)) return { allowRanges: [], trustEnvProxy: false };
+	let raw: string;
 	try {
-		if (!existsSync(WEB_SEARCH_CONFIG_PATH)) return { allowRanges: [], trustEnvProxy: false };
-		const raw = readFileSync(WEB_SEARCH_CONFIG_PATH, "utf-8");
-		ssrf = (JSON.parse(raw) as { ssrf?: unknown })?.ssrf;
+		raw = readFileSync(WEB_SEARCH_CONFIG_PATH, "utf-8");
 	} catch {
 		return { allowRanges: [], trustEnvProxy: false };
 	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${WEB_SEARCH_CONFIG_PATH}: ${message}`);
+	}
+	const ssrf = parsed && typeof parsed === "object" && !Array.isArray(parsed)
+		? (parsed as { ssrf?: unknown }).ssrf
+		: undefined;
 	if (ssrf === undefined || ssrf === null) return { allowRanges: [], trustEnvProxy: false };
 	if (typeof ssrf !== "object" || Array.isArray(ssrf)) {
 		throw new Error(`ssrf in ${WEB_SEARCH_CONFIG_PATH} must be an object`);
@@ -135,7 +144,7 @@ async function extractWithJinaReader(
 
 	try {
 		const ssrf = loadSsrfConfig();
-		await validateRemoteUrl(url, { allowRanges: ssrf.allowRanges, trustEnvProxy: ssrf.trustEnvProxy, lookup });
+		await validateRemoteUrl(url, { allowRanges: ssrf.allowRanges, trustEnvProxy: ssrf.trustEnvProxy, ...(lookup ? { lookup } : {}) });
 		const res = await fetch(jinaUrl, {
 			headers: {
 				"Accept": "text/markdown",
@@ -236,7 +245,7 @@ function buildFrameResult(
 		content: `${frames.length} frames extracted from ${label}`,
 		error: null,
 		frames,
-		duration,
+		...(duration !== undefined ? { duration } : {}),
 	};
 }
 
@@ -423,7 +432,11 @@ export async function extractContent(
 		const parsed = new URL(url);
 		if (parsed.protocol === "http:" || parsed.protocol === "https:") {
 			const ssrf = loadSsrfConfig();
-			await validateRemoteUrl(parsed, { allowRanges: ssrf.allowRanges, trustEnvProxy: ssrf.trustEnvProxy, lookup: options?.lookup });
+			await validateRemoteUrl(parsed, {
+				allowRanges: ssrf.allowRanges,
+				trustEnvProxy: ssrf.trustEnvProxy,
+				...(options?.lookup ? { lookup: options.lookup } : {}),
+			});
 		}
 	} catch (err) {
 		return { url, title: "", content: "", error: errorMessage(err) };
@@ -574,7 +587,11 @@ async function extractViaHttp(
 					"Upgrade-Insecure-Requests": "1",
 				},
 			},
-			{ allowRanges: ssrf.allowRanges, trustEnvProxy: ssrf.trustEnvProxy, lookup: options?.lookup },
+			{
+				allowRanges: ssrf.allowRanges,
+				trustEnvProxy: ssrf.trustEnvProxy,
+				...(options?.lookup ? { lookup: options.lookup } : {}),
+			},
 		);
 
 		if (!response.ok) {

--- a/fetch-params.ts
+++ b/fetch-params.ts
@@ -28,14 +28,17 @@ export function normalizeFetchContentParams(params: FetchContentParams): Normali
 
 	const shouldIncludeFrames = frames !== undefined && (timestamp !== undefined || frames > 1);
 
+	const forceClone = typeof params.forceClone === "boolean" ? params.forceClone : undefined;
+	const model = normalizeOptionalString(params.model);
+
 	return {
 		urlList,
 		options: {
-			forceClone: typeof params.forceClone === "boolean" ? params.forceClone : undefined,
-			prompt,
-			timestamp,
-			frames: shouldIncludeFrames ? frames : undefined,
-			model: normalizeOptionalString(params.model),
+			...(forceClone !== undefined ? { forceClone } : {}),
+			...(prompt !== undefined ? { prompt } : {}),
+			...(timestamp !== undefined ? { timestamp } : {}),
+			...(shouldIncludeFrames ? { frames } : {}),
+			...(model !== undefined ? { model } : {}),
 		},
 	};
 }

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -27,7 +27,7 @@ let cachedSearchConfig: { searchProvider: SearchProvider; searchModel?: string }
 function getSearchConfig(): { searchProvider: SearchProvider; searchModel?: string } {
 	if (cachedSearchConfig) return cachedSearchConfig;
 	if (!existsSync(CONFIG_PATH)) {
-		cachedSearchConfig = { searchProvider: "auto", searchModel: undefined };
+		cachedSearchConfig = { searchProvider: "auto" };
 		return cachedSearchConfig;
 	}
 
@@ -48,9 +48,10 @@ function getSearchConfig(): { searchProvider: SearchProvider; searchModel?: stri
 		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
 	}
 
+	const searchModel = normalizeSearchModel(raw.searchModel);
 	cachedSearchConfig = {
 		searchProvider: normalizeSearchProvider(raw.searchProvider ?? raw.provider),
-		searchModel: normalizeSearchModel(raw.searchModel),
+		...(searchModel ? { searchModel } : {}),
 	};
 	return cachedSearchConfig;
 }

--- a/index.ts
+++ b/index.ts
@@ -126,27 +126,29 @@ interface CuratorBootstrap {
 	timeoutSeconds: number;
 }
 
-function loadConfig(): WebSearchConfig {
-	if (!existsSync(WEB_SEARCH_CONFIG_PATH)) return {};
-	const raw = readFileSync(WEB_SEARCH_CONFIG_PATH, "utf-8");
+function parseConfigRoot(raw: string): Record<string, unknown> {
+	let parsed: unknown;
 	try {
-		return JSON.parse(raw) as WebSearchConfig;
+		parsed = JSON.parse(raw);
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		throw new Error(`Failed to parse ${WEB_SEARCH_CONFIG_PATH}: ${message}`);
 	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error(`Invalid config in ${WEB_SEARCH_CONFIG_PATH}: expected a JSON object`);
+	}
+	return parsed as Record<string, unknown>;
+}
+
+function loadConfig(): WebSearchConfig {
+	if (!existsSync(WEB_SEARCH_CONFIG_PATH)) return {};
+	return parseConfigRoot(readFileSync(WEB_SEARCH_CONFIG_PATH, "utf-8")) as WebSearchConfig;
 }
 
 function saveConfig(updates: Partial<WebSearchConfig>): void {
 	let config: Record<string, unknown> = {};
 	if (existsSync(WEB_SEARCH_CONFIG_PATH)) {
-		const raw = readFileSync(WEB_SEARCH_CONFIG_PATH, "utf-8");
-		try {
-			config = JSON.parse(raw) as Record<string, unknown>;
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			throw new Error(`Failed to parse ${WEB_SEARCH_CONFIG_PATH}: ${message}`);
-		}
+		config = parseConfigRoot(readFileSync(WEB_SEARCH_CONFIG_PATH, "utf-8"));
 	}
 
 	Object.assign(config, updates);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,13 @@
     "url": "https://github.com/nicobailon/pi-web-access/issues"
   },
   "homepage": "https://github.com/nicobailon/pi-web-access#readme",
+  "files": [
+    "*.ts",
+    "skills/",
+    "CHANGELOG.md",
+    "banner.png",
+    "pi-web-fetch-demo.mp4"
+  ],
   "dependencies": {
     "@mozilla/readability": "^0.6.0",
     "linkedom": "^0.16.0",

--- a/perplexity.ts
+++ b/perplexity.ts
@@ -118,7 +118,9 @@ export async function searchWithPerplexity(query: string, options: SearchOptions
 	});
 
 	const apiKey = await getApiKey(options.signal);
-	const numResults = Math.min(options.numResults ?? 5, 20);
+	const numResults = typeof options.numResults === "number" && Number.isFinite(options.numResults)
+		? Math.max(1, Math.min(Math.floor(options.numResults), 20))
+		: 5;
 
 	const requestBody: Record<string, unknown> = {
 		model: "sonar",
@@ -147,7 +149,7 @@ export async function searchWithPerplexity(query: string, options: SearchOptions
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify(requestBody),
-			signal: options.signal,
+			...(options.signal ? { signal: options.signal } : {}),
 		});
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);

--- a/source-check.ts
+++ b/source-check.ts
@@ -232,19 +232,22 @@ export function buildResearchArtifact(input: BuildArtifactInput): ResearchArtifa
 		if (seen.has(result.url)) continue;
 		seen.add(result.url);
 		const page = fetchedByUrl.get(result.url);
+		const fetched = Boolean(page && !page.error);
 		sources.push({
 			rank: result.rank ?? index + 1,
 			url: result.url,
 			title: result.title,
 			snippet: result.snippet,
 			quality: classifySource(result.url),
-			fetched: Boolean(page && !page.error),
-			fetch_timestamp: page ? Date.now() : undefined,
-			content_hash: page && !page.error ? hashContent(page.content) : undefined,
-			fetch_error: page?.error ?? undefined,
+			fetched,
+			...(page ? { fetch_timestamp: Date.now() } : {}),
+			...(page && !page.error ? { content_hash: hashContent(page.content) } : {}),
+			...(page?.error ? { fetch_error: page.error } : {}),
 		});
 	}
 	const passages = buildPassages(sources, input.fetched, input.query);
+	const domainInclude = filters.filter((domain) => !domain.startsWith("-"));
+	const domainExclude = filters.filter((domain) => domain.startsWith("-")).map((domain) => domain.slice(1));
 	return {
 		id: generateId(),
 		type: "research",
@@ -252,13 +255,13 @@ export function buildResearchArtifact(input: BuildArtifactInput): ResearchArtifa
 		query: input.query,
 		sources,
 		passages,
-		provider: input.provider,
-		summary: input.summary,
-		content_hash: passages.length > 0 ? hashContent(passages.map((passage) => passage.text).join("\n")) : undefined,
+		...(input.provider !== undefined ? { provider: input.provider } : {}),
+		...(input.summary !== undefined ? { summary: input.summary } : {}),
+		...(passages.length > 0 ? { content_hash: hashContent(passages.map((passage) => passage.text).join("\n")) } : {}),
 		filters: {
-			recency: input.recency,
-			domain_include: filters.filter((domain) => !domain.startsWith("-")),
-			domain_exclude: filters.filter((domain) => domain.startsWith("-")).map((domain) => domain.slice(1)),
+			...(input.recency !== undefined ? { recency: input.recency } : {}),
+			domain_include: domainInclude,
+			domain_exclude: domainExclude,
 		},
 	};
 }

--- a/test/curator-server-timeout.test.mjs
+++ b/test/curator-server-timeout.test.mjs
@@ -80,6 +80,28 @@ test("curator times out when searches finish but no browser connects", async () 
 	}
 });
 
+test("curator submit rejects contradictory summary metadata", async () => {
+	const { startCuratorServer } = await loadServer();
+	const handle = await startCuratorServer(baseOptions(20), baseCallbacks(() => {}));
+
+	try {
+		for (const summaryMeta of [
+			{ model: null, durationMs: 0, tokenEstimate: 0, fallbackUsed: false, phase: "deterministic-fallback" },
+			{ model: "model", durationMs: 0, tokenEstimate: 0, fallbackUsed: true, phase: "summary-model" },
+		]) {
+			const response = await fetch(new URL("/submit", handle.url), {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ token: "test-token", selected: [], summaryMeta }),
+			});
+			assert.equal(response.status, 400);
+			assert.deepEqual(await response.json(), { ok: false, error: "Invalid summaryMeta" });
+		}
+	} finally {
+		handle.close();
+	}
+});
+
 test("curator heartbeat timeout finalizes connected idle browser sessions", async () => {
 	const { startCuratorServer } = await loadServer();
 	let resolveCancel;

--- a/test/package-typebox-dependency.test.mjs
+++ b/test/package-typebox-dependency.test.mjs
@@ -16,7 +16,12 @@ test("packed installs include typebox without peer dependencies", async () => {
 			encoding: "utf8",
 			stdio: ["ignore", "pipe", "pipe"],
 		});
-		const [{ filename }] = JSON.parse(packOutput);
+		const [{ filename, files }] = JSON.parse(packOutput);
+		const packedFiles = files.map((file) => file.path);
+		assert.ok(packedFiles.includes("index.ts"));
+		assert.ok(packedFiles.includes("CHANGELOG.md"));
+		assert.ok(packedFiles.some((path) => path.startsWith("skills/")));
+		assert.ok(!packedFiles.some((path) => path.startsWith("test/")));
 		const tarball = join(tempDir, filename);
 
 		execFileSync("npm", ["install", "--omit=peer", "--ignore-scripts", "--no-audit", "--no-fund", tarball], {

--- a/test/provider-precedence.test.mjs
+++ b/test/provider-precedence.test.mjs
@@ -89,6 +89,36 @@ test("auto still uses provider fallback when no provider is configured", async (
 	assert.deepEqual(calls, ["https://api.openai.com/v1/responses"]);
 });
 
+test("malformed config root fails with an explicit object-shape error", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-invalid-config-root-"));
+	const agentDir = join(root, "agent-dir");
+	await mkdir(agentDir, { recursive: true });
+	await writeFile(join(agentDir, "web-search.json"), "null\n", "utf8");
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			globalThis.fetch = async () => { throw new Error("fetch should not run"); };
+			const tools = [];
+			const pi = {
+				registerTool(tool) { tools.push(tool); },
+				registerShortcut() {},
+				registerCommand() {},
+				on() {},
+				appendEntry() {},
+				sendMessage() {},
+			};
+			const extension = (await import(${JSON.stringify(indexUrl)})).default;
+			extension(pi);
+			const tool = tools.find((candidate) => candidate.name === "web_search");
+			await tool.execute("invalid-config-root-test", { query: "x", workflow: "none", provider: "auto" });
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PI_CODING_AGENT_DIR: agentDir, OPENAI_API_KEY: "openai-test-key" },
+	});
+	assert.notEqual(child.status, 0);
+	assert.match(child.stderr, /Invalid config in .*web-search\.json: expected a JSON object/);
+});
+
 test("curated and non-curated branches both resolve the requested provider", async () => {
 	const { readFile } = await import("node:fs/promises");
 	const source = await readFile(new URL("../index.ts", import.meta.url), "utf8");

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -8,6 +8,7 @@ import { test } from "node:test";
 const braveModuleUrl = new URL("../brave.ts", import.meta.url).href;
 const exaModuleUrl = new URL("../exa.ts", import.meta.url).href;
 const openaiModuleUrl = new URL("../openai-search.ts", import.meta.url).href;
+const perplexityModuleUrl = new URL("../perplexity.ts", import.meta.url).href;
 const tavilyModuleUrl = new URL("../tavily.ts", import.meta.url).href;
 const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
 
@@ -77,6 +78,29 @@ test("Brave search applies domain filters in the query and returned results", as
 	assert.equal(output.count, "20");
 	assert.equal(output.token, "brave-test-key");
 	assert.deepEqual(output.results.map((result) => result.url), ["https://github.com/nicobailon/pi-web-access"]);
+});
+
+test("Perplexity normalizes invalid result counts", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-perplexity-count-"));
+	const child = runChild(`
+		globalThis.fetch = async () => new Response(JSON.stringify({
+			choices: [{ message: { content: "answer" } }],
+			citations: ["https://example.com/a", "https://example.com/b", "https://example.com/c", "https://example.com/d", "https://example.com/e"],
+		}), { status: 200, headers: { "content-type": "application/json" } });
+
+		const { searchWithPerplexity } = await import(${JSON.stringify(perplexityModuleUrl)});
+		const negative = await searchWithPerplexity("negative", { numResults: -1 });
+		const nan = await searchWithPerplexity("nan", { numResults: Number.NaN });
+		const decimal = await searchWithPerplexity("decimal", { numResults: 3.8 });
+		console.log(JSON.stringify({ counts: [negative.results.length, nan.results.length, decimal.results.length] }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PERPLEXITY_API_KEY: "pplx-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout.trim()).counts, [1, 5, 3]);
 });
 
 test("Tavily search uses bearer auth and maps filters/content", async () => {

--- a/test/source-check.test.mjs
+++ b/test/source-check.test.mjs
@@ -48,6 +48,7 @@ test("artifact assembly handles omitted domain filters and failed fetches", () =
   assert.equal(artifact.sources[0].fetched, false);
   assert.equal(artifact.sources[0].fetch_error, "blocked");
   assert.equal(artifact.sources[0].content_hash, undefined);
+  assert.equal(typeof artifact.sources[0].fetch_timestamp, "number");
 });
 
 test("claim assessment references passage IDs and stores a non-empty artifact ID", () => {

--- a/test/ssrf-allow-ranges-config.test.mjs
+++ b/test/ssrf-allow-ranges-config.test.mjs
@@ -153,11 +153,11 @@ test("loadSsrfAllowRanges returns [] when ssrf.allowRanges is unset", async () =
 	assert.deepEqual(result.ranges, []);
 });
 
-test("loadSsrfAllowRanges fails safe with [] when the config JSON is invalid", async () => {
+test("loadSsrfAllowRanges reports malformed config JSON", async () => {
 	const { root, agentDir, configPath } = await makeConfigDir("pi-ssrf-badjson-");
 	await writeFile(configPath, "{ not valid json", "utf8");
 
 	const result = runLoad(envFor(root, agentDir));
-	assert.equal(result.ok, true, result.error);
-	assert.deepEqual(result.ranges, []);
+	assert.equal(result.ok, false);
+	assert.match(result.error, /Failed to parse .*web-search\.json/);
 });


### PR DESCRIPTION
Tightens the unreleased changes before release by removing explicit `undefined` optional fields where they were leaking into runtime objects, making SQLite query results an explicit success/failure union, and rejecting contradictory curator summary metadata. It also validates malformed config roots and SSRF JSON more loudly, normalizes malformed Perplexity result counts, and limits the npm package to runtime files, docs, skills, and declared assets.

Validation: `npm test`, `git diff --check`, and `npm pack --dry-run --json` with `CHANGELOG.md` present and `test/` excluded.