### PR TITLE
fix: harden unreleased release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to this project will be documented in this file.
 - Removed the bundled `librarian` skill from this package instead of keeping a second research workflow coupled to GitHub clone internals. Thanks mcwalrus (@mcwalrus) for #136 and gravewhisper (@gravewhisper) for #23.
 
 ### Fixed
+- Prevented opt-in Gemini Web browser cookies from crossing origins on redirects, disabled automatic redirects for cookie-bearing generation and upload requests, and restored local file reads for Gemini Web uploads.
+- Preserved caller cancellation in non-curated multi-query searches instead of continuing with later queries, and passed the active extension context into curator-added searches.
+- Hardened new provider result boundaries and removed a dead auto-routing condition without changing provider behavior.
 - Hardened unreleased config/result boundaries by rejecting malformed config roots, reporting malformed SSRF JSON, normalizing invalid Perplexity result counts, and rejecting contradictory curator summary metadata.
 - Reworked opt-in Gemini Web browser-cookie extraction to scan non-default Chromium profiles, preflight required cookie names before Keychain/secret-tool access, and cache encryption passwords only in-process. Thanks Kevin Truong (@kevinQTruong) for the originating PR #14, Jessica Black (@jssblck) for reporting #9, János Veres (@jveres) for reporting #2, and RimuruW (@RimuruW) for reporting #15.
 - Added read-only `sqlite3` CLI and Python stdlib fallbacks when `node:sqlite` is unavailable, with sanitized actionable diagnostics instead of silently reporting Gemini Web as unavailable.

--- a/anysearch.ts
+++ b/anysearch.ts
@@ -99,18 +99,13 @@ function parseResponse(value: unknown): AnySearchResponse {
 			throw invalidResponse(`expected data.results[${index}] object`);
 		}
 		const result = value as Record<string, unknown>;
-		for (const field of ["title", "url", "snippet", "content"] as const) {
-			if (typeof result[field] !== "string") {
-				throw invalidResponse(`expected data.results[${index}].${field} string`);
-			}
-		}
-		if (!result.url) throw invalidResponse(`expected data.results[${index}].url to be non-empty`);
-		results.push({
-			title: result.title,
-			url: result.url,
-			snippet: result.snippet,
-			content: result.content,
-		});
+		const { title, url, snippet, content } = result;
+		if (typeof title !== "string") throw invalidResponse(`expected data.results[${index}].title string`);
+		if (typeof url !== "string") throw invalidResponse(`expected data.results[${index}].url string`);
+		if (typeof snippet !== "string") throw invalidResponse(`expected data.results[${index}].snippet string`);
+		if (typeof content !== "string") throw invalidResponse(`expected data.results[${index}].content string`);
+		if (!url) throw invalidResponse(`expected data.results[${index}].url to be non-empty`);
+		results.push({ title, url, snippet, content });
 	}
 
 	return { code: 0, data: { results, metadata: data.metadata as Record<string, unknown> } };

--- a/chrome-cookies.ts
+++ b/chrome-cookies.ts
@@ -118,8 +118,10 @@ export async function getGoogleCookies(
 				if (metaVersion.failure) sawBackendFailure = metaVersion.failure;
 				if (metaVersion.value === null) continue;
 				const rowsResult = await queryCookieRows(tempDb, hosts, ALL_COOKIE_NAMES);
-				if (rowsResult.failure) sawBackendFailure = rowsResult.failure;
-				if (!rowsResult.rows) continue;
+				if (rowsResult.status === "failure") {
+					sawBackendFailure = rowsResult.failure;
+					continue;
+				}
 
 				const cookies: CookieMap = {};
 				for (const row of rowsResult.rows) {
@@ -307,8 +309,8 @@ async function importSqlite(): Promise<typeof import("node:sqlite") | null> {
 }
 
 type QueryResult =
-	| { rows: SqliteRow[] }
-	| { rows: null; failure: SqliteFailure };
+	| { status: "success"; rows: SqliteRow[] }
+	| { status: "failure"; failure: SqliteFailure };
 
 async function runSqliteQuery(dbPath: string, sql: string): Promise<QueryResult> {
 	const sqlite = await importSqlite();
@@ -317,7 +319,7 @@ async function runSqliteQuery(dbPath: string, sql: string): Promise<QueryResult>
 		try {
 			const db = new sqlite.DatabaseSync(dbPath, { readOnly: true });
 			try {
-				return { rows: db.prepare(sql).all() as SqliteRow[] };
+				return { status: "success", rows: db.prepare(sql).all() as SqliteRow[] };
 			} finally {
 				db.close();
 			}
@@ -327,23 +329,23 @@ async function runSqliteQuery(dbPath: string, sql: string): Promise<QueryResult>
 	}
 
 	const cli = await runSqliteCli(dbPath, sql);
-	if (cli.rows) return cli;
+	if (cli.status === "success") return cli;
 	if (cli.failure === "query") queryFailed = true;
 	const python = await runPythonSqlite(dbPath, sql);
-	if (python.rows) return python;
+	if (python.status === "success") return python;
 	if (python.failure === "query") queryFailed = true;
-	return { rows: null, failure: queryFailed ? "query" : "unavailable" };
+	return { status: "failure", failure: queryFailed ? "query" : "unavailable" };
 }
 
 function runSqliteCli(dbPath: string, sql: string): Promise<QueryResult> {
 	return new Promise((resolve) => {
 		execFile("sqlite3", ["-readonly", "-json", dbPath, sql], { timeout: 5000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
-			if (err) { resolve({ rows: null, failure: err.code === "ENOENT" ? "unavailable" : "query" }); return; }
+			if (err) { resolve({ status: "failure", failure: err.code === "ENOENT" ? "unavailable" : "query" }); return; }
 			try {
 				const parsed = JSON.parse(stdout || "[]");
-				resolve(Array.isArray(parsed) ? { rows: parsed as SqliteRow[] } : { rows: null, failure: "query" });
+				resolve(Array.isArray(parsed) ? { status: "success", rows: parsed as SqliteRow[] } : { status: "failure", failure: "query" });
 			} catch {
-				resolve({ rows: null, failure: "query" });
+				resolve({ status: "failure", failure: "query" });
 			}
 		});
 	});
@@ -353,12 +355,12 @@ function runPythonSqlite(dbPath: string, sql: string): Promise<QueryResult> {
 	const script = "import json,sqlite3,sys\ntry:\n c=sqlite3.connect('file:'+sys.argv[1]+'?mode=ro',uri=True)\n c.row_factory=sqlite3.Row\n print(json.dumps([dict(r) for r in c.execute(sys.argv[2]).fetchall()]))\nexcept Exception:\n sys.exit(1)";
 	return new Promise((resolve) => {
 		execFile("python3", ["-c", script, dbPath, sql], { timeout: 5000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
-			if (err) { resolve({ rows: null, failure: err.code === "ENOENT" ? "unavailable" : "query" }); return; }
+			if (err) { resolve({ status: "failure", failure: err.code === "ENOENT" ? "unavailable" : "query" }); return; }
 			try {
 				const parsed = JSON.parse(stdout || "[]");
-				resolve(Array.isArray(parsed) ? { rows: parsed as SqliteRow[] } : { rows: null, failure: "query" });
+				resolve(Array.isArray(parsed) ? { status: "success", rows: parsed as SqliteRow[] } : { status: "failure", failure: "query" });
 			} catch {
-				resolve({ rows: null, failure: "query" });
+				resolve({ status: "failure", failure: "query" });
 			}
 		});
 	});
@@ -366,7 +368,7 @@ function runPythonSqlite(dbPath: string, sql: string): Promise<QueryResult> {
 
 async function readMetaVersion(dbPath: string): Promise<{ value: number | null; failure?: SqliteFailure }> {
 	const result = await runSqliteQuery(dbPath, "SELECT value FROM meta WHERE key = 'version'");
-	if (!result.rows) {
+	if (result.status === "failure") {
 		return result.failure === "unavailable"
 			? { value: null, failure: result.failure }
 			: { value: 0 };
@@ -379,7 +381,7 @@ async function readMetaVersion(dbPath: string): Promise<{ value: number | null; 
 
 async function hasCookieNames(dbPath: string, hosts: string[], names: string[]): Promise<{ present: boolean; failure?: SqliteFailure }> {
 	const result = await runSqliteQuery(dbPath, `SELECT DISTINCT name FROM cookies WHERE ${buildCookieWhere(hosts, names)}`);
-	if (!result.rows) return { present: false, failure: result.failure };
+	if (result.status === "failure") return { present: false, failure: result.failure };
 	const present = new Set(result.rows.map((row) => typeof row.name === "string" ? row.name : ""));
 	return { present: names.every((name) => present.has(name)) };
 }

--- a/firecrawl.ts
+++ b/firecrawl.ts
@@ -265,13 +265,15 @@ export async function extractWithFirecrawl(
 	if (!data || typeof data !== "object" || Array.isArray(data)) {
 		throw new Error("Firecrawl scrape returned an unexpected data shape");
 	}
-	const content = typeof (data as FirecrawlScrapeData).markdown === "string"
-		? (data as FirecrawlScrapeData).markdown.trim()
-		: null;
-	if (content === null) throw new Error("Firecrawl scrape returned markdown in an unexpected shape");
+	const scrape = data as FirecrawlScrapeData;
+	if (typeof scrape.markdown !== "string") {
+		throw new Error("Firecrawl scrape returned markdown in an unexpected shape");
+	}
+	const content = scrape.markdown.trim();
 	if (!content) return null;
-	const title = typeof (data as FirecrawlScrapeData).metadata?.title === "string" && (data as FirecrawlScrapeData).metadata.title.trim()
-		? (data as FirecrawlScrapeData).metadata.title.trim()
-		: typeof (data as FirecrawlScrapeData).title === "string" ? (data as FirecrawlScrapeData).title.trim() : "";
+	const metadataTitle = scrape.metadata?.title;
+	const title = typeof metadataTitle === "string" && metadataTitle.trim()
+		? metadataTitle.trim()
+		: typeof scrape.title === "string" ? scrape.title.trim() : "";
 	return { url, title, content, error: null };
 }

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -353,7 +353,7 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
-	if (provider !== "exa" && isExaAvailable()) {
+	if (isExaAvailable()) {
 		try {
 			const result = await searchWithExa(query, options);
 			if (result) return { ...result, provider: "exa" };

--- a/gemini-web.ts
+++ b/gemini-web.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import { getLastGoogleCookieDiagnostic, type CookieMap, getGoogleCookies } from "./chrome-cookies.ts";
 import { getChromeProfileFromConfig, isBrowserCookieAccessAllowed, normalizeChromeProfile } from "./gemini-web-config.ts";
@@ -133,6 +134,7 @@ async function runGeminiWebOnce(
 
 	const res = await fetch(GEMINI_STREAM_GENERATE_URL, {
 		method: "POST",
+		redirect: "error",
 		headers: {
 			"content-type": "application/x-www-form-urlencoded;charset=utf-8",
 			host: "gemini.google.com",
@@ -191,6 +193,7 @@ async function fetchWithCookieRedirects(
 	signal: AbortSignal,
 ): Promise<string> {
 	let current = url;
+	const allowedOrigin = new URL(url).origin;
 	for (let i = 0; i <= maxRedirects; i++) {
 		const res = await fetch(current, {
 			headers: { "user-agent": USER_AGENT, cookie: cookieHeader },
@@ -200,7 +203,11 @@ async function fetchWithCookieRedirects(
 		if (res.status >= 300 && res.status < 400) {
 			const location = res.headers.get("location");
 			if (location) {
-				current = new URL(location, current).toString();
+				const next = new URL(location, current);
+				if (next.origin !== allowedOrigin) {
+					throw new Error(`Refusing to send Google cookies across origins: ${allowedOrigin} -> ${next.origin}`);
+				}
+				current = next.toString();
 				continue;
 			}
 		}
@@ -300,6 +307,7 @@ async function uploadFile(
 
 	const res = await fetch(GEMINI_UPLOAD_URL, {
 		method: "POST",
+		redirect: "error",
 		headers: {
 			"content-type": `multipart/form-data; boundary=${boundary}`,
 			"push-id": GEMINI_UPLOAD_PUSH_ID,

--- a/index.ts
+++ b/index.ts
@@ -1095,7 +1095,7 @@ export default function (pi: ExtensionAPI) {
 		return { results, urls };
 	}
 
-	async function openCuratorBrowser(callId: string, pc: PendingCurate, searchesComplete = true): Promise<void> {
+	async function openCuratorBrowser(callId: string, pc: PendingCurate, ctx: ExtensionContext, searchesComplete = true): Promise<void> {
 		if (pendingCurates.get(callId) !== pc) return;
 		let handle: CuratorServerHandle | null = null;
 		const sendCuratorFallbackUpdate = (message: string) => {
@@ -1334,7 +1334,7 @@ export default function (pi: ExtensionAPI) {
 			const [callId, pc] = entries[entries.length - 1];
 
 			if (pc.phase === "searching") {
-				pc.browserPromise = openCuratorBrowser(callId, pc, false);
+				pc.browserPromise = openCuratorBrowser(callId, pc, ctx, false);
 				ctx.ui.notify("Opening curator — remaining searches will stream in", "info");
 				return;
 			}
@@ -1510,7 +1510,7 @@ export default function (pi: ExtensionAPI) {
 				const onAbort = () => closeCurator(callId);
 				pendingCurates.set(callId, pc);
 				signal?.addEventListener("abort", onAbort, { once: true });
-				pc.browserPromise = openCuratorBrowser(callId, pc, false);
+				pc.browserPromise = openCuratorBrowser(callId, pc, ctx, false);
 
 				for (let qi = 0; qi < queryList.length; qi++) {
 					if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
@@ -1621,6 +1621,7 @@ export default function (pi: ExtensionAPI) {
 					}
 					if (inlineContent) allInlineContent.push(...inlineContent);
 				} catch (err) {
+					if (signal?.aborted || isAbortError(err)) throw err;
 					const message = err instanceof Error ? err.message : String(err);
 					const requestedProvider = typeof resolvedProvider === "string" && resolvedProvider !== "auto"
 						? resolvedProvider

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-access",
   "version": "0.13.0",
-  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, Tavily, SearXNG, Firecrawl extraction, Exa, Perplexity, and Gemini.",
+  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, Tavily, SERPdive, AnySearch, SearXNG, Firecrawl extraction, Exa, Perplexity, and Gemini.",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/test/curator-fallback.test.mjs
+++ b/test/curator-fallback.test.mjs
@@ -14,6 +14,12 @@ test("web_search curator auto-open failures keep the curator alive with a manual
 	assert.doesNotMatch(indexSrc, /Failed to open curator UI: \$\{message\}`\);\n\t\t\tif \(pendingCurates\.get\(callId\) === pc \|\| \(handle && activeCurators\.get\(callId\) === handle\)\) \{\n\t\t\t\tcloseCurator\(callId\);/);
 });
 
+test("curator add-search receives the active extension context", () => {
+	assert.match(indexSrc, /openCuratorBrowser\(callId: string, pc: PendingCurate, ctx: ExtensionContext,/);
+	assert.match(indexSrc, /openCuratorBrowser\(callId, pc, ctx, false\)/);
+	assert.match(indexSrc, /extensionContext: ctx,/);
+});
+
 test("curator fallback helper is visible to the browser-open catch block", () => {
 	const functionIndex = indexSrc.indexOf("async function openCuratorBrowser");
 	const declarationIndex = indexSrc.indexOf("const sendCuratorFallbackUpdate", functionIndex);

--- a/test/gemini-web-cookie-opt-in.test.mjs
+++ b/test/gemini-web-cookie-opt-in.test.mjs
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 const moduleUrl = new URL("../gemini-web-config.ts", import.meta.url).href;
+const geminiWebUrl = new URL("../gemini-web.ts", import.meta.url).href;
 
 function runCookieAccessCheck(home, extraEnv = {}) {
 	const env = { ...process.env, HOME: home, USERPROFILE: home, ...extraEnv };
@@ -21,6 +22,79 @@ function runCookieAccessCheck(home, extraEnv = {}) {
 		env,
 	});
 }
+
+test("Gemini Web never forwards browser cookies across origins", async () => {
+	const originalFetch = globalThis.fetch;
+	const calls = [];
+	try {
+		globalThis.fetch = async (url, init = {}) => {
+			calls.push({ url: String(url), cookie: init.headers?.cookie, redirect: init.redirect });
+			if (String(url).startsWith("https://gemini.google.com/") || String(url).startsWith("https://accounts.google.com/")) {
+				return new Response(null, { status: 302, headers: { location: "https://attacker.example/collect" } });
+			}
+			throw new Error(`Unexpected cross-origin request: ${url}`);
+		};
+
+		const { getActiveGoogleEmail } = await import(geminiWebUrl);
+		const email = await getActiveGoogleEmail({ "__Secure-1PSID": "sensitive-cookie" });
+		assert.equal(email, null);
+		assert.equal(calls.some((call) => call.url.startsWith("https://attacker.example/")), false);
+		assert.equal(calls.every((call) => call.redirect === "manual"), true);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("Gemini Web generation rejects automatic redirects", async () => {
+	const originalFetch = globalThis.fetch;
+	try {
+		globalThis.fetch = async (url, init = {}) => {
+			if (String(url) === "https://gemini.google.com/app") {
+				return new Response('"SNlM0e":"test-token"', { status: 200 });
+			}
+			if (String(url).includes("BardFrontendService/StreamGenerate")) {
+				assert.equal(init.redirect, "error");
+				throw new Error("generation transport reached");
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+
+		const { queryWithCookies } = await import(geminiWebUrl);
+		await assert.rejects(
+			queryWithCookies("search", { "__Secure-1PSID": "cookie" }),
+			/generation transport reached/,
+		);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
+
+test("Gemini Web file uploads read the file and reject automatic redirects", async () => {
+	const originalFetch = globalThis.fetch;
+	const dir = await mkdtemp(join(tmpdir(), "pi-web-access-gemini-upload-"));
+	const filePath = join(dir, "sample.txt");
+	await writeFile(filePath, "sample", "utf8");
+	try {
+		globalThis.fetch = async (url, init = {}) => {
+			if (String(url) === "https://gemini.google.com/app") {
+				return new Response('"SNlM0e":"test-token"', { status: 200 });
+			}
+			if (String(url) === "https://content-push.googleapis.com/upload") {
+				assert.equal(init.redirect, "error");
+				throw new Error("upload transport reached");
+			}
+			throw new Error(`Unexpected request: ${url}`);
+		};
+
+		const { queryWithCookies } = await import(geminiWebUrl);
+		await assert.rejects(
+			queryWithCookies("inspect file", { "__Secure-1PSID": "cookie" }, { files: [filePath] }),
+			/upload transport reached/,
+		);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+});
 
 test("browser cookie access is disabled unless explicitly allowed", async () => {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-cookie-opt-in-"));

--- a/test/provider-precedence.test.mjs
+++ b/test/provider-precedence.test.mjs
@@ -119,6 +119,42 @@ test("malformed config root fails with an explicit object-shape error", async ()
 	assert.match(child.stderr, /Invalid config in .*web-search\.json: expected a JSON object/);
 });
 
+test("non-curated search stops after caller cancellation", async () => {
+	const agentDir = await createConfig(null);
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			let calls = 0;
+			globalThis.fetch = async () => {
+				calls += 1;
+				throw new DOMException("The operation was aborted", "AbortError");
+			};
+			const tools = [];
+			const pi = {
+				registerTool(tool) { tools.push(tool); },
+				registerShortcut() {}, registerCommand() {}, on() {}, appendEntry() {}, sendMessage() {},
+			};
+			const extension = (await import(${JSON.stringify(indexUrl)})).default;
+			extension(pi);
+			const tool = tools.find((candidate) => candidate.name === "web_search");
+			const controller = new AbortController();
+			controller.abort();
+			let error = "";
+			try {
+				await tool.execute("cancel-test", { queries: ["first", "second"], provider: "anysearch", workflow: "none" }, controller.signal);
+			} catch (err) {
+				error = String(err);
+			}
+			console.log(JSON.stringify({ calls, error }));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PI_CODING_AGENT_DIR: agentDir },
+	});
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.calls, 1);
+	assert.match(output.error, /abort/i);
+});
+
 test("curated and non-curated branches both resolve the requested provider", async () => {
 	const { readFile } = await import("node:fs/promises");
 	const source = await readFile(new URL("../index.ts", import.meta.url), "utf8");


### PR DESCRIPTION
## Summary

This is the minimal cleanup from a full `v0.13.0..HEAD` release-readiness audit.

- contain opt-in Gemini Web cookies to same-origin manual redirects and reject automatic redirects on cookie-bearing generation/upload requests
- restore the missing local-file read import for Gemini Web uploads
- preserve caller cancellation in non-curated multi-query searches
- pass the active extension context into curator-added searches
- tighten AnySearch, Firecrawl, routing, and SQLite result state boundaries without changing provider behavior
- update focused regressions, changelog, and provider metadata

The package version remains `0.13.0` and the changelog remains `[Unreleased]` intentionally. Version promotion is a separate release operation; this PR does not create a release or tag.

## Validation

- focused release regressions: 59/59
- `npm test`: 201/201
- `git diff --check`
- `npm pack --dry-run`
- `pi -e ./index.ts --list-models`
- fresh read-only review of the exact candidate: no blocker and no over-engineering finding

A broad TypeScript diagnostic comparison also removed all new diagnostics in the touched provider/runtime files and reduced the total from the v0.13.0 baseline; unrelated pre-existing diagnostics remain outside this focused change.
