### PR TITLE
Add TinyFish search and fetch provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added TinyFish as a first-class search and extraction provider with `tinyfishApiKey` / `TINYFISH_API_KEY` credentials, domain and recency filters, paginated result counts, batched inline content, ordered routing, curator selection, and a hosted `fetch_content` fallback before Parallel.
+
 ## [0.14.0] - 2026-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Added TinyFish as a first-class search and extraction provider with `tinyfishApiKey` / `TINYFISH_API_KEY` credentials, domain and recency filters, paginated result counts, batched inline content, ordered routing, curator selection, and a hosted `fetch_content` fallback before Parallel.
+- Added TinyFish as a first-class search and extraction provider with `tinyfishApiKey` / `TINYFISH_API_KEY` credentials, domain and recency filters, paginated result counts, batched inline content, ordered routing, curator selection, and a hosted `fetch_content` fallback before Parallel. Thanks José Antonio Galiano Sandoval (`@jagaliano`) for PR #172.
 
 ## [0.14.0] - 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Pi Web Access
 
-**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, Tavily, SERPdive, AnySearch, self-hosted SearXNG, optional browser-cookie Gemini Web, or bring your own API keys.**
+**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, TinyFish, Tavily, SERPdive, AnySearch, self-hosted SearXNG, optional browser-cookie Gemini Web, or bring your own API keys.**
 
 [![npm version](https://img.shields.io/npm/v/pi-web-access?style=for-the-badge)](https://www.npmjs.com/package/pi-web-access)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
@@ -14,11 +14,11 @@ https://github.com/user-attachments/assets/cac6a17a-1eeb-4dde-9818-cdf85d8ea98f
 
 ## Why Pi Web Access
 
-**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, Tavily, SERPdive, Exa, Perplexity, or Gemini API for more control; configure a self-hosted SearXNG endpoint for private search; or opt into browser-cookie access for Gemini Web.
+**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, TinyFish, Tavily, SERPdive, Exa, Perplexity, or Gemini API for more control; configure a self-hosted SearXNG endpoint for private search; or opt into browser-cookie access for Gemini Web.
 
 **Video Understanding** — Point it at a YouTube video or local screen recording and ask questions about what's on screen. Full transcripts, visual descriptions, and frame extraction at exact timestamps.
 
-**Smart Fallbacks** — Every capability has a fallback chain. Search tries configured SearXNG first for local/private search, then OpenAI when suitable and available, Exa, Brave, Parallel, Tavily, SERPdive, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. With no SearXNG configured, the existing zero-config order is unchanged. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages try configured self-hosted Firecrawl first, then Jina Reader, Parallel, and Gemini extraction. Something always works.
+**Smart Fallbacks** — Every capability has a fallback chain. Search tries configured SearXNG first for local/private search, then OpenAI when suitable and available, Exa, Brave, Parallel, TinyFish, Tavily, SERPdive, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. With no SearXNG configured, the existing zero-config order is unchanged. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages try configured self-hosted Firecrawl first, then Jina Reader, TinyFish, Parallel, and Gemini extraction. Something always works.
 
 **GitHub Cloning** — GitHub URLs are cloned locally instead of scraped. The agent gets real file contents and a local path to explore, not rendered HTML.
 
@@ -35,12 +35,13 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
   "openaiApiKey": "sk-...",
   "braveApiKey": "BSA_...",
   "exaApiKey": "exa-...",
+  "tinyfishApiKey": "sk-tinyfish-...",
   "perplexityApiKey": "pplx-...",
   "geminiApiKey": "AIza..."
 }
 ```
 
-In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first for local/private search, then OpenAI when suitable and available, Exa (direct API if keyed, MCP if not), Brave, Parallel, Tavily, SERPdive, Perplexity, Gemini API, and Gemini Web when browser-cookie access is enabled. With no SearXNG configured, the existing zero-config order is unchanged. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
+In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first for local/private search, then OpenAI when suitable and available, Exa (direct API if keyed, MCP if not), Brave, Parallel, TinyFish, Tavily, SERPdive, Perplexity, Gemini API, and Gemini Web when browser-cookie access is enabled. With no SearXNG configured, the existing zero-config order is unchanged. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
 
 For sandboxed networks that provide outbound proxy transport through environment variables, set `ssrf.trustEnvProxy` to `true` to skip local DNS preflight for proxied hostnames:
 
@@ -88,7 +89,7 @@ fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on sc
 
 ### web_search
 
-Search the web via OpenAI, Brave, Parallel, Tavily, SERPdive, AnySearch, self-hosted SearXNG, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
+Search the web via OpenAI, Brave, Parallel, TinyFish, Tavily, SERPdive, AnySearch, self-hosted SearXNG, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
 
 ```typescript
 web_search({ query: "rust async programming" })
@@ -108,7 +109,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "auto-summary" })
 | `numResults` | Results per query (default: 5, max: 20) |
 | `recencyFilter` | `day`, `week`, `month`, or `year` |
 | `domainFilter` | Limit to domains (prefix with `-` to exclude) |
-| `provider` | Configured provider when omitted or set to `auto`; otherwise `openai`, `brave`, `parallel`, `tavily`, `serpdive`, `anysearch`, `searxng`, `exa`, `perplexity`, or `gemini` (auto-selects when no provider or routing is configured; AnySearch is explicit-only) |
+| `provider` | Configured provider when omitted or set to `auto`; otherwise `openai`, `brave`, `parallel`, `tinyfish`, `tavily`, `serpdive`, `anysearch`, `searxng`, `exa`, `perplexity`, or `gemini` (auto-selects when no provider or routing is configured; AnySearch is explicit-only) |
 | `includeContent` | Fetch full page content from sources in background |
 | `workflow` | `none` (skip curator), `summary-review` (open curator and auto-generate a summary draft, default), or `auto-summary` (generate a summary without opening the curator) |
 
@@ -199,20 +200,20 @@ PDF URLs are extracted as text and saved to `~/Downloads/` as markdown. The agen
 
 ### Blocked pages
 
-When Readability fails or returns only a cookie notice, the extension retries configured Firecrawl extraction first, then Jina Reader (handles JS rendering server-side, no API key needed), Parallel, Gemini URL Context API, and Gemini Web extraction when browser cookies are enabled. Firecrawl requests are cache-only by default and require an explicit fresh-scrape opt-in before the Firecrawl server can fetch target URLs. Handles SPAs, JS-heavy pages, and anti-bot protections transparently. Also parses Next.js RSC flight data when present.
+When Readability fails or returns only a cookie notice, the extension retries configured Firecrawl extraction first, then Jina Reader (handles JS rendering server-side, no API key needed), TinyFish, Parallel, Gemini URL Context API, and Gemini Web extraction when browser cookies are enabled. Firecrawl requests are cache-only by default and require an explicit fresh-scrape opt-in before the Firecrawl server can fetch target URLs. Handles SPAs, JS-heavy pages, and anti-bot protections transparently. Also parses Next.js RSC flight data when present.
 
 ## How It Works
 
 ```
 web_search(query)
-  → SearXNG (if configured) → OpenAI (when suitable) → Exa → Brave → Parallel → Tavily → SERPdive → Perplexity → Gemini
+  → SearXNG (if configured) → OpenAI (when suitable) → Exa → Brave → Parallel → TinyFish → Tavily → SERPdive → Perplexity → Gemini
 
 fetch_content(url)
   → Video file?  Gemini API (Files API) → Gemini Web (if browser cookies enabled)
   → GitHub URL?  Clone repo, return file contents + local path
   → YouTube URL? Gemini Web (if browser cookies enabled) → Gemini API → Perplexity
   → HTTP fetch → PDF? Extract text, save to ~/Downloads/
-               → HTML? Readability → RSC parser → Firecrawl (if configured, cache-only by default) → Jina Reader → Parallel → Gemini fallback
+               → HTML? Readability → RSC parser → Firecrawl (if configured, cache-only by default) → Jina Reader → TinyFish → Parallel → Gemini fallback
                → Text/JSON/Markdown? Return directly
 ```
 
@@ -272,6 +273,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "braveApiKey": "BSA_...",
   "exaApiKey": "exa-...",
   "parallelApiKey": "...",
+  "tinyfishApiKey": "sk-tinyfish-...",
   "tavilyApiKey": "tvly-...",
   "serpdiveApiKey": "sd_live_...",
   "serpdiveModel": "krill",
@@ -330,7 +332,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
 }
 ```
 
-All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `tavilyApiKey`, `serpdiveApiKey`, `anysearchApiKey`, `firecrawlApiKey`, `exaApiKey`, `perplexityApiKey`, `geminiApiKey`, and `cloudflareApiKey`) accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time. Escape `$$` as a literal leading `$` and `$!` as a literal leading `!`:
+All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `tinyfishApiKey`, `tavilyApiKey`, `serpdiveApiKey`, `anysearchApiKey`, `firecrawlApiKey`, `exaApiKey`, `perplexityApiKey`, `geminiApiKey`, and `cloudflareApiKey`) accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time. Escape `$$` as a literal leading `$` and `$!` as a literal leading `!`:
 
 ```json
 {
@@ -351,7 +353,24 @@ Set `searxngBaseUrl` or `SEARXNG_BASE_URL` to use a self-hosted SearXNG JSON API
 
 Set `firecrawlBaseUrl` or `FIRECRAWL_BASE_URL` to use Firecrawl as an extraction-only fallback for `fetch_content`. It calls `/v2/scrape` by default; set `firecrawlApiVersion` or `FIRECRAWL_API_VERSION` to `v1` for older self-hosted images. Firecrawl requests are cache-only by default (`lockdown: true`), so the Firecrawl server does not make fresh outbound target requests unless you explicitly set `firecrawlFreshScrape: true` or `FIRECRAWL_FRESH_SCRAPE=1`. Enable fresh scraping only for a Firecrawl deployment whose own egress, redirects, DNS rebinding behavior, and internal-network access are isolated or allowlisted; this extension can preflight the submitted URL but cannot control network requests made by the Firecrawl server. The configured Firecrawl API base URL and redirects are still validated by the same SSRF guard as other remote requests, and Firecrawl credentials are stripped from cross-origin API redirects.
 
-Without an explicit `$` or `!` source, `OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TAVILY_API_KEY`, `SERPDIVE_API_KEY`, `ANYSEARCH_API_KEY`, `FIRECRAWL_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars retain their existing precedence over literal config file values. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` or `searchProvider` sets the default search provider and is used when a tool call omits `provider` or sends `"auto"`: `"openai"`, `"brave"`, `"parallel"`, `"tavily"`, `"serpdive"`, `"anysearch"`, `"searxng"`, `"exa"`, `"perplexity"`, or `"gemini"`. AnySearch is never selected by `auto`; choose it explicitly or place it in `searchRouting`. If either single-provider field is configured, it takes precedence over `searchRouting`. Otherwise, `searchRouting` can opt into an ordered `providers` list and an explicit `fallbackOn` list containing `"transient"`, `"quota"`, and/or `"network"`; only those typed failures continue to the next available candidate. Named providers remain strict, and exhausted routes return per-provider diagnostics. Random, weighted, sticky, and cooldown routing are not enabled. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the configured search and source-check tools while leaving fetch/content tools available. `toolNames` can opt into alternate public tool names for environments where another extension or model reserves the defaults, without changing behavior: `webSearch`, `sourceCheck`, `fetchContent`, and `getSearchContent` default to `web_search`, `source_check`, `fetch_content`, and `get_search_content`. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on the configured search tool, or toggled at runtime with `/curator`. `chromeProfile` pins Gemini Web cookie lookup to a specific Chromium profile. When omitted, detected Chromium profiles are scanned in stable order and the first profile containing the required Gemini cookies is used. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid browser data access and surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. Cookie databases are copied to a temporary read-only working copy; the reader uses `node:sqlite` when available and otherwise tries the `sqlite3` CLI or Python's standard-library SQLite module. `searchModel` overrides the Gemini API model used by the configured search tool without changing URL, YouTube, or video extraction defaults. Gemini API grounded search uses `gemini-2.5-flash` by default; set `searchModel` to choose another model. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected. `ssrf.trustEnvProxy` is a separate opt-in for sandboxed environments with valid HTTP(S) proxy env vars; it skips local DNS preflight only for proxied hostnames and still blocks localhost, literal private IPs, and `NO_PROXY` matches. It does not configure proxy transport.
+Without an explicit `$` or `!` source, `OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TINYFISH_API_KEY`, `TAVILY_API_KEY`, `SERPDIVE_API_KEY`, `ANYSEARCH_API_KEY`, `FIRECRAWL_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars retain their existing precedence over literal config file values. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` or `searchProvider` sets the default search provider and is used when a tool call omits `provider` or sends `"auto"`: `"openai"`, `"brave"`, `"parallel"`, `"tinyfish"`, `"tavily"`, `"serpdive"`, `"anysearch"`, `"searxng"`, `"exa"`, `"perplexity"`, or `"gemini"`. AnySearch is never selected by `auto`; choose it explicitly or place it in `searchRouting`. If either single-provider field is configured, it takes precedence over `searchRouting`. Otherwise, `searchRouting` can opt into an ordered `providers` list and an explicit `fallbackOn` list containing `"transient"`, `"quota"`, and/or `"network"`; only those typed failures continue to the next available candidate. Named providers remain strict, and exhausted routes return per-provider diagnostics. Random, weighted, sticky, and cooldown routing are not enabled. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the configured search and source-check tools while leaving fetch/content tools available. `toolNames` can opt into alternate public tool names for environments where another extension or model reserves the defaults, without changing behavior: `webSearch`, `sourceCheck`, `fetchContent`, and `getSearchContent` default to `web_search`, `source_check`, `fetch_content`, and `get_search_content`. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on the configured search tool, or toggled at runtime with `/curator`. `chromeProfile` pins Gemini Web cookie lookup to a specific Chromium profile. When omitted, detected Chromium profiles are scanned in stable order and the first profile containing the required Gemini cookies is used. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid browser data access and surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. Cookie databases are copied to a temporary read-only working copy; the reader uses `node:sqlite` when available and otherwise tries the `sqlite3` CLI or Python's standard-library SQLite module. `searchModel` overrides the Gemini API model used by the configured search tool without changing URL, YouTube, or video extraction defaults. Gemini API grounded search uses `gemini-2.5-flash` by default; set `searchModel` to choose another model. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected. `ssrf.trustEnvProxy` is a separate opt-in for sandboxed environments with valid HTTP(S) proxy env vars; it skips local DNS preflight only for proxied hostnames and still blocks localhost, literal private IPs, and `NO_PROXY` matches. It does not configure proxy transport.
+
+### TinyFish
+
+`tinyfishApiKey` enables the TinyFish Search and Fetch APIs; alternatively, set `TINYFISH_API_KEY`. Get an API key from the [TinyFish API Keys](https://agent.tinyfish.ai/api-keys) page. Like the other provider keys, `tinyfishApiKey` can contain a literal key, an environment-variable reference, or a trusted command credential source:
+
+```json
+{
+  "tinyfishApiKey": "$TINYFISH_API_KEY",
+  "provider": "tinyfish"
+}
+```
+
+Setting `provider` is optional. In `auto` mode, an available TinyFish provider is tried after Parallel and before Tavily. You can also select it per request with `provider: "tinyfish"` or place `"tinyfish"` in `searchRouting.providers`.
+
+TinyFish Search supports the shared `numResults`, `recencyFilter`, and include/exclude `domainFilter` options. Requests above 10 results use TinyFish pagination. When `includeContent` is true, result URLs are sent to TinyFish Fetch in batches of up to 10 and returned as inline Markdown content. TinyFish Fetch is also used as a hosted `fetch_content` fallback after Jina Reader and before Parallel.
+
+The stable Search (`https://api.search.tinyfish.ai`) and Fetch (`https://api.fetch.tinyfish.ai`) endpoints are built in, so no base URL setting is required. TinyFish currently documents both APIs as credit-free, with Free-plan limits of 30 search requests per minute and 150 fetched URLs per minute; an API key is still required. See the [TinyFish Search reference](https://docs.tinyfish.ai/search-api/reference) and [TinyFish Fetch reference](https://docs.tinyfish.ai/fetch-api/reference).
 
 ### AnySearch
 
@@ -393,7 +412,7 @@ Values use the same format as pi keybindings (e.g. `ctrl+s`, `ctrl+shift+s`, `al
 
 Set `"enabled": false` under any feature to disable it. For GitHub specifically, `githubClone.enabled: false` only skips clone/API specialization; it does not unregister `fetch_content` or block generic URL extraction. Config changes require a Pi restart.
 
-Rate limits: Perplexity is capped at 10 requests/minute (client-side). Content fetches run 3 concurrent with a 30s timeout per URL.
+Rate limits: Perplexity is capped at 10 requests/minute (client-side). TinyFish applies the plan limits documented by its API. Content fetches run 3 concurrent with a 30s timeout per URL.
 
 ## Limitations
 
@@ -417,13 +436,14 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Content f
 | `openai-search.ts` | OpenAI Responses API web search provider with Codex/API-key auth |
 | `brave.ts` | Brave Search API provider |
 | `parallel.ts` | Parallel search provider and extraction fallback |
+| `tinyfish.ts` | TinyFish Search and Fetch API provider |
 | `tavily.ts` | Tavily Search API provider |
 | `serpdive.ts` | SERPdive Search API provider |
 | `anysearch.ts` | Explicit-only AnySearch search provider |
 | `searxng.ts` | Self-hosted SearXNG JSON API search provider |
 | `exa.ts` | Exa.ai search provider — direct API and MCP proxy |
 | `extract.ts` | URL/file path routing, HTTP extraction, fallback orchestration |
-| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, Tavily, SERPdive, Exa, Perplexity, Gemini API, Gemini Web |
+| `gemini-search.ts` | Search routing across OpenAI, Brave, Parallel, TinyFish, Tavily, SERPdive, Exa, Perplexity, Gemini API, Gemini Web |
 | `gemini-url-context.ts` | Gemini URL Context + Web extraction fallbacks |
 | `gemini-web.ts` | Gemini Web client (cookie auth, StreamGenerate) |
 | `gemini-web-config.ts` | Gemini Web profile and browser-cookie opt-in config |

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -8,7 +8,7 @@ function safeInlineJSON(data: unknown): string {
 }
 
 function buildProviderButtons(
-	available: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean },
+	available: { openai: boolean; brave: boolean; parallel: boolean; tinyfish: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean },
 	selected: string,
 	hasInitialQueries: boolean,
 ): string {
@@ -17,6 +17,7 @@ function buildProviderButtons(
 		{ value: "exa", label: "Exa", available: available.exa },
 		{ value: "brave", label: "Brave", available: available.brave },
 		{ value: "parallel", label: "Parallel", available: available.parallel },
+		{ value: "tinyfish", label: "TinyFish", available: available.tinyfish },
 		{ value: "tavily", label: "Tavily", available: available.tavily },
 		{ value: "serpdive", label: "SERPdive", available: available.serpdive },
 		{ value: "searxng", label: "SearXNG", available: available.searxng },
@@ -41,7 +42,7 @@ export function generateCuratorPage(
 	queries: string[],
 	sessionToken: string,
 	timeout: number,
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean },
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tinyfish: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean },
 	defaultProvider: string,
 	searchProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
@@ -668,6 +669,11 @@ main {
   color: #89dceb;
   background: rgba(137, 220, 235, 0.14);
   border-color: rgba(137, 220, 235, 0.3);
+}
+.provider-tag.provider-tinyfish {
+  color: #74c7ec;
+  background: rgba(116, 199, 236, 0.14);
+  border-color: rgba(116, 199, 236, 0.3);
 }
 .provider-tag.provider-tavily {
   color: #a6e3a1;
@@ -1402,7 +1408,7 @@ const SCRIPT = `(function() {
   var token = DATA.sessionToken;
   var timeoutSec = DATA.timeout;
   var queries = Array.isArray(DATA.queries) ? DATA.queries : [];
-  var providers = ["openai", "exa", "brave", "parallel", "tavily", "serpdive", "searxng", "perplexity", "gemini", "anysearch"];
+  var providers = ["openai", "exa", "brave", "parallel", "tinyfish", "tavily", "serpdive", "searxng", "perplexity", "gemini", "anysearch"];
   var availProviders = DATA.availableProviders && typeof DATA.availableProviders === "object" ? DATA.availableProviders : {};
   var workflow = "summary-review";
   var initialDefaultProvider = typeof DATA.defaultProvider === "string" ? DATA.defaultProvider : "exa";
@@ -1605,6 +1611,7 @@ const SCRIPT = `(function() {
     if (provider === "openai") return "OpenAI";
     if (provider === "brave") return "Brave";
     if (provider === "parallel") return "Parallel";
+    if (provider === "tinyfish") return "TinyFish";
     if (provider === "tavily") return "Tavily";
     if (provider === "serpdive") return "SERPdive";
     if (provider === "searxng") return "SearXNG";

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -12,7 +12,7 @@ export interface CuratorServerOptions {
 	queries: string[];
 	sessionToken: string;
 	timeout: number;
-	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean };
+	availableProviders: { openai: boolean; brave: boolean; parallel: boolean; tinyfish: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean };
 	defaultProvider: string;
 	searchProvider: string;
 	summaryModels: Array<{ value: string; label: string }>;
@@ -258,6 +258,7 @@ export function startCuratorServer(
 		if (provider === "openai") return availableProviders.openai;
 		if (provider === "brave") return availableProviders.brave;
 		if (provider === "parallel") return availableProviders.parallel;
+		if (provider === "tinyfish") return availableProviders.tinyfish;
 		if (provider === "tavily") return availableProviders.tavily;
 		if (provider === "serpdive") return availableProviders.serpdive;
 		if (provider === "searxng") return availableProviders.searxng;

--- a/extract.ts
+++ b/extract.ts
@@ -10,6 +10,7 @@ import { isYouTubeURL, isYouTubeEnabled, extractYouTube, extractYouTubeFrame, ex
 import { CredentialResolutionError } from "./credential-source.ts";
 import { extractWithUrlContext, extractWithGeminiWeb } from "./gemini-url-context.ts";
 import { extractWithParallel, isParallelAvailable } from "./parallel.ts";
+import { extractWithTinyFish, isTinyFishAvailable } from "./tinyfish.ts";
 import { extractWithFirecrawl, isFirecrawlAvailable } from "./firecrawl.ts";
 import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } from "./video-extract.ts";
 import { fetchRemoteUrl, loadFetchContentDomainPolicy, loadSsrfConfig, validateRemoteUrl, type Lookup } from "./ssrf-protection.ts";
@@ -479,6 +480,21 @@ export async function extractContent(
 	if (jinaResult) return jinaResult;
 	if (signal?.aborted) return abortedResult(url);
 
+	let tinyfishError: string | null = null;
+	try {
+		if (isTinyFishAvailable()) {
+			const tinyfishResult = await extractWithTinyFish(url, signal, options);
+			if (tinyfishResult) return tinyfishResult;
+		}
+	} catch (err) {
+		if (isAbortError(err)) return abortedResult(url);
+		tinyfishError = errorMessage(err);
+		if (isConfigParseError(err)) {
+			return { ...httpResult, error: tinyfishError };
+		}
+	}
+	if (signal?.aborted) return abortedResult(url);
+
 	let parallelError: string | null = null;
 	try {
 		if (isParallelAvailable()) {
@@ -511,11 +527,13 @@ export async function extractContent(
 	const guidance = [
 		httpResult.error,
 		...(firecrawlError ? [`Firecrawl fallback failed: ${firecrawlError}`] : []),
+		...(tinyfishError ? [`TinyFish fallback failed: ${tinyfishError}`] : []),
 		...(parallelError ? [`Parallel fallback failed: ${parallelError}`] : []),
 		"",
 		"Fallback options:",
 		`  \u2022 Set firecrawlBaseUrl in ${WEB_SEARCH_CONFIG_PATH} to a self-hosted Firecrawl instance`,
-		`  \u2022 Set PARALLEL_API_KEY in ${WEB_SEARCH_CONFIG_PATH}`,
+		`  \u2022 Set tinyfishApiKey in ${WEB_SEARCH_CONFIG_PATH} or TINYFISH_API_KEY`,
+		`  \u2022 Set parallelApiKey in ${WEB_SEARCH_CONFIG_PATH} or PARALLEL_API_KEY`,
 		`  \u2022 Set GEMINI_API_KEY in ${WEB_SEARCH_CONFIG_PATH}`,
 		"  \u2022 Sign into gemini.google.com in Chrome",
 		"  \u2022 Use web_search to find content about this topic",

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -9,13 +9,14 @@ import { isExaAvailable, searchWithExa } from "./exa.ts";
 import { isBraveAvailable, searchWithBrave } from "./brave.ts";
 import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
 import { isParallelAvailable, searchWithParallel } from "./parallel.ts";
+import { isTinyFishAvailable, searchWithTinyFish } from "./tinyfish.ts";
 import { isTavilyAvailable, searchWithTavily } from "./tavily.ts";
 import { isSerpdiveAvailable, searchWithSerpdive } from "./serpdive.ts";
 import { isSearXNGAvailable, searchWithSearXNG } from "./searxng.ts";
 import { isAnySearchAvailable, searchWithAnySearch } from "./anysearch.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tavily" | "searxng" | "perplexity" | "gemini" | "exa" | "serpdive" | "anysearch";
+export type SearchProvider = "auto" | "openai" | "brave" | "parallel" | "tinyfish" | "tavily" | "searxng" | "perplexity" | "gemini" | "exa" | "serpdive" | "anysearch";
 export type ResolvedSearchProvider = Exclude<SearchProvider, "auto">;
 export type SearchProviderErrorKind =
 	| "transient"
@@ -62,7 +63,7 @@ export interface AttributedSearchResponse extends SearchResponse {
 
 const CONFIG_PATH = getWebSearchConfigPath();
 const DEFAULT_SEARCH_MODEL = "gemini-2.5-flash";
-const VALID_SEARCH_PROVIDERS: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "searxng", "perplexity", "gemini", "exa", "serpdive", "anysearch"];
+const VALID_SEARCH_PROVIDERS: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tinyfish", "tavily", "searxng", "perplexity", "gemini", "exa", "serpdive", "anysearch"];
 const VALID_ROUTING_KINDS = ["transient", "quota", "network"] as const;
 
 type SearchConfig = {
@@ -262,6 +263,7 @@ async function searchWithResolvedProvider(
 	}
 	if (provider === "brave") return { ...(await searchWithBrave(query, options)), provider };
 	if (provider === "parallel") return { ...(await searchWithParallel(query, options)), provider };
+	if (provider === "tinyfish") return { ...(await searchWithTinyFish(query, options)), provider };
 	if (provider === "tavily") return { ...(await searchWithTavily(query, options)), provider };
 	if (provider === "serpdive") return { ...(await searchWithSerpdive(query, options)), provider };
 	if (provider === "anysearch") return { ...(await searchWithAnySearch(query, options)), provider };
@@ -286,6 +288,7 @@ async function isResolvedProviderAvailable(provider: ResolvedSearchProvider, opt
 	if (provider === "openai") return isOpenAISearchAvailable(options.extensionContext);
 	if (provider === "brave") return isBraveAvailable();
 	if (provider === "parallel") return isParallelAvailable();
+	if (provider === "tinyfish") return isTinyFishAvailable();
 	if (provider === "tavily") return isTavilyAvailable();
 	if (provider === "serpdive") return isSerpdiveAvailable();
 	if (provider === "anysearch") return isAnySearchAvailable();
@@ -383,6 +386,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	if (isTinyFishAvailable()) {
+		try {
+			const result = await searchWithTinyFish(query, options);
+			return { ...result, provider: "tinyfish" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`TinyFish: ${errorMessage(err)}`);
+		}
+	}
+
 	if (isTavilyAvailable()) {
 		try {
 			const result = await searchWithTavily(query, options);
@@ -428,8 +441,8 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	throw new Error(
 		"No search provider available. Either:\n" +
 		"  1. Use /login to sign in with a Codex subscription for OpenAI web search\n" +
-		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, tavilyApiKey, serpdiveApiKey, searxngBaseUrl, perplexityApiKey, exaApiKey, geminiApiKey, or cloudflareApiKey in ${CONFIG_PATH}\n` +
-		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, SERPDIVE_API_KEY, SEARXNG_BASE_URL, EXA_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, or CLOUDFLARE_API_KEY env vars\n" +
+		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, tinyfishApiKey, tavilyApiKey, serpdiveApiKey, searxngBaseUrl, perplexityApiKey, exaApiKey, geminiApiKey, or cloudflareApiKey in ${CONFIG_PATH}\n` +
+		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TINYFISH_API_KEY, TAVILY_API_KEY, SERPDIVE_API_KEY, SEARXNG_BASE_URL, EXA_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, or CLOUDFLARE_API_KEY env vars\n" +
 		"  4. Set GOOGLE_GEMINI_BASE_URL with CLOUDFLARE_API_KEY for Cloudflare AI Gateway routing\n" +
 		"  5. Sign into gemini.google.com in a supported Chromium-based browser\n" +
 		"  6. Explicitly select provider: \"anysearch\" for anonymous AnySearch"

--- a/index.ts
+++ b/index.ts
@@ -41,6 +41,7 @@ import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
 import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
 import { isParallelAvailable } from "./parallel.ts";
+import { isTinyFishAvailable } from "./tinyfish.ts";
 import { isTavilyAvailable } from "./tavily.ts";
 import { isSerpdiveAvailable } from "./serpdive.ts";
 import { isSearXNGAvailable } from "./searxng.ts";
@@ -94,6 +95,7 @@ function renderSearchErrorPlan(plan: SearchErrorPlan, expanded: boolean, theme: 
 
 interface WebSearchConfig {
 	anysearchApiKey?: unknown;
+	tinyfishApiKey?: unknown;
 	provider?: string;
 	searchProvider?: string;
 	workflow?: string;
@@ -119,6 +121,7 @@ interface ProviderAvailability {
 	openai: boolean;
 	brave: boolean;
 	parallel: boolean;
+	tinyfish: boolean;
 	tavily: boolean;
 	serpdive: boolean;
 	searxng: boolean;
@@ -229,7 +232,7 @@ function normalizeProviderInput(value: unknown): SearchProvider | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") return "auto";
 	const normalized = value.trim().toLowerCase();
-	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini", "serpdive", "anysearch"];
+	const valid: SearchProvider[] = ["auto", "openai", "brave", "parallel", "tinyfish", "tavily", "searxng", "exa", "perplexity", "gemini", "serpdive", "anysearch"];
 	return valid.includes(normalized as SearchProvider) ? normalized as SearchProvider : "auto";
 }
 
@@ -282,6 +285,7 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 		openai: await isOpenAISearchAvailable(ctx),
 		brave: isBraveAvailable(),
 		parallel: isParallelAvailable(),
+		tinyfish: isTinyFishAvailable(),
 		tavily: isTavilyAvailable(),
 		serpdive: isSerpdiveAvailable(),
 		searxng: isSearXNGAvailable(),
@@ -320,6 +324,7 @@ function firstAvailableProvider(available: ProviderAvailability, preferOpenAI: b
 	if (available.exa) return "exa";
 	if (available.brave) return "brave";
 	if (available.parallel) return "parallel";
+	if (available.tinyfish) return "tinyfish";
 	if (available.tavily) return "tavily";
 	if (available.serpdive) return "serpdive";
 	if (available.perplexity) return "perplexity";
@@ -353,6 +358,9 @@ function resolveProvider(
 	}
 	if (provider === "parallel" && !available.parallel) {
 		return firstAvailableProvider(available, preferOpenAI, "parallel");
+	}
+	if (provider === "tinyfish" && !available.tinyfish) {
+		return firstAvailableProvider(available, preferOpenAI, "tinyfish");
 	}
 	if (provider === "tavily" && !available.tavily) {
 		return firstAvailableProvider(available, preferOpenAI, "tavily");
@@ -1381,7 +1389,7 @@ export default function (pi: ExtensionAPI) {
 		name: toolNames.webSearch,
 		label: "Web Search",
 		description:
-			`Search the web using OpenAI, Brave, Parallel, Tavily, SearXNG, Exa, Perplexity, Gemini, or AnySearch. Returns an AI-synthesized answer with source citations. OpenAI search uses a Codex subscription or OpenAI API key. AnySearch is available only when explicitly selected. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation or "auto-summary" for a model-generated summary without the browser curator. The configured provider is used when provider is omitted or set to auto; omit provider unless explicitly overriding it. Without a configured provider, auto-selects OpenAI when suitable and available, then Exa, Brave, Parallel, Tavily, Perplexity, Gemini API, or Gemini Web. When SearXNG is configured, it is preferred first for local/private search.`,
+			`Search the web using OpenAI, Brave, Parallel, TinyFish, Tavily, SearXNG, Exa, Perplexity, Gemini, or AnySearch. Returns an AI-synthesized answer with source citations. OpenAI search uses a Codex subscription or OpenAI API key. AnySearch is available only when explicitly selected. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation or "auto-summary" for a model-generated summary without the browser curator. The configured provider is used when provider is omitted or set to auto; omit provider unless explicitly overriding it. Without a configured provider, auto-selects OpenAI when suitable and available, then Exa, Brave, Parallel, TinyFish, Tavily, Perplexity, Gemini API, or Gemini Web. When SearXNG is configured, it is preferred first for local/private search.`,
 		promptSnippet:
 			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage. Omit provider unless explicitly overriding the configured default.",
 		parameters: Type.Object({
@@ -1394,7 +1402,7 @@ export default function (pi: ExtensionAPI) {
 			),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
 			provider: Type.Optional(
-				StringEnum(["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini", "serpdive", "anysearch"], { description: "Search provider; omit this field (preferred) to use the configured provider, or use auto when none is configured" }),
+				StringEnum(["auto", "openai", "brave", "parallel", "tinyfish", "tavily", "searxng", "exa", "perplexity", "gemini", "serpdive", "anysearch"], { description: "Search provider; omit this field (preferred) to use the configured provider, or use auto when none is configured" }),
 			),
 			workflow: Type.Optional(
 				StringEnum(["none", "summary-review", "auto-summary"], {
@@ -1941,7 +1949,7 @@ export default function (pi: ExtensionAPI) {
 			fetchContent: Type.Optional(Type.Boolean({ description: "Fetch up to 5 result pages for exact passage extraction." })),
 			recencyFilter: Type.Optional(StringEnum(["day", "week", "month", "year"], { description: "Filter by recency." })),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains; prefix with - to exclude." })),
-			provider: Type.Optional(StringEnum(["auto", "openai", "brave", "parallel", "tavily", "searxng", "exa", "perplexity", "gemini", "serpdive", "anysearch"], { description: "Search provider." })),
+			provider: Type.Optional(StringEnum(["auto", "openai", "brave", "parallel", "tinyfish", "tavily", "searxng", "exa", "perplexity", "gemini", "serpdive", "anysearch"], { description: "Search provider." })),
 		}),
 		async execute(_callId, params, signal, _onUpdate, ctx) {
 			const claim = typeof params.claim === "string" ? params.claim.trim() : "";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-access",
   "version": "0.14.0",
-  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, Tavily, SERPdive, AnySearch, SearXNG, Firecrawl extraction, Exa, Perplexity, and Gemini.",
+  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, TinyFish, Tavily, SERPdive, AnySearch, SearXNG, Firecrawl extraction, Exa, Perplexity, and Gemini.",
   "type": "module",
   "scripts": {
     "test": "node --test",
@@ -14,6 +14,7 @@
     "pi-coding-agent",
     "extension",
     "web-search",
+    "tinyfish",
     "perplexity",
     "fetch",
     "scraping"

--- a/test/anysearch-provider.test.mjs
+++ b/test/anysearch-provider.test.mjs
@@ -19,7 +19,7 @@ function runChild(script, env) {
 	const childEnv = { ...process.env };
 	for (const key of [
 		"PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME", "ANYSEARCH_API_KEY", "OPENAI_API_KEY", "BRAVE_API_KEY",
-		"PARALLEL_API_KEY", "TAVILY_API_KEY", "SERPDIVE_API_KEY", "SEARXNG_BASE_URL", "EXA_API_KEY",
+		"PARALLEL_API_KEY", "TINYFISH_API_KEY", "TAVILY_API_KEY", "SERPDIVE_API_KEY", "SEARXNG_BASE_URL", "EXA_API_KEY",
 		"PERPLEXITY_API_KEY", "GEMINI_API_KEY",
 	]) delete childEnv[key];
 	Object.assign(childEnv, env);

--- a/test/fetch-content-domain-policy.test.mjs
+++ b/test/fetch-content-domain-policy.test.mjs
@@ -11,7 +11,7 @@ async function runExtract(config, urls, optionsByUrl = []) {
 	const root = await mkdtemp(join(tmpdir(), "pi-domain-policy-extract-"));
 	await writeFile(join(root, "web-search.json"), JSON.stringify(config), "utf8");
 	const childEnv = { ...process.env, PI_CODING_AGENT_DIR: root, HOME: root, USERPROFILE: root };
-	for (const key of ["GEMINI_API_KEY", "GOOGLE_GEMINI_API_KEY", "GOOGLE_API_KEY", "CLOUDFLARE_API_KEY", "PARALLEL_API_KEY", "FIRECRAWL_BASE_URL", "FIRECRAWL_API_KEY"]) delete childEnv[key];
+	for (const key of ["GEMINI_API_KEY", "GOOGLE_GEMINI_API_KEY", "GOOGLE_API_KEY", "CLOUDFLARE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "FIRECRAWL_BASE_URL", "FIRECRAWL_API_KEY"]) delete childEnv[key];
 	const child = spawnSync(process.execPath, ["--input-type=module"], {
 		input: `
 			let fetchCalls = [];

--- a/test/firecrawl-extraction.test.mjs
+++ b/test/firecrawl-extraction.test.mjs
@@ -12,7 +12,7 @@ function runChild(script, env = {}) {
 	const childEnv = { ...process.env };
 	for (const key of [
 		"PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME", "FIRECRAWL_BASE_URL", "FIRECRAWL_API_KEY",
-		"FIRECRAWL_API_VERSION", "FIRECRAWL_FRESH_SCRAPE", "PARALLEL_API_KEY", "GEMINI_API_KEY",
+		"FIRECRAWL_API_VERSION", "FIRECRAWL_FRESH_SCRAPE", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "GEMINI_API_KEY",
 	]) delete childEnv[key];
 	Object.assign(childEnv, env);
 	return spawnSync(process.execPath, ["--input-type=module"], {

--- a/test/parallel.test.mjs
+++ b/test/parallel.test.mjs
@@ -20,6 +20,7 @@ function runChild(script, env = {}) {
 	const childEnv = { ...process.env };
 	delete childEnv.PI_CODING_AGENT_DIR;
 	delete childEnv.XDG_CONFIG_HOME;
+	delete childEnv.TINYFISH_API_KEY;
 	Object.assign(childEnv, env);
 	return spawnSync(process.execPath, ["--input-type=module"], {
 		input: script,

--- a/test/provider-credential-source.test.mjs
+++ b/test/provider-credential-source.test.mjs
@@ -10,6 +10,7 @@ const braveModuleUrl = new URL("../brave.ts", import.meta.url).href;
 const geminiApiModuleUrl = new URL("../gemini-api.ts", import.meta.url).href;
 const openaiModuleUrl = new URL("../openai-search.ts", import.meta.url).href;
 const parallelModuleUrl = new URL("../parallel.ts", import.meta.url).href;
+const tinyfishModuleUrl = new URL("../tinyfish.ts", import.meta.url).href;
 const perplexityModuleUrl = new URL("../perplexity.ts", import.meta.url).href;
 const tavilyModuleUrl = new URL("../tavily.ts", import.meta.url).href;
 
@@ -32,6 +33,7 @@ function runChild(script, env) {
 		"GOOGLE_GEMINI_BASE_URL",
 		"OPENAI_API_KEY",
 		"PARALLEL_API_KEY",
+		"TINYFISH_API_KEY",
 		"PERPLEXITY_API_KEY",
 		"TAVILY_API_KEY",
 	]) delete childEnv[key];
@@ -118,6 +120,7 @@ test("provider API errors redact resolved credential-source values", async () =>
 		geminiBaseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/google-ai-studio",
 		openaiApiKey: "!printf openai-redaction-secret",
 		parallelApiKey: "!printf parallel-redaction-secret",
+		tinyfishApiKey: "!printf tinyfish-redaction-secret",
 		perplexityApiKey: "!printf perplexity-redaction-secret",
 		tavilyApiKey: "!printf tavily-redaction-secret",
 	});
@@ -127,6 +130,7 @@ test("provider API errors redact resolved credential-source values", async () =>
 			geminiApi: await import(${JSON.stringify(geminiApiModuleUrl)}),
 			openai: await import(${JSON.stringify(openaiModuleUrl)}),
 			parallel: await import(${JSON.stringify(parallelModuleUrl)}),
+			tinyfish: await import(${JSON.stringify(tinyfishModuleUrl)}),
 			perplexity: await import(${JSON.stringify(perplexityModuleUrl)}),
 			tavily: await import(${JSON.stringify(tavilyModuleUrl)}),
 		};
@@ -134,6 +138,7 @@ test("provider API errors redact resolved credential-source values", async () =>
 			["brave", "brave-redaction-secret", () => modules.brave.searchWithBrave("query")],
 			["openai", "openai-redaction-secret", () => modules.openai.searchWithOpenAI("query")],
 			["parallel", "parallel-redaction-secret", () => modules.parallel.searchWithParallel("query")],
+			["tinyfish", "tinyfish-redaction-secret", () => modules.tinyfish.searchWithTinyFish("query")],
 			["perplexity", "perplexity-redaction-secret", () => modules.perplexity.searchWithPerplexity("query")],
 			["tavily", "tavily-redaction-secret", () => modules.tavily.searchWithTavily("query")],
 			["cloudflare", "cf-redaction-secret", () => modules.geminiApi.queryGeminiApiWithVideo("prompt", "files/synthetic")],

--- a/test/provider-precedence.test.mjs
+++ b/test/provider-precedence.test.mjs
@@ -24,7 +24,7 @@ async function createConfig(config = {
 function runTool(agentDir, provider) {
 	const providerSource = provider === undefined ? "undefined" : JSON.stringify(provider);
 	const childEnv = { ...process.env, PI_CODING_AGENT_DIR: agentDir, OPENAI_API_KEY: "openai-test-key" };
-	for (const key of ["BRAVE_API_KEY", "PARALLEL_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY", "GEMINI_API_KEY", "PERPLEXITY_API_KEY"]) {
+	for (const key of ["BRAVE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY", "GEMINI_API_KEY", "PERPLEXITY_API_KEY"]) {
 		delete childEnv[key];
 	}
 	const child = spawnSync(process.execPath, ["--input-type=module"], {

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -21,6 +21,7 @@ function runChild(script, env) {
 		"OPENAI_API_KEY",
 		"BRAVE_API_KEY",
 		"PARALLEL_API_KEY",
+		"TINYFISH_API_KEY",
 		"TAVILY_API_KEY",
 		"SEARXNG_BASE_URL",
 		"EXA_API_KEY",

--- a/test/search-routing.test.mjs
+++ b/test/search-routing.test.mjs
@@ -15,7 +15,7 @@ async function createConfig(config) {
 
 function runChild(script, env) {
 	const childEnv = { ...process.env };
-	for (const key of ["PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME", "OPENAI_API_KEY", "BRAVE_API_KEY", "PARALLEL_API_KEY", "TAVILY_API_KEY", "SERPDIVE_API_KEY", "SEARXNG_BASE_URL", "EXA_API_KEY", "PERPLEXITY_API_KEY", "GEMINI_API_KEY"]) {
+	for (const key of ["PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME", "OPENAI_API_KEY", "BRAVE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "TAVILY_API_KEY", "SERPDIVE_API_KEY", "SEARXNG_BASE_URL", "EXA_API_KEY", "PERPLEXITY_API_KEY", "GEMINI_API_KEY"]) {
 		delete childEnv[key];
 	}
 	Object.assign(childEnv, env);

--- a/test/tinyfish.test.mjs
+++ b/test/tinyfish.test.mjs
@@ -1,0 +1,331 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const tinyfishModuleUrl = new URL("../tinyfish.ts", import.meta.url).href;
+const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
+const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
+const curatorPageModuleUrl = new URL("../curator-page.ts", import.meta.url).href;
+
+const PROVIDER_ENV_KEYS = [
+	"OPENAI_API_KEY",
+	"BRAVE_API_KEY",
+	"PARALLEL_API_KEY",
+	"TINYFISH_API_KEY",
+	"TAVILY_API_KEY",
+	"SERPDIVE_API_KEY",
+	"ANYSEARCH_API_KEY",
+	"SEARXNG_BASE_URL",
+	"EXA_API_KEY",
+	"PERPLEXITY_API_KEY",
+	"GEMINI_API_KEY",
+	"GOOGLE_GEMINI_API_KEY",
+	"GOOGLE_API_KEY",
+	"CLOUDFLARE_API_KEY",
+	"FIRECRAWL_BASE_URL",
+	"FIRECRAWL_API_KEY",
+];
+
+async function createHome(config = {}) {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-tinyfish-"));
+	await mkdir(join(home, ".pi"), { recursive: true });
+	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	return home;
+}
+
+function runChild(script, env = {}) {
+	const childEnv = { ...process.env };
+	delete childEnv.PI_CODING_AGENT_DIR;
+	delete childEnv.XDG_CONFIG_HOME;
+	for (const key of PROVIDER_ENV_KEYS) delete childEnv[key];
+	Object.assign(childEnv, env);
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+}
+
+test("TinyFish availability reads environment and config credentials", async () => {
+	const emptyHome = await createHome();
+	let child = runChild(`
+		const { isTinyFishAvailable } = await import(${JSON.stringify(tinyfishModuleUrl)});
+		console.log(String(isTinyFishAvailable()));
+	`, { HOME: emptyHome, USERPROFILE: emptyHome });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(child.stdout.trim(), "false");
+
+	child = runChild(`
+		const { isTinyFishAvailable } = await import(${JSON.stringify(tinyfishModuleUrl)});
+		console.log(String(isTinyFishAvailable()));
+	`, { HOME: emptyHome, USERPROFILE: emptyHome, TINYFISH_API_KEY: "synthetic-tinyfish-env-key" });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(child.stdout.trim(), "true");
+
+	const configHome = await createHome({ tinyfishApiKey: "synthetic-tinyfish-config-key" });
+	child = runChild(`
+		const { isTinyFishAvailable } = await import(${JSON.stringify(tinyfishModuleUrl)});
+		console.log(String(isTinyFishAvailable()));
+	`, { HOME: configHome, USERPROFILE: configHome });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(child.stdout.trim(), "true");
+});
+
+test("explicit TinyFish search maps filters, results, and full inline content", async () => {
+	const home = await createHome({ provider: "tinyfish" });
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			const urlText = String(url);
+			const headers = Object.fromEntries(new Headers(init.headers));
+			calls.push({ url: urlText, headers, body: init.body ? JSON.parse(init.body) : null });
+			if (urlText.startsWith("https://api.search.tinyfish.ai?")) {
+				return new Response(JSON.stringify({
+					query: "tinyfish docs",
+					results: [
+						{ position: 1, site_name: "docs.tinyfish.ai", title: "TinyFish Docs", snippet: "  Search   and fetch  ", url: "https://docs.tinyfish.ai/" },
+						{ position: 2, site_name: "example.com", title: "Second", snippet: "Second result", url: "https://example.com/second" },
+					],
+					total_results: 2,
+					page: 0,
+				}), { status: 200 });
+			}
+			if (urlText === "https://api.fetch.tinyfish.ai") {
+				return new Response(JSON.stringify({
+					results: [{ url: "https://docs.tinyfish.ai/", final_url: "https://docs.tinyfish.ai/", title: "TinyFish Docs", text: "# Full TinyFish documentation", format: "markdown" }],
+					errors: [],
+				}), { status: 200 });
+			}
+			throw new Error("Unexpected fetch " + urlText);
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("tinyfish docs", {
+			provider: "tinyfish",
+			includeContent: true,
+			numResults: 1,
+			recencyFilter: "week",
+			domainFilter: ["docs.tinyfish.ai", "-example.com"],
+		});
+		console.log(JSON.stringify({ calls, result }));
+	`, { HOME: home, USERPROFILE: home, TINYFISH_API_KEY: "synthetic-tinyfish-test-key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.calls.length, 2);
+	const searchUrl = new URL(output.calls[0].url);
+	assert.equal(searchUrl.origin + searchUrl.pathname, "https://api.search.tinyfish.ai/");
+	assert.equal(searchUrl.searchParams.get("query"), "tinyfish docs");
+	assert.equal(searchUrl.searchParams.get("include_domains"), "docs.tinyfish.ai");
+	assert.equal(searchUrl.searchParams.get("exclude_domains"), "example.com");
+	assert.equal(searchUrl.searchParams.get("recency_minutes"), "10080");
+	assert.equal(output.calls[0].headers["x-api-key"], "synthetic-tinyfish-test-key");
+	assert.deepEqual(output.calls[1].body, {
+		urls: ["https://docs.tinyfish.ai/"],
+		format: "markdown",
+		per_url_timeout_ms: 110000,
+	});
+	assert.equal(output.result.provider, "tinyfish");
+	assert.deepEqual(output.result.results, [{
+		title: "TinyFish Docs",
+		url: "https://docs.tinyfish.ai/",
+		snippet: "Search and fetch",
+	}]);
+	assert.deepEqual(output.result.inlineContent, [{
+		url: "https://docs.tinyfish.ai/",
+		title: "TinyFish Docs",
+		content: "# Full TinyFish documentation",
+		error: null,
+	}]);
+});
+
+test("TinyFish search paginates when more than ten results are requested", async () => {
+	const home = await createHome();
+	const child = runChild(`
+		const urls = [];
+		globalThis.fetch = async (url) => {
+			const parsed = new URL(String(url));
+			urls.push(parsed.toString());
+			const page = Number(parsed.searchParams.get("page") || 0);
+			const start = page * 10;
+			return new Response(JSON.stringify({
+				query: "many",
+				results: Array.from({ length: 10 }, (_, i) => ({ title: "Result " + (start + i), snippet: "Snippet", url: "https://example.com/" + (start + i) })),
+				total_results: 10,
+				page,
+			}), { status: 200 });
+		};
+		const { searchWithTinyFish } = await import(${JSON.stringify(tinyfishModuleUrl)});
+		const result = await searchWithTinyFish("many", { numResults: 15 });
+		console.log(JSON.stringify({ urls, count: result.results.length, last: result.results.at(-1)?.url }));
+	`, { HOME: home, USERPROFILE: home, TINYFISH_API_KEY: "synthetic-tinyfish-test-key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.urls.length, 2);
+	assert.equal(new URL(output.urls[1]).searchParams.get("page"), "1");
+	assert.equal(output.count, 15);
+	assert.equal(output.last, "https://example.com/14");
+});
+
+test("TinyFish extraction maps successful content and reports per-URL errors", async () => {
+	const home = await createHome();
+	const child = runChild(`
+		let attempt = 0;
+		const bodies = [];
+		globalThis.fetch = async (_url, init) => {
+			bodies.push(JSON.parse(init.body));
+			attempt += 1;
+			if (attempt === 1) {
+				return new Response(JSON.stringify({
+					results: [{ url: "https://example.com/good", final_url: "https://example.com/good", title: "Good", text: "# Rendered body", format: "markdown" }],
+					errors: [],
+				}), { status: 200 });
+			}
+			return new Response(JSON.stringify({
+				results: [],
+				errors: [{ url: "https://example.com/blocked", error: "bot_blocked", status: 403 }],
+			}), { status: 200 });
+		};
+		const { extractWithTinyFish } = await import(${JSON.stringify(tinyfishModuleUrl)});
+		const good = await extractWithTinyFish("https://example.com/good", undefined, { prompt: "Read the article", timeoutMs: 45000 });
+		let error = "";
+		try { await extractWithTinyFish("https://example.com/blocked"); }
+		catch (err) { error = err.message; }
+		console.log(JSON.stringify({ bodies, good, error }));
+	`, { HOME: home, USERPROFILE: home, TINYFISH_API_KEY: "synthetic-tinyfish-test-key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.bodies[0], {
+		urls: ["https://example.com/good"],
+		format: "markdown",
+		per_url_timeout_ms: 45000,
+		purpose: "Read the article",
+	});
+	assert.deepEqual(output.good, {
+		url: "https://example.com/good",
+		title: "Good",
+		content: "# Rendered body",
+		error: null,
+	});
+	assert.match(output.error, /TinyFish Fetch failed .*bot_blocked \(HTTP 403\)/);
+});
+
+test("TinyFish API errors redact credentials", async () => {
+	const home = await createHome();
+	const child = runChild(`
+		globalThis.fetch = async () => new Response("rejected synthetic-tinyfish-secret", { status: 401 });
+		const { searchWithTinyFish } = await import(${JSON.stringify(tinyfishModuleUrl)});
+		let error = "";
+		try { await searchWithTinyFish("redact me"); }
+		catch (err) { error = err.message; }
+		console.log(JSON.stringify({ error }));
+	`, { HOME: home, USERPROFILE: home, TINYFISH_API_KEY: "synthetic-tinyfish-secret" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.match(output.error, /TinyFish Search API error 401/);
+	assert.equal(output.error.includes("synthetic-tinyfish-secret"), false);
+	assert.match(output.error, /\[redacted\]/i);
+});
+
+test("fetch_content uses TinyFish before Parallel after local and Jina extraction fail", async () => {
+	const home = await createHome();
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			const urlText = String(url);
+			calls.push(urlText);
+			if (urlText === "https://example.com/app") {
+				return new Response("<html><body><script></script><script></script><script></script><script></script>Loading</body></html>", { status: 200, headers: { "content-type": "text/html" } });
+			}
+			if (urlText.startsWith("https://r.jina.ai/")) return new Response("", { status: 503 });
+			if (urlText === "https://api.fetch.tinyfish.ai") {
+				return new Response(JSON.stringify({
+					results: [{ url: "https://example.com/app", final_url: "https://example.com/app", title: "Rendered", text: "# TinyFish rendered content", format: "markdown" }],
+					errors: [],
+				}), { status: 200 });
+			}
+			if (urlText === "https://api.parallel.ai/v1/extract") throw new Error("Parallel must not run");
+			throw new Error("Unexpected fetch " + urlText);
+		};
+		const { extractContent } = await import(${JSON.stringify(extractModuleUrl)});
+		const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
+		const result = await extractContent("https://example.com/app", undefined, { lookup });
+		console.log(JSON.stringify({ calls, result }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		TINYFISH_API_KEY: "synthetic-tinyfish-test-key",
+		PARALLEL_API_KEY: "synthetic-parallel-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.calls, [
+		"https://example.com/app",
+		"https://r.jina.ai/https://example.com/app",
+		"https://api.fetch.tinyfish.ai",
+	]);
+	assert.deepEqual(output.result, {
+		url: "https://example.com/app",
+		title: "Rendered",
+		content: "# TinyFish rendered content",
+		error: null,
+	});
+});
+
+test("configured searchRouting can select TinyFish", async () => {
+	const home = await createHome({
+		searchRouting: { providers: ["tinyfish"], fallbackOn: ["network"] },
+	});
+	const child = runChild(`
+		globalThis.fetch = async () => new Response(JSON.stringify({
+			query: "route",
+			results: [{ title: "Routed", snippet: "TinyFish route", url: "https://example.com/routed" }],
+			total_results: 1,
+			page: 0,
+		}), { status: 200 });
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("route", { provider: "auto" });
+		console.log(JSON.stringify({ provider: result.provider, results: result.results }));
+	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: join(home, ".pi"), TINYFISH_API_KEY: "synthetic-tinyfish-test-key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.provider, "tinyfish");
+	assert.equal(output.results[0].title, "Routed");
+});
+
+test("curator page exposes TinyFish as a manual provider", async () => {
+	const { generateCuratorPage } = await import(curatorPageModuleUrl);
+	const page = generateCuratorPage(
+		["tinyfish query"],
+		"session-token",
+		20,
+		{
+			openai: false,
+			brave: false,
+			parallel: false,
+			tinyfish: true,
+			tavily: false,
+			serpdive: false,
+			searxng: false,
+			perplexity: false,
+			exa: false,
+			gemini: false,
+			anysearch: false,
+		},
+		"tinyfish",
+		"tinyfish",
+		[],
+		null,
+	);
+	assert.match(page, /data-provider="tinyfish"/);
+	assert.match(page, />TinyFish<\/button>/);
+	assert.match(page, /provider-tag\.provider-tinyfish/);
+});

--- a/test/web-search-answer-render.test.mjs
+++ b/test/web-search-answer-render.test.mjs
@@ -15,6 +15,7 @@ function runChild(script, env) {
 		"OPENAI_API_KEY",
 		"BRAVE_API_KEY",
 		"PARALLEL_API_KEY",
+		"TINYFISH_API_KEY",
 		"TAVILY_API_KEY",
 		"EXA_API_KEY",
 		"PERPLEXITY_API_KEY",

--- a/tinyfish.ts
+++ b/tinyfish.ts
@@ -1,0 +1,397 @@
+import { existsSync, readFileSync } from "node:fs";
+import { activityMonitor } from "./activity.ts";
+import type { ExtractedContent, ExtractOptions } from "./extract.ts";
+import type { SearchOptions, SearchResponse } from "./perplexity.ts";
+import { hasCredentialSource, redactCredential, resolveCredential } from "./credential-source.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const TINYFISH_SEARCH_URL = "https://api.search.tinyfish.ai";
+const TINYFISH_FETCH_URL = "https://api.fetch.tinyfish.ai";
+const CONFIG_PATH = getWebSearchConfigPath();
+const SEARCH_TIMEOUT_MS = 60_000;
+const FETCH_TIMEOUT_MS = 150_000;
+const MAX_FETCH_URLS = 10;
+const MAX_FETCH_PER_URL_TIMEOUT_MS = 110_000;
+
+interface WebSearchConfig {
+	tinyfishApiKey?: unknown;
+}
+
+interface TinyFishSearchResult {
+	position?: number;
+	site_name?: string | null;
+	title?: string | null;
+	snippet?: string | null;
+	url?: string | null;
+	date?: string | null;
+	publisher?: string | null;
+}
+
+interface TinyFishSearchResponse {
+	query?: string;
+	results?: TinyFishSearchResult[];
+	total_results?: number;
+	page?: number;
+}
+
+interface TinyFishFetchResult {
+	url?: string;
+	final_url?: string;
+	title?: string | null;
+	text?: string | Record<string, unknown> | null;
+	format?: string;
+}
+
+interface TinyFishFetchError {
+	url?: string;
+	error?: string;
+	status?: number;
+}
+
+interface TinyFishFetchResponse {
+	results?: TinyFishFetchResult[];
+	errors?: TinyFishFetchError[];
+}
+
+interface TinyFishSearchOptions extends SearchOptions {
+	includeContent?: boolean;
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(raw) as WebSearchConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+export function clearTinyFishConfigCache(): void {
+	cachedConfig = null;
+}
+
+async function getApiKey(signal?: AbortSignal): Promise<string> {
+	const key = await resolveCredential({
+		provider: "TinyFish",
+		configuredValue: loadConfig().tinyfishApiKey,
+		environmentValue: process.env.TINYFISH_API_KEY,
+		signal,
+	});
+	if (!key) {
+		throw new Error(
+			"TinyFish API key not found. Either:\n" +
+			`  1. Create ${CONFIG_PATH} with { "tinyfishApiKey": "your-key" }\n` +
+			"  2. Set TINYFISH_API_KEY environment variable\n" +
+			"Get a key at https://agent.tinyfish.ai/api-keys",
+		);
+	}
+	return key;
+}
+
+export function isTinyFishAvailable(): boolean {
+	return hasCredentialSource({
+		provider: "TinyFish",
+		configuredValue: loadConfig().tinyfishApiKey,
+		environmentValue: process.env.TINYFISH_API_KEY,
+	});
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function requestSignal(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+	const timeout = AbortSignal.timeout(timeoutMs);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function normalizeDomain(value: string): string | null {
+	let input = value.trim().toLowerCase();
+	if (!input) return null;
+	if (input.startsWith("-")) input = input.slice(1).trim();
+	if (!input) return null;
+	try {
+		const parsed = input.includes("://") ? new URL(input) : new URL(`https://${input}`);
+		input = parsed.hostname;
+	} catch {
+		input = input.split("/")[0]?.split(":")[0] ?? "";
+	}
+	input = input.replace(/^\.+|\.+$/g, "");
+	return /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(input) ? input : null;
+}
+
+function mapDomainFilter(domainFilter: string[] | undefined): { includeDomains: string[]; excludeDomains: string[] } {
+	const includeDomains: string[] = [];
+	const excludeDomains: string[] = [];
+	for (const raw of domainFilter ?? []) {
+		const domain = normalizeDomain(raw);
+		if (!domain) continue;
+		const target = raw.trim().startsWith("-") ? excludeDomains : includeDomains;
+		if (!target.includes(domain)) target.push(domain);
+	}
+	return { includeDomains, excludeDomains };
+}
+
+function recencyMinutes(filter: SearchOptions["recencyFilter"]): number | undefined {
+	if (!filter) return undefined;
+	const minutes: Record<NonNullable<SearchOptions["recencyFilter"]>, number> = {
+		day: 1_440,
+		week: 10_080,
+		month: 43_200,
+		year: 525_600,
+	};
+	return minutes[filter];
+}
+
+function normalizeNumResults(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 5;
+	return Math.max(1, Math.min(Math.floor(value), 20));
+}
+
+function buildSearchUrl(query: string, options: SearchOptions, page: number): string {
+	const params = new URLSearchParams({ query });
+	const { includeDomains, excludeDomains } = mapDomainFilter(options.domainFilter);
+	if (includeDomains.length > 0) params.set("include_domains", includeDomains.join(","));
+	if (excludeDomains.length > 0) params.set("exclude_domains", excludeDomains.join(","));
+	const recency = recencyMinutes(options.recencyFilter);
+	if (recency !== undefined) params.set("recency_minutes", String(recency));
+	if (page > 0) params.set("page", String(page));
+	return `${TINYFISH_SEARCH_URL}?${params.toString()}`;
+}
+
+async function tinyFishJsonRequest<T>(
+	label: "Search" | "Fetch",
+	url: string,
+	apiKey: string,
+	init: RequestInit,
+	timeoutMs: number,
+	signal?: AbortSignal,
+): Promise<T> {
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			...init,
+			headers: {
+				"X-API-Key": apiKey,
+				...(init.body ? { "Content-Type": "application/json" } : {}),
+				...init.headers,
+			},
+			signal: requestSignal(signal, timeoutMs),
+		});
+	} catch (err) {
+		const message = errorMessage(err);
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
+	}
+
+	const raw = await response.text();
+	if (!response.ok) {
+		throw new Error(`TinyFish ${label} API error ${response.status}: ${redactCredential(raw, apiKey).slice(0, 300)}`);
+	}
+	try {
+		return JSON.parse(raw) as T;
+	} catch (err) {
+		throw new Error(`TinyFish ${label} API returned invalid JSON: ${errorMessage(err)}`);
+	}
+}
+
+function mapSearchResults(results: TinyFishSearchResult[] | undefined): SearchResponse["results"] {
+	if (!Array.isArray(results)) return [];
+	return results.flatMap((item) => {
+		if (!item || typeof item.url !== "string" || item.url.trim().length === 0) return [];
+		const url = item.url.trim();
+		return [{
+			title: typeof item.title === "string" && item.title.trim() ? item.title.trim() : url,
+			url,
+			snippet: typeof item.snippet === "string" ? item.snippet.replace(/\s+/g, " ").trim() : "",
+		}];
+	});
+}
+
+function deduplicateResults(results: SearchResponse["results"], limit: number): SearchResponse["results"] {
+	const seen = new Set<string>();
+	const unique: SearchResponse["results"] = [];
+	for (const result of results) {
+		if (seen.has(result.url)) continue;
+		seen.add(result.url);
+		unique.push(result);
+		if (unique.length >= limit) break;
+	}
+	return unique;
+}
+
+function buildAnswer(results: SearchResponse["results"]): string {
+	return results.map((result) => {
+		if (result.snippet) return `${result.snippet}\nSource: ${result.title} (${result.url})`;
+		return `Source: ${result.title} (${result.url})`;
+	}).join("\n\n");
+}
+
+function fetchPerUrlTimeout(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return MAX_FETCH_PER_URL_TIMEOUT_MS;
+	return Math.max(1, Math.min(Math.floor(value), MAX_FETCH_PER_URL_TIMEOUT_MS));
+}
+
+function fetchBody(urls: string[], options: ExtractOptions = {}): Record<string, unknown> {
+	const body: Record<string, unknown> = {
+		urls,
+		format: "markdown",
+		per_url_timeout_ms: fetchPerUrlTimeout(options.timeoutMs),
+	};
+	const purpose = options.prompt?.trim();
+	if (purpose) body.purpose = purpose.slice(0, 2_000);
+	return body;
+}
+
+function findFetchError(errors: TinyFishFetchError[] | undefined, url: string): TinyFishFetchError | undefined {
+	if (!Array.isArray(errors)) return undefined;
+	return errors.find(item => item?.url === url) ?? errors[0];
+}
+
+function fetchResultContent(result: TinyFishFetchResult): string {
+	if (typeof result.text === "string") return result.text.trim();
+	if (result.text && typeof result.text === "object") return JSON.stringify(result.text, null, 2);
+	return "";
+}
+
+function mapFetchResult(result: TinyFishFetchResult | undefined, requestedUrl: string): ExtractedContent | null {
+	if (!result) return null;
+	const content = fetchResultContent(result);
+	if (!content) return null;
+	return {
+		url: requestedUrl,
+		title: typeof result.title === "string" ? result.title.trim() : "",
+		content,
+		error: null,
+	};
+}
+
+async function fetchBatch(
+	urls: string[],
+	apiKey: string,
+	signal?: AbortSignal,
+	options: ExtractOptions = {},
+): Promise<TinyFishFetchResponse> {
+	return tinyFishJsonRequest<TinyFishFetchResponse>(
+		"Fetch",
+		TINYFISH_FETCH_URL,
+		apiKey,
+		{ method: "POST", body: JSON.stringify(fetchBody(urls, options)) },
+		FETCH_TIMEOUT_MS,
+		signal,
+	);
+}
+
+async function fetchInlineContent(
+	urls: string[],
+	apiKey: string,
+	signal?: AbortSignal,
+): Promise<ExtractedContent[]> {
+	const content: ExtractedContent[] = [];
+	for (let offset = 0; offset < urls.length; offset += MAX_FETCH_URLS) {
+		const batch = urls.slice(offset, offset + MAX_FETCH_URLS);
+		const data = await fetchBatch(batch, apiKey, signal);
+		if (!Array.isArray(data.results) || !Array.isArray(data.errors)) {
+			throw new Error("TinyFish Fetch API returned an unexpected response shape");
+		}
+		for (const url of batch) {
+			const result = Array.isArray(data.results)
+				? data.results.find(item => item?.url === url || item?.final_url === url)
+				: undefined;
+			const mapped = mapFetchResult(result, url);
+			if (mapped) content.push(mapped);
+		}
+	}
+	return content;
+}
+
+export async function searchWithTinyFish(query: string, options: TinyFishSearchOptions = {}): Promise<SearchResponse> {
+	const apiKey = await getApiKey(options.signal);
+	const numResults = normalizeNumResults(options.numResults);
+	const activityId = activityMonitor.logStart({ type: "api", query });
+	try {
+		const combined: SearchResponse["results"] = [];
+		const pages = numResults > 10 ? 2 : 1;
+		for (let page = 0; page < pages; page++) {
+			const data = await tinyFishJsonRequest<TinyFishSearchResponse>(
+				"Search",
+				buildSearchUrl(query, options, page),
+				apiKey,
+				{ method: "GET" },
+				SEARCH_TIMEOUT_MS,
+				options.signal,
+			);
+			if (!Array.isArray(data.results)) throw new Error("TinyFish Search API returned an unexpected response shape");
+			combined.push(...mapSearchResults(data.results));
+			if (data.results.length < 10) break;
+		}
+
+		const results = deduplicateResults(combined, numResults);
+		const response: SearchResponse = { answer: buildAnswer(results), results };
+		if (options.includeContent && results.length > 0) {
+			const inlineContent = await fetchInlineContent(results.map(result => result.url), apiKey, options.signal);
+			if (inlineContent.length > 0) response.inlineContent = inlineContent;
+		}
+		activityMonitor.logComplete(activityId, 200);
+		return response;
+	} catch (err) {
+		const message = errorMessage(err);
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
+		else activityMonitor.logError(activityId, redactedMessage);
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
+	}
+}
+
+export async function extractWithTinyFish(
+	url: string,
+	signal?: AbortSignal,
+	options: ExtractOptions = {},
+): Promise<ExtractedContent | null> {
+	const apiKey = await getApiKey(signal);
+	const activityId = activityMonitor.logStart({ type: "fetch", url });
+	try {
+		const data = await fetchBatch([url], apiKey, signal, options);
+		if (!Array.isArray(data.results) || !Array.isArray(data.errors)) {
+			throw new Error("TinyFish Fetch API returned an unexpected response shape");
+		}
+		const result = data.results.find(item => item?.url === url || item?.final_url === url) ?? data.results[0];
+		const mapped = mapFetchResult(result, url);
+		if (mapped) {
+			activityMonitor.logComplete(activityId, 200);
+			return mapped;
+		}
+		const fetchError = findFetchError(data.errors, url);
+		if (fetchError) {
+			const status = typeof fetchError.status === "number" ? ` (HTTP ${fetchError.status})` : "";
+			throw new Error(`TinyFish Fetch failed for ${url}: ${fetchError.error || "unknown error"}${status}`);
+		}
+		activityMonitor.logComplete(activityId, 200);
+		return null;
+	} catch (err) {
+		const message = errorMessage(err);
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
+		else activityMonitor.logError(activityId, redactedMessage);
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
+	}
+}


### PR DESCRIPTION
## Summary

[TinyFish](https://docs.tinyfish.ai/) is a web retrieval service that provides APIs for web search and rendered page fetching. This PR adds TinyFish as a first-class Pi Web Access provider for both capabilities.

TinyFish currently documents its Search and Fetch APIs as credit-free. An API key is still required, and the applicable plan rate limits remain controlled by TinyFish.

## What changed

- Added TinyFish Search using the shared `web_search` interface.
- Added TinyFish Fetch for `includeContent` and as a hosted `fetch_content` fallback after Jina Reader and before Parallel.
- Added `tinyfishApiKey` and `TINYFISH_API_KEY` credential support, including the existing `$ENV` and trusted `!command` credential-source conventions.
- Added explicit provider selection, automatic fallback, configured routing, curator availability, provider labels, and documentation.
- Added pagination for searches requesting more than 10 results and Fetch batching for up to 10 URLs per request.

## Consistency with existing providers

The implementation follows the same criteria used by the existing providers:

- shared search options and normalized response types
- strict named-provider behavior plus ordered `auto` and `searchRouting` support
- common credential resolution and credential redaction
- activity monitoring, abort handling, timeouts, and visible provider errors
- curator integration and hosted extraction fallback ordering
- provider-specific regression tests and README configuration guidance

The stable TinyFish Search (`https://api.search.tinyfish.ai`) and Fetch (`https://api.fetch.tinyfish.ai`) endpoints are built in, following the same direct-provider approach used elsewhere. No additional runtime dependency is required.

## Security and scope

- No API keys or confidential information are included.
- The temporary key used for live verification was not persisted.

## Validation

- `npm run typecheck`
- `npm test` — 209 tests passed
- `git diff --check`
- Live TinyFish Search and Fetch smoke tests

API references: [Search](https://docs.tinyfish.ai/search-api/reference) and [Fetch](https://docs.tinyfish.ai/fetch-api/reference).
