### PR TITLE
feat: add fetch content domain policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added optional `fetchContent.domainPolicy` hostname allow/deny rules for `fetch_content`, checked before target requests and redirects while preserving SSRF protection and local-source behavior. Thanks Joseph Maliksi (@jmaliksi) for #79.
 - Added explicit-only AnySearch direct search provider with anonymous access, optional `anysearchApiKey` / `ANYSEARCH_API_KEY` credentials, strict response validation, and request-time credential sources. Thanks Robin (@choronz) for #130.
 - Added SERPdive search provider with request-time credential sources, a free-tier `krill` default that never spends on install, opt-in `mako`/`moby` retrieval depth, locally applied domain filters, and recency documented as a query hint rather than a guaranteed freshness filter. Thanks Eden d'Alexis (@edendalexis) for #139.
 - Added opt-in ordered search routing through `searchRouting.providers` with explicit transient, quota, and network fallback kinds; named providers remain strict, single-provider config retains precedence, and exhausted routes preserve per-provider diagnostics. Thanks @smithyyang for #77.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,12 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
     "preferredModel": "gemini-3-flash-preview",
     "maxSizeMB": 50
   },
+  "fetchContent": {
+    "domainPolicy": {
+      "allow": ["example.com"],
+      "deny": ["blocked.example.com"]
+    }
+  },
   "shortcuts": {
     "curate": "ctrl+shift+s",
     "activity": "ctrl+shift+w"
@@ -338,6 +344,8 @@ All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `t
 This syntax applies to provider credentials only; other configuration fields are not interpolated. `firecrawlApiKey` uses the same credential-source rules, while `firecrawlBaseUrl`, `firecrawlApiVersion`, and `firecrawlFreshScrape` are literal config values.
 
 A command source is not run while the extension loads or registers tools. Each selected provider request runs it again with a five-second timeout, a 16 KiB output limit, a minimized environment, and a one-line non-empty stdout requirement. Command text and stderr are omitted from errors. These commands are trusted local configuration, not a same-user process isolation boundary; use absolute executable paths and protect the config file. `OP_SESSION_*` variables are forwarded to trusted resolver commands so shell-local 1Password sessions can be reused without storing them in config. An explicit source overrides legacy provider environment variables and fails that provider locally rather than falling back with a stale credential. Direct Google Gemini API requests send the resolved key only in the `x-goog-api-key` header, never in the URL.
+
+`fetchContent.domainPolicy` is an optional hostname allow/deny policy for `fetch_content` target URLs. It is off when omitted. Each bare hostname matches itself and its subdomains; `deny` wins when a hostname matches both lists. The policy is checked before HTTP(S) target handling and before each redirect followed by this extension's own fetch path. Local file paths and non-HTTP sources are not subject to this policy. It is an additional restriction: the existing SSRF guard still blocks private and internal destinations. Remote extraction services can still perform their own DNS, redirects, and egress after this extension preflights the submitted target URL, so keep their deployments separately isolated.
 
 Set `searxngBaseUrl` or `SEARXNG_BASE_URL` to use a self-hosted SearXNG JSON API. A configured endpoint is preferred first in `auto` mode for local/private search. Its base URL and redirects remain subject to the SSRF guard; add only the narrowest self-hosted range to `ssrf.allowRanges` when it resolves to a private or synthetic range. Thanks to Marcos A. Núñez (@marnunez) for PR #107 and Avinash Kanaujiya (@avinashkanaujiya) for issue #105.
 

--- a/extract.ts
+++ b/extract.ts
@@ -12,7 +12,7 @@ import { extractWithUrlContext, extractWithGeminiWeb } from "./gemini-url-contex
 import { extractWithParallel, isParallelAvailable } from "./parallel.ts";
 import { extractWithFirecrawl, isFirecrawlAvailable } from "./firecrawl.ts";
 import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } from "./video-extract.ts";
-import { fetchRemoteUrl, loadSsrfConfig, validateRemoteUrl, type Lookup } from "./ssrf-protection.ts";
+import { fetchRemoteUrl, loadFetchContentDomainPolicy, loadSsrfConfig, validateRemoteUrl, type Lookup } from "./ssrf-protection.ts";
 import { formatSeconds, getWebSearchConfigPath } from "./utils.ts";
 
 const DEFAULT_TIMEOUT_MS = 30000;
@@ -95,7 +95,13 @@ async function extractWithJinaReader(
 
 	try {
 		const ssrf = loadSsrfConfig();
-		await validateRemoteUrl(url, { allowRanges: ssrf.allowRanges, trustEnvProxy: ssrf.trustEnvProxy, ...(lookup ? { lookup } : {}) });
+		const domainPolicy = loadFetchContentDomainPolicy();
+		await validateRemoteUrl(url, {
+			allowRanges: ssrf.allowRanges,
+			trustEnvProxy: ssrf.trustEnvProxy,
+			domainPolicy,
+			...(lookup ? { lookup } : {}),
+		});
 		const res = await fetch(jinaUrl, {
 			headers: {
 				"Accept": "text/markdown",
@@ -228,6 +234,27 @@ export async function extractContent(
 ): Promise<ExtractedContent> {
 	if (signal?.aborted) {
 		return { url, title: "", content: "", error: "Aborted" };
+	}
+
+	let remoteUrl: URL | null = null;
+	try {
+		const parsed = new URL(url);
+		if (parsed.protocol === "http:" || parsed.protocol === "https:") remoteUrl = parsed;
+	} catch {
+	}
+	if (remoteUrl) {
+		try {
+			const ssrf = loadSsrfConfig();
+			const domainPolicy = loadFetchContentDomainPolicy();
+			await validateRemoteUrl(remoteUrl, {
+				allowRanges: ssrf.allowRanges,
+				trustEnvProxy: ssrf.trustEnvProxy,
+				domainPolicy,
+				...(options?.lookup ? { lookup: options.lookup } : {}),
+			});
+		} catch (err) {
+			return { url, title: "", content: "", error: errorMessage(err) };
+		}
 	}
 
 	if (options?.frames && !options.timestamp) {
@@ -380,15 +407,7 @@ export async function extractContent(
 	}
 
 	try {
-		const parsed = new URL(url);
-		if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-			const ssrf = loadSsrfConfig();
-			await validateRemoteUrl(parsed, {
-				allowRanges: ssrf.allowRanges,
-				trustEnvProxy: ssrf.trustEnvProxy,
-				...(options?.lookup ? { lookup: options.lookup } : {}),
-			});
-		}
+		if (!remoteUrl) new URL(url);
 	} catch (err) {
 		return { url, title: "", content: "", error: errorMessage(err) };
 	}
@@ -542,6 +561,7 @@ async function extractViaHttp(
 
 	try {
 		const ssrf = loadSsrfConfig();
+		const domainPolicy = loadFetchContentDomainPolicy();
 		const response = await fetchRemoteUrl(
 			url,
 			{
@@ -561,6 +581,7 @@ async function extractViaHttp(
 			{
 				allowRanges: ssrf.allowRanges,
 				trustEnvProxy: ssrf.trustEnvProxy,
+				domainPolicy,
 				...(options?.lookup ? { lookup: options.lookup } : {}),
 			},
 		);

--- a/ssrf-protection.ts
+++ b/ssrf-protection.ts
@@ -17,6 +17,73 @@ export interface SsrfConfig {
 	trustEnvProxy: boolean;
 }
 
+export interface DomainPolicy {
+	allow: string[];
+	deny: string[];
+}
+
+const DEFAULT_DOMAIN_POLICY: DomainPolicy = { allow: [], deny: [] };
+
+export function loadFetchContentDomainPolicy(): DomainPolicy {
+	if (!existsSync(WEB_SEARCH_CONFIG_PATH)) return { ...DEFAULT_DOMAIN_POLICY };
+	let raw: string;
+	try {
+		raw = readFileSync(WEB_SEARCH_CONFIG_PATH, "utf-8");
+	} catch {
+		return { ...DEFAULT_DOMAIN_POLICY };
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${WEB_SEARCH_CONFIG_PATH}: ${message}`);
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return { ...DEFAULT_DOMAIN_POLICY };
+	}
+	const fetchContent = (parsed as { fetchContent?: unknown }).fetchContent;
+	if (fetchContent === undefined || fetchContent === null) return { ...DEFAULT_DOMAIN_POLICY };
+	if (typeof fetchContent !== "object" || Array.isArray(fetchContent)) {
+		throw new Error(`fetchContent in ${WEB_SEARCH_CONFIG_PATH} must be an object`);
+	}
+	const policy = (fetchContent as { domainPolicy?: unknown }).domainPolicy;
+	if (policy === undefined || policy === null) return { ...DEFAULT_DOMAIN_POLICY };
+	if (typeof policy !== "object" || Array.isArray(policy)) {
+		throw new Error(`fetchContent.domainPolicy in ${WEB_SEARCH_CONFIG_PATH} must be an object`);
+	}
+	const config = policy as { allow?: unknown; deny?: unknown };
+	return {
+		allow: parseDomainEntries(config.allow, "allow"),
+		deny: parseDomainEntries(config.deny, "deny"),
+	};
+}
+
+function parseDomainEntries(value: unknown, field: "allow" | "deny"): string[] {
+	if (value === undefined || value === null) return [];
+	if (!Array.isArray(value)) {
+		throw new Error(`fetchContent.domainPolicy.${field} in ${WEB_SEARCH_CONFIG_PATH} must be an array of hostnames`);
+	}
+	return value.map((entry, index) => {
+		if (typeof entry !== "string") {
+			throw new Error(`fetchContent.domainPolicy.${field} in ${WEB_SEARCH_CONFIG_PATH} must contain only hostnames; entry ${index + 1} is ${typeof entry}`);
+		}
+		const hostname = normalizeDomainEntry(entry);
+		if (!hostname) {
+			throw new Error(`fetchContent.domainPolicy.${field} in ${WEB_SEARCH_CONFIG_PATH} contains an invalid hostname: ${JSON.stringify(entry)}`);
+		}
+		return hostname;
+	});
+}
+
+function normalizeDomainEntry(entry: string): string | null {
+	const hostname = normalizeHostname(entry.trim());
+	if (!hostname || /\s|[\\/?:#@]/.test(hostname)) return null;
+	if (net.isIP(hostname)) return hostname;
+	if (hostname.length > 253 || !/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(hostname)) return null;
+	return hostname;
+}
+
 export function loadSsrfConfig(): SsrfConfig {
 	if (!existsSync(WEB_SEARCH_CONFIG_PATH)) return { allowRanges: [], trustEnvProxy: false };
 	let raw: string;
@@ -60,6 +127,8 @@ export function loadSsrfConfig(): SsrfConfig {
 
 interface ValidationOptions {
 	lookup?: Lookup;
+	/** Optional hostname policy for fetch_content target URLs. */
+	domainPolicy?: DomainPolicy;
 	/**
 	 * CIDR ranges (e.g. "198.18.0.0/15") to exempt from the SSRF guard.
 	 * Useful when a host runs a TUN/fake-IP proxy (Surge, Clash, Mihomo, ...)
@@ -104,6 +173,7 @@ export async function validateRemoteUrl(rawUrl: string | URL, options: Validatio
 	}
 
 	const allowRanges = parseAllowRanges(options.allowRanges);
+	assertDomainPolicy(hostname, options.domainPolicy);
 
 	if (net.isIP(hostname)) {
 		assertPublicAddress(hostname, hostname, allowRanges);
@@ -157,6 +227,20 @@ export async function fetchRemoteUrl(
 
 function normalizeHostname(hostname: string): string {
 	return hostname.toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+}
+
+function assertDomainPolicy(hostname: string, policy?: DomainPolicy): void {
+	if (!policy) return;
+	if (policy.deny.some((entry) => domainMatches(hostname, entry))) {
+		throw new Error(`Blocked hostname by fetch_content domain policy: ${hostname}`);
+	}
+	if (policy.allow.length > 0 && !policy.allow.some((entry) => domainMatches(hostname, entry))) {
+		throw new Error(`Hostname not allowed by fetch_content domain policy: ${hostname}`);
+	}
+}
+
+function domainMatches(hostname: string, entry: string): boolean {
+	return hostname === entry || hostname.endsWith(`.${entry}`);
 }
 
 function getProxyForProtocol(protocol: string): string {

--- a/test/fetch-content-domain-policy.test.mjs
+++ b/test/fetch-content-domain-policy.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const extractUrl = new URL("../extract.ts", import.meta.url).href;
+
+async function runExtract(config, urls, optionsByUrl = []) {
+	const root = await mkdtemp(join(tmpdir(), "pi-domain-policy-extract-"));
+	await writeFile(join(root, "web-search.json"), JSON.stringify(config), "utf8");
+	const childEnv = { ...process.env, PI_CODING_AGENT_DIR: root, HOME: root, USERPROFILE: root };
+	for (const key of ["GEMINI_API_KEY", "GOOGLE_GEMINI_API_KEY", "GOOGLE_API_KEY", "CLOUDFLARE_API_KEY", "PARALLEL_API_KEY", "FIRECRAWL_BASE_URL", "FIRECRAWL_API_KEY"]) delete childEnv[key];
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			let fetchCalls = [];
+			globalThis.fetch = async (url) => {
+				fetchCalls.push(String(url));
+				return new Response(\`<!doctype html><html><head><title>Allowed</title></head><body><article><h1>Allowed</h1><p>\${"Readable content. ".repeat(60)}</p></article></body></html>\`, { status: 200, headers: { "content-type": "text/html" } });
+			};
+			const { extractContent } = await import(${JSON.stringify(extractUrl)});
+			const urls = ${JSON.stringify(urls)};
+			const optionsByUrl = ${JSON.stringify(optionsByUrl)};
+			const results = [];
+			for (let index = 0; index < urls.length; index += 1) {
+				results.push(await extractContent(urls[index], undefined, { ...optionsByUrl[index], lookup: async () => [{ address: "93.184.216.34", family: 4 }] }));
+			}
+			console.log(JSON.stringify({ fetchCalls, results }));
+		`,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+	assert.equal(child.status, 0, child.stderr);
+	return JSON.parse(child.stdout.trim());
+}
+
+test("fetch_content enforces domain policy before target network requests", async () => {
+	const output = await runExtract(
+		{ fetchContent: { domainPolicy: { allow: ["allowed.example"], deny: ["blocked.example"] } } },
+		["https://blocked.example/article", "https://allowed.example/article"],
+	);
+	assert.equal(output.fetchCalls.length, 1);
+	assert.equal(output.fetchCalls[0], "https://allowed.example/article");
+	assert.match(output.results[0].error, /Blocked hostname by fetch_content domain policy/);
+	assert.equal(output.results[1].error, null);
+	assert.equal(output.results[1].title, "Allowed");
+});
+
+test("fetch_content domain policy leaves local file inputs outside hostname checks", async () => {
+	const output = await runExtract(
+		{ fetchContent: { domainPolicy: { allow: ["only.example"] } } },
+		["file:///tmp/not-a-web-source.txt"],
+	);
+	assert.deepEqual(output.fetchCalls, []);
+	assert.doesNotMatch(output.results[0].error, /fetch_content domain policy/);
+});
+
+test("fetch_content domain policy blocks YouTube frame and timestamp branches before network helpers", async () => {
+	const output = await runExtract(
+		{ fetchContent: { domainPolicy: { deny: ["youtube.com"] } } },
+		["https://www.youtube.com/watch?v=dQw4w9WgXcQ", "https://www.youtube.com/watch?v=dQw4w9WgXcQ"],
+		[{ frames: 1 }, { timestamp: "1" }],
+	);
+	assert.deepEqual(output.fetchCalls, []);
+	assert.match(output.results[0].error, /Blocked hostname by fetch_content domain policy: www\.youtube\.com/);
+	assert.match(output.results[1].error, /Blocked hostname by fetch_content domain policy: www\.youtube\.com/);
+});

--- a/test/ssrf-allow-ranges-config.test.mjs
+++ b/test/ssrf-allow-ranges-config.test.mjs
@@ -83,6 +83,48 @@ test("loadSsrfConfig defaults trustEnvProxy to false", async () => {
 	assert.deepEqual(result.config, { allowRanges: ["198.18.0.0/15"], trustEnvProxy: false });
 });
 
+test("loadFetchContentDomainPolicy reads normalized allow and deny hostnames", async () => {
+	const { root, agentDir, configPath } = await makeConfigDir("pi-domain-policy-valid-");
+	await writeFile(configPath, JSON.stringify({ fetchContent: { domainPolicy: { allow: [" Example.COM. "], deny: ["blocked.example.com"] } } }), "utf8");
+
+	const childEnv = envFor(root, agentDir);
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { loadFetchContentDomainPolicy } = await import(${JSON.stringify(extractUrl.replace("/extract.ts", "/ssrf-protection.ts"))});
+			console.log(JSON.stringify(loadFetchContentDomainPolicy()));
+		`,
+		encoding: "utf8",
+		env: childEnv,
+	});
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout), { allow: ["example.com"], deny: ["blocked.example.com"] });
+});
+
+test("loadFetchContentDomainPolicy rejects malformed policy values", async () => {
+	for (const domainPolicy of [
+		{ allow: "example.com" },
+		{ deny: ["*.example.com"] },
+		{ allow: ["example.com", 42] },
+	]) {
+		const { root, agentDir, configPath } = await makeConfigDir("pi-domain-policy-invalid-");
+		await writeFile(configPath, JSON.stringify({ fetchContent: { domainPolicy } }), "utf8");
+		const childEnv = envFor(root, agentDir);
+		const child = spawnSync(process.execPath, ["--input-type=module"], {
+			input: `
+				const { loadFetchContentDomainPolicy } = await import(${JSON.stringify(extractUrl.replace("/extract.ts", "/ssrf-protection.ts"))});
+				try { loadFetchContentDomainPolicy(); console.log(JSON.stringify({ ok: true })); }
+				catch (err) { console.log(JSON.stringify({ ok: false, error: err.message })); }
+			`,
+			encoding: "utf8",
+			env: childEnv,
+		});
+		assert.equal(child.status, 0, child.stderr);
+		const result = JSON.parse(child.stdout);
+		assert.equal(result.ok, false, JSON.stringify(domainPolicy));
+		assert.match(result.error, /fetchContent\.domainPolicy\.(allow|deny)/);
+	}
+});
+
 test("loadSsrfConfig accepts an explicit trustEnvProxy opt-in", async () => {
 	const { root, agentDir, configPath } = await makeConfigDir("pi-ssrf-proxy-enabled-");
 	await writeFile(configPath, JSON.stringify({ ssrf: { trustEnvProxy: true } }), "utf8");

--- a/test/ssrf-protection.test.mjs
+++ b/test/ssrf-protection.test.mjs
@@ -56,6 +56,65 @@ test("validateRemoteUrl permits public HTTP and HTTPS targets", async () => {
 	assert.equal((await validateRemoteUrl("https://[2606:2800:220:1:248:1893:25c8:1946]/")).hostname, "[2606:2800:220:1:248:1893:25c8:1946]");
 });
 
+test("domain policy allows exact and subdomain matches, and is off by default", async () => {
+	assert.equal((await validateRemoteUrl("https://example.com/", { lookup: publicLookup })).hostname, "example.com");
+	assert.equal((await validateRemoteUrl("https://www.example.com/", {
+		lookup: publicLookup,
+		domainPolicy: { allow: ["example.com"], deny: [] },
+	})).hostname, "www.example.com");
+	await assert.rejects(
+		validateRemoteUrl("https://other.test/", {
+			lookup: publicLookup,
+			domainPolicy: { allow: ["example.com"], deny: [] },
+		}),
+		/Hostname not allowed by fetch_content domain policy/,
+	);
+});
+
+test("domain policy deny wins over allow", async () => {
+	await assert.rejects(
+		validateRemoteUrl("https://private.example.com/", {
+			lookup: publicLookup,
+			domainPolicy: { allow: ["example.com"], deny: ["private.example.com"] },
+		}),
+		/Blocked hostname by fetch_content domain policy/,
+	);
+});
+
+test("domain policy validates redirect targets before following", async () => {
+	const requested = [];
+	const fetchImpl = async (url) => {
+		requested.push(url.toString());
+		return new Response("", { status: 302, headers: { location: "https://denied.example/next" } });
+	};
+
+	await assert.rejects(
+		fetchRemoteUrl("https://allowed.example/", {}, {
+			lookup: publicLookup,
+			fetch: fetchImpl,
+			domainPolicy: { allow: ["allowed.example"], deny: ["denied.example"] },
+		}),
+		/Blocked hostname by fetch_content domain policy/,
+	);
+	assert.deepEqual(requested, ["https://allowed.example/"]);
+});
+
+test("domain policy never relaxes SSRF protection", async () => {
+	await assert.rejects(
+		validateRemoteUrl("http://127.0.0.1/", {
+			domainPolicy: { allow: ["127.0.0.1"], deny: [] },
+		}),
+		/Blocked internal address/,
+	);
+	await assert.rejects(
+		validateRemoteUrl("https://internal.example/", {
+			lookup: async () => [{ address: "10.0.0.5", family: 4 }],
+			domainPolicy: { allow: ["example"], deny: [] },
+		}),
+		/Blocked internal address/,
+	);
+});
+
 test("fetchRemoteUrl validates redirect targets before following", async () => {
 	const requested = [];
 	const fetchImpl = async (url) => {


### PR DESCRIPTION
Adds an opt-in config-only `fetchContent.domainPolicy` hostname policy for #79.

The policy is default-off. Bare hostnames match themselves and subdomains; `deny` wins over `allow`. It is enforced before HTTP(S) target handling and before redirects followed by this extension's own fetch path. Local files and non-HTTP sources stay outside the hostname policy, and SSRF protections still run independently so an allow rule cannot bypass private/internal destination blocking.

Prompt/user-confirmation UX is intentionally not included. The README also calls out the boundary for remote extraction services: this extension can preflight the submitted target URL, but services like Firecrawl, Jina, Gemini URL Context, or Parallel may perform their own DNS, redirects, and egress after that.

Validation:
`node --test test/fetch-content-domain-policy.test.mjs test/ssrf-protection.test.mjs test/ssrf-allow-ranges-config.test.mjs test/firecrawl-extraction.test.mjs test/parallel-extract.test.mjs test/fetch-params.test.mjs`
`npm test`
`git diff --check`
`npm pack --dry-run`

Thanks Joseph Maliksi (@jmaliksi) for #79.

Closes #79.
