### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-25
+
 ### Added
 - Added optional `fetchContent.domainPolicy` hostname allow/deny rules for `fetch_content`, checked before target requests and redirects while preserving SSRF protection and local-source behavior. Thanks Joseph Maliksi (@jmaliksi) for #79.
 - Added explicit-only AnySearch direct search provider with anonymous access, optional `anysearchApiKey` / `ANYSEARCH_API_KEY` credentials, strict response validation, and request-time credential sources. Thanks Robin (@choronz) for #130.

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -132,8 +132,12 @@ function normalizeSummaryMeta(value: unknown): SummaryMeta | null {
 	if (!value || typeof value !== "object") return null;
 	const meta = value as Record<string, unknown>;
 
-	const model = meta.model;
-	if (model !== null && typeof model !== "string") return null;
+	const model = meta.model === null
+		? null
+		: typeof meta.model === "string"
+			? meta.model
+			: undefined;
+	if (model === undefined) return null;
 
 	const durationMs = meta.durationMs;
 	if (typeof durationMs !== "number" || !Number.isFinite(durationMs) || durationMs < 0) return null;
@@ -144,16 +148,18 @@ function normalizeSummaryMeta(value: unknown): SummaryMeta | null {
 	const fallbackUsed = meta.fallbackUsed;
 	if (typeof fallbackUsed !== "boolean") return null;
 
-	const fallbackReason = meta.fallbackReason;
-	if (fallbackReason !== undefined && typeof fallbackReason !== "string") return null;
+	const fallbackReason = typeof meta.fallbackReason === "string" ? meta.fallbackReason : undefined;
+	if (meta.fallbackReason !== undefined && fallbackReason === undefined) return null;
 
-	const phase = meta.phase;
-	if (phase !== undefined && phase !== "summary-model" && phase !== "deterministic-fallback") return null;
+	const phase = meta.phase === "summary-model" || meta.phase === "deterministic-fallback"
+		? meta.phase
+		: undefined;
+	if (meta.phase !== undefined && phase === undefined) return null;
 	if (phase === "deterministic-fallback" && fallbackUsed !== true) return null;
 	if (phase === "summary-model" && fallbackUsed !== false) return null;
 
-	const edited = meta.edited;
-	if (edited !== undefined && typeof edited !== "boolean") return null;
+	const edited = typeof meta.edited === "boolean" ? meta.edited : undefined;
+	if (meta.edited !== undefined && edited === undefined) return null;
 
 	return {
 		model,
@@ -447,7 +453,7 @@ export function startCuratorServer(
 					allowEmpty: false,
 					maxExclusive: nextQueryIndex,
 				});
-				if (!parsed.ok) {
+				if ("error" in parsed) {
 					sendJson(res, 400, { ok: false, error: parsed.error });
 					return;
 				}
@@ -475,7 +481,7 @@ export function startCuratorServer(
 
 				try {
 					const result = await callbacks.onSummarize(parsed.indices, controller.signal, model, feedback);
-					if (requestId !== summarizeRequestSeq || state === "COMPLETED") {
+					if (requestId !== summarizeRequestSeq || completed) {
 						sendJson(res, 409, { ok: false, error: "Summarize request superseded" });
 						return;
 					}
@@ -532,7 +538,7 @@ export function startCuratorServer(
 					allowEmpty: true,
 					maxExclusive: nextQueryIndex,
 				});
-				if (!parsed.ok) {
+				if ("error" in parsed) {
 					sendJson(res, 400, { ok: false, error: parsed.error });
 					return;
 				}

--- a/extract.ts
+++ b/extract.ts
@@ -681,6 +681,9 @@ async function extractViaHttp(
 			};
 		}
 
+		if (typeof article.content !== "string") {
+			throw new Error("Readability returned invalid article content");
+		}
 		const markdown = turndown.turndown(article.content);
 		activityMonitor.logComplete(activityId, response.status);
 

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { Box, Text, truncateToWidth } from "@earendil-works/pi-tui";
+import type { AgentToolResult, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Box, Text, truncateToWidth, type KeyId } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { StringEnum, complete, type Model } from "@earendil-works/pi-ai/compat";
+import { StringEnum, complete, type Api, type ImageContent, type Model, type TextContent } from "@earendil-works/pi-ai/compat";
 import type { ExtractedContent, ExtractOptions } from "./extract.ts";
 import { normalizeFetchContentParams } from "./fetch-params.ts";
 import { clearCloneCache } from "./github-extract.ts";
@@ -52,8 +52,11 @@ import {
 	withClaimAssessment,
 	storeResearchArtifact,
 	getResearchArtifact,
+	type RecencyFilter,
 	type ResearchArtifact,
 } from "./source-check.ts";
+
+type ExtensionTheme = ExtensionContext["ui"]["theme"];
 
 const WEB_SEARCH_CONFIG_PATH = getWebSearchConfigPath();
 
@@ -74,7 +77,7 @@ function isAbortError(err: unknown): boolean {
 /** Shared collapsed/expanded renderer for an error/cancel plan produced by
  * buildSearchErrorPlan(). Used by every tool renderResult's error branch so
  * Ctrl+O (app.tools.expand) reveals diagnostics instead of a dead-end single line. */
-function renderSearchErrorPlan(plan: SearchErrorPlan, expanded: boolean, theme: { fg: (key: string, s: string) => string; bg: (key: string, s: string) => string }) {
+function renderSearchErrorPlan(plan: SearchErrorPlan, expanded: boolean, theme: ExtensionTheme) {
 	if (expanded) {
 		return new Text(plan.expanded.map((l, i) => i === 0 ? theme.fg("error", l) : theme.fg("toolOutput", l)).join("\n"), 0, 0);
 	}
@@ -101,8 +104,8 @@ interface WebSearchConfig {
 	};
 	toolNames?: Partial<ToolNames>;
 	shortcuts?: {
-		curate?: string;
-		activity?: string;
+		curate?: KeyId;
+		activity?: KeyId;
 	};
 	ssrf?: {
 		/** CIDR ranges exempted from the SSRF guard (e.g. fake-IP proxy ranges). */
@@ -180,7 +183,7 @@ const DEFAULT_TOOL_NAMES: ToolNames = {
 	getSearchContent: "get_search_content",
 };
 const TOOL_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
-const DEFAULT_SHORTCUTS = { curate: "ctrl+shift+s", activity: "ctrl+shift+w" };
+const DEFAULT_SHORTCUTS = { curate: "ctrl+shift+s", activity: "ctrl+shift+w" } satisfies Record<string, KeyId>;
 const DEFAULT_CURATOR_TIMEOUT_SECONDS = 20;
 const MAX_CURATOR_TIMEOUT_SECONDS = 600;
 
@@ -235,6 +238,12 @@ function resolveRequestedProvider(requested: unknown): SearchProvider {
 	if (normalizedRequested && normalizedRequested !== "auto") return normalizedRequested;
 	const config = loadConfig();
 	return normalizeProviderInput(config.searchProvider ?? config.provider) ?? "auto";
+}
+
+function normalizeRecencyFilter(value: unknown): RecencyFilter | undefined {
+	return value === "day" || value === "week" || value === "month" || value === "year"
+		? value
+		: undefined;
 }
 
 function normalizeCuratorTimeoutSeconds(value: unknown): number | undefined {
@@ -395,7 +404,7 @@ interface PendingCurate {
 	onUpdate: ((update: { content: Array<{ type: string; text: string }>; details?: Record<string, unknown> }) => void) | undefined;
 	signal: AbortSignal | undefined;
 	abortSearches: () => void;
-	finish: (value: unknown) => void;
+	finish: (value: AgentToolResult<Record<string, unknown>>) => void;
 	cancel: (reason?: "user" | "stale") => void;
 	browserPromise?: Promise<void>;
 	browserOpenError?: string;
@@ -630,7 +639,7 @@ function updateWidget(ctx: ExtensionContext): void {
 
 function formatEntryLine(
 	entry: ActivityEntry,
-	theme: { fg: (color: string, text: string) => string },
+	theme: ExtensionTheme,
 ): string {
 	const typeStr = entry.type === "api" ? "API" : "GET";
 	const target =
@@ -793,7 +802,7 @@ export default function (pi: ExtensionAPI) {
 			curatorUrl?: string;
 			browserOpenError?: string;
 		},
-	) {
+	): AgentToolResult<Record<string, unknown>> {
 		const message = `Search curation cancelled (${reason}).`;
 		const cancelledQueries = partial?.queries?.length
 			? partial.queries.map(q => ({
@@ -824,7 +833,7 @@ export default function (pi: ExtensionAPI) {
 	async function resolveFirstAvailableModel(
 		ctx: SummaryGenerationContext,
 		candidates: Array<{ provider: string; id: string }>,
-	): Promise<{ model: Model; apiKey: string; headers?: Record<string, string> }> {
+	): Promise<{ model: Model<Api>; apiKey: string; headers?: Record<string, string> }> {
 		const enabledModelPatterns = loadEnabledModelPatterns(ctx);
 		for (const { provider, id } of candidates) {
 			const model = ctx.modelRegistry.find(provider, id);
@@ -855,11 +864,7 @@ export default function (pi: ExtensionAPI) {
 		if (response.stopReason === "aborted") throw new Error("Aborted");
 		const contentParts = Array.isArray(response.content) ? response.content : [];
 		const text = contentParts
-			.map(p => {
-				if (!p || typeof p !== "object") return "";
-				const part = p as Record<string, unknown>;
-				return typeof part.text === "string" ? part.text : "";
-			})
+			.map(part => part.type === "text" ? part.text : "")
 			.join("")
 			.trim();
 		if (!text) throw new Error("Rewrite returned empty response");
@@ -979,7 +984,7 @@ export default function (pi: ExtensionAPI) {
 		};
 	}
 
-	function buildSearchReturn(opts: SearchReturnOptions) {
+	function buildSearchReturn(opts: SearchReturnOptions): AgentToolResult<Record<string, unknown>> {
 		const sc = opts.results.filter(r => !r.error).length;
 		const tr = opts.results.reduce((sum, r) => sum + r.results.length, 0);
 
@@ -1406,6 +1411,7 @@ export default function (pi: ExtensionAPI) {
 			const configWorkflow = loadConfigForExtensionInit().workflow;
 			const workflow = resolveWorkflow(params.workflow ?? configWorkflow, ctx?.hasUI !== false);
 			const shouldCurate = workflow === "summary-review";
+			const recencyFilter = normalizeRecencyFilter(params.recencyFilter);
 
 			if (queryList.length === 0) {
 				return {
@@ -1424,8 +1430,8 @@ export default function (pi: ExtensionAPI) {
 			if (shouldCurate) {
 				closeCurator(callId);
 
-				let resolvePromise: (value: unknown) => void = () => {};
-				const promise = new Promise<unknown>((resolve) => {
+				let resolvePromise: (value: AgentToolResult<Record<string, unknown>>) => void = () => {};
+				const promise = new Promise<AgentToolResult<Record<string, unknown>>>((resolve) => {
 					resolvePromise = resolve;
 				});
 				const includeContent = params.includeContent ?? false;
@@ -1440,7 +1446,7 @@ export default function (pi: ExtensionAPI) {
 				const requestedProvider = resolveRequestedProvider(params.provider);
 				const bootstrap = await loadCuratorBootstrap(requestedProvider, ctx, {
 					numResults: params.numResults,
-					recencyFilter: params.recencyFilter,
+					recencyFilter,
 				});
 				const availableProviders = bootstrap.availableProviders;
 				const defaultProvider = bootstrap.defaultProvider;
@@ -1465,7 +1471,7 @@ export default function (pi: ExtensionAPI) {
 					queryList,
 					includeContent,
 					numResults: params.numResults,
-					recencyFilter: params.recencyFilter,
+					recencyFilter,
 					domainFilter: params.domainFilter,
 					availableProviders,
 					defaultProvider,
@@ -1482,7 +1488,7 @@ export default function (pi: ExtensionAPI) {
 					cancel: () => {},
 				};
 
-				const finish = (value: unknown) => {
+				const finish = (value: AgentToolResult<Record<string, unknown>>) => {
 					if (cancelled) return;
 					cancelled = true;
 					pc.abortSearches();
@@ -1523,7 +1529,7 @@ export default function (pi: ExtensionAPI) {
 						const { answer, results, inlineContent, provider } = await search(queryList[qi], {
 							provider: requestedProvider,
 							numResults: params.numResults,
-							recencyFilter: params.recencyFilter,
+							recencyFilter,
 							domainFilter: params.domainFilter,
 							includeContent: params.includeContent,
 							signal: searchSignal,
@@ -1606,7 +1612,7 @@ export default function (pi: ExtensionAPI) {
 					const { answer, results, inlineContent, provider } = await search(query, {
 						provider: resolvedProvider,
 						numResults: params.numResults,
-						recencyFilter: params.recencyFilter,
+						recencyFilter,
 						domainFilter: params.domainFilter,
 						includeContent: params.includeContent,
 						signal,
@@ -1953,6 +1959,7 @@ export default function (pi: ExtensionAPI) {
 			const domainFilter = Array.isArray(params.domainFilter)
 				? params.domainFilter.filter((domain): domain is string => typeof domain === "string")
 				: undefined;
+			const recencyFilter = normalizeRecencyFilter(params.recencyFilter);
 			const resultsByUrl = new Map<string, SearchResult>();
 			const summaries: string[] = [];
 			const errors: Array<{ query: string; error: string }> = [];
@@ -1964,7 +1971,7 @@ export default function (pi: ExtensionAPI) {
 					const response = await search(query, {
 						provider: resolveRequestedProvider(params.provider),
 						numResults,
-						recencyFilter: params.recencyFilter,
+						recencyFilter,
 						domainFilter,
 						signal,
 						extensionContext: ctx,
@@ -2001,7 +2008,7 @@ export default function (pi: ExtensionAPI) {
 				summary: summaries.length > 0 ? summaries.join("\n\n") : undefined,
 				results,
 				fetched,
-				recency: params.recencyFilter,
+				recency: recencyFilter,
 				domainFilter,
 			}), [claim]);
 			if (errors.length > 0) artifact.errors = errors;
@@ -2047,7 +2054,7 @@ export default function (pi: ExtensionAPI) {
 			})),
 		}),
 
-		async execute(_toolCallId, params, signal, onUpdate) {
+		async execute(_toolCallId, params, signal, onUpdate): Promise<AgentToolResult<Record<string, unknown>>> {
 			const { urlList, options } = normalizeFetchContentParams(params);
 			if (urlList.length === 0) {
 				return {
@@ -2097,7 +2104,7 @@ export default function (pi: ExtensionAPI) {
 						`Use ${toolNames.getSearchContent}({ responseId: "${responseId}", urlIndex: 0, offset: ${MAX_INLINE_CONTENT} }) for the next slice.`;
 				}
 
-				const content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> = [];
+				const content: Array<TextContent | ImageContent> = [];
 				if (result.frames?.length) {
 					for (const frame of result.frames) {
 						content.push({ type: "image", data: frame.data, mimeType: frame.mimeType });
@@ -2286,7 +2293,7 @@ export default function (pi: ExtensionAPI) {
 			limit: Type.Optional(Type.Number({ description: `Maximum characters to return for fetched URL content slices (default/max ${MAX_CONTENT_SLICE_LENGTH})` })),
 		}),
 
-		async execute(_toolCallId, params) {
+		async execute(_toolCallId, params): Promise<AgentToolResult<Record<string, unknown>>> {
 			const data = getResult(params.responseId);
 			if (!data) {
 				return {
@@ -2545,7 +2552,7 @@ export default function (pi: ExtensionAPI) {
 			const curatorTimeoutSeconds = bootstrap.timeoutSeconds;
 			let currentProvider = initialProvider;
 			const rawSearchProvider = normalizeProviderInput(loadConfig().provider ?? "auto") ?? "auto";
-			let currentSearchProvider = rawSearchProvider === "auto" ? "auto" : initialProvider;
+			let currentSearchProvider: SearchProvider = rawSearchProvider === "auto" ? "auto" : initialProvider;
 			const summaryContext: SummaryGenerationContext = {
 				model: ctx.model,
 				modelRegistry: ctx.modelRegistry,

--- a/openai-search.ts
+++ b/openai-search.ts
@@ -111,12 +111,11 @@ function extractAccountId(token: string): string | undefined {
 }
 
 async function resolvePiAuth(ctx: ExtensionContext): Promise<OpenAIAuth | undefined> {
-	const { getModel } = await import("@earendil-works/pi-ai/compat");
 	for (const candidate of AUTH_MODEL_CANDIDATES) {
 		for (const modelId of candidate.models) {
-			const model = getModel(candidate.provider, modelId);
-			if (!model) continue;
 			try {
+				const model = ctx.modelRegistry.find(candidate.provider, modelId);
+				if (!model) continue;
 				const resolved = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 				if (resolved.ok && resolved.apiKey) {
 					return {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "pi-web-access",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, Tavily, SERPdive, AnySearch, SearXNG, Firecrawl extraction, Exa, Perplexity, and Gemini.",
   "type": "module",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "typecheck": "tsc",
+    "audit:runtime": "npm audit --omit=dev --omit=peer"
   },
   "keywords": [
     "pi-package",
@@ -33,6 +35,10 @@
     "banner.png",
     "pi-web-fetch-demo.mp4"
   ],
+  "devDependencies": {
+    "@types/turndown": "^5.0.6",
+    "typescript": "^7.0.2"
+  },
   "dependencies": {
     "@mozilla/readability": "^0.6.0",
     "linkedom": "^0.16.0",

--- a/promise-try.d.ts
+++ b/promise-try.d.ts
@@ -1,0 +1,7 @@
+declare module "promise.try" {
+	function promiseTry<T>(callback: () => T | PromiseLike<T>): Promise<T>;
+	namespace promiseTry {
+		function shim(): void;
+	}
+	export default promiseTry;
+}

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -1,4 +1,4 @@
-import { complete, type Message, type Model } from "@earendil-works/pi-ai/compat";
+import { complete, type Api, type Message, type Model } from "@earendil-works/pi-ai/compat";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 import type { QueryResultData } from "./storage.ts";
@@ -196,14 +196,14 @@ function parseModelSelector(value: string): { provider: string; id: string } {
 async function resolveSummaryModelCandidates(
 	ctx: SummaryGenerationContext,
 	modelOverride?: string,
-): Promise<{ candidates: Array<{ model: Model; apiKey: string; headers?: Record<string, string> }>; errors: string[] }> {
+): Promise<{ candidates: Array<{ model: Model<Api>; apiKey: string; headers?: Record<string, string> }>; errors: string[] }> {
 	const enabledModelPatterns = loadEnabledModelPatterns(ctx);
 	const specs: Array<{ provider: string; id: string }> = [];
 	const normalizedOverride = typeof modelOverride === "string" ? modelOverride.trim() : "";
 	if (normalizedOverride.length > 0) specs.push(parseModelSelector(normalizedOverride));
 	specs.push(...PREFERRED_SUMMARY_MODELS);
 
-	const candidates: Array<{ model: Model; apiKey: string; headers?: Record<string, string> }> = [];
+	const candidates: Array<{ model: Model<Api>; apiKey: string; headers?: Record<string, string> }> = [];
 	const errors: string[] = [];
 	const seen = new Set<string>();
 	for (const spec of specs) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "target": "ES2022"
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary

Prepare the reviewed tree for a future v0.14.0 release without creating a tag or release.

- bump package metadata from the already-published 0.13.0 to 0.14.0
- promote `[Unreleased]` to `0.14.0` dated 2026-07-25 while retaining a fresh empty Unreleased section
- eliminate all 23 prior ad-hoc TypeScript diagnostics, add a minimal TypeScript 7 project gate, and align host API/result boundaries with Pi 0.82.1
- add a package-owned runtime audit gate that excludes host-provided peer dependencies; the owned dependency tree reports zero vulnerabilities

The host-inclusive audit still observes advisories under Pi's peer dependency tree. This package cannot safely override those downstream host resolutions, so the release gate scopes the audit to dependencies this package owns.

## Validation

- focused tests: 53/53
- `npm test`: 201/201
- `npm run typecheck`: 0 diagnostics with TypeScript 7.0.2
- `npm run audit:runtime`: 0 vulnerabilities
- `git diff --check`
- `npm pack --dry-run`: v0.14.0, 44 files, runtime declaration included, tests/config excluded
- `pi -e ./index.ts --list-models` on Pi 0.82.1
- fresh read-only review: no blocker or over-engineering

No release or tag is created by this PR.
