### PR TITLE
fix: surface declared Link discovery relations in fetch_content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Surfaced RFC Link / HTML discovery relations (`service-desc`, `service-doc`, `service-meta`, `api-catalog`, `describedby`) from HTTP `Link` headers and matching `link`/`a[rel]` markup during `fetch_content` HTML extraction, including empty SPA shells, without broad `/docs` URL heuristics. Thanks `@XWIlluDelu` for PR #175.
 - Expand leading `~` and `$HOME`-style environment variables in `githubClone.clonePath` before cloning repositories. Thanks `@unship` for PR #184.
 - Write extracted PDF markdown to a temporary `pi-web-pdf` directory by default instead of `~/Downloads`, while preserving explicit output directories. Thanks `@ahalekelly` for PR #183.
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ PDF URLs are extracted as text and saved to `~/Downloads/` as markdown. The agen
 
 ### Blocked pages
 
-When Readability fails or returns only a cookie notice, the extension retries configured Firecrawl extraction first, then Jina Reader (handles JS rendering server-side, no API key needed), TinyFish, Parallel, Gemini URL Context API, and Gemini Web extraction when browser cookies are enabled. Firecrawl requests are cache-only by default and require an explicit fresh-scrape opt-in before the Firecrawl server can fetch target URLs. Handles SPAs, JS-heavy pages, and anti-bot protections transparently. Also parses Next.js RSC flight data when present.
+When Readability fails or returns only a cookie notice, the extension retries configured Firecrawl extraction first, then Jina Reader (handles JS rendering server-side, no API key needed), TinyFish, Parallel, Gemini URL Context API, and Gemini Web extraction when browser cookies are enabled. Firecrawl requests are cache-only by default and require an explicit fresh-scrape opt-in before the Firecrawl server can fetch target URLs. Handles SPAs, JS-heavy pages, and anti-bot protections transparently. Also parses Next.js RSC flight data when present. HTML extraction also surfaces registered discovery relations (`service-desc`, `service-doc`, `service-meta`, `api-catalog`, `describedby`) from the HTTP `Link` header and matching `link`/`a[rel]` markup. Readable or rendered content remains primary; on an empty shell, the normal extraction fallbacks run before declared links are returned on their own.
 
 ## How It Works
 
@@ -216,7 +216,7 @@ fetch_content(url)
   → GitHub URL?  Clone repo, return file contents + local path
   → YouTube URL? Gemini Web (if browser cookies enabled) → Gemini API → Perplexity
   → HTTP fetch → PDF? Extract text, save to ~/Downloads/
-               → HTML? Readability → RSC parser → Firecrawl (if configured, cache-only by default) → Jina Reader → TinyFish → Parallel → Gemini fallback
+               → HTML? Readability (+ declared Link/rel discovery) → RSC parser → Firecrawl (if configured, cache-only by default) → Jina Reader → TinyFish → Parallel → Gemini fallback
                → Text/JSON/Markdown? Return directly
 ```
 

--- a/declared-web-links.ts
+++ b/declared-web-links.ts
@@ -1,0 +1,173 @@
+const MAX_DECLARED_LINKS = 20;
+const MAX_DECLARED_URL_LENGTH = 4096;
+const DECLARATION_RELATIONS = new Set([
+	"api-catalog",
+	"describedby",
+	"service-desc",
+	"service-doc",
+	"service-meta",
+]);
+
+const RELATION_LABELS: Record<string, string> = {
+	"api-catalog": "API catalog",
+	"describedby": "Description",
+	"service-desc": "Service description",
+	"service-doc": "Service documentation",
+	"service-meta": "Service metadata",
+};
+
+export interface DeclaredWebLink {
+	url: string;
+	relations: string[];
+	type?: string;
+}
+
+export function discoverDeclaredWebLinks(
+	document: Document,
+	linkHeader: string | null,
+	responseUrl: string,
+): DeclaredWebLink[] {
+	const links = new Map<string, DeclaredWebLink>();
+	for (const value of splitLinkHeader(linkHeader ?? "")) {
+		const target = /^\s*<([^>]*)>/.exec(value);
+		if (!target) continue;
+		const parameters = parseLinkParameters(value.slice(target[0].length));
+		if (!parameters || parameters.has("anchor")) continue;
+		addDeclaredLink(links, {
+			url: resolveHttpUrl(target[1], responseUrl),
+			relations: declaredRelations(parameters.get("rel")),
+			type: parameters.get("type"),
+		});
+		if (links.size >= MAX_DECLARED_LINKS) break;
+	}
+
+	if (links.size < MAX_DECLARED_LINKS) {
+		const declaredBase = document.querySelector("base[href]")?.getAttribute("href");
+		const documentBase = resolveHttpUrl(declaredBase, responseUrl) ?? responseUrl;
+		for (const element of document.querySelectorAll("link[rel][href], a[rel][href]")) {
+			addDeclaredLink(links, {
+				url: resolveHttpUrl(element.getAttribute("href"), documentBase),
+				relations: declaredRelations(element.getAttribute("rel")),
+				type: element.getAttribute("type"),
+			});
+			if (links.size >= MAX_DECLARED_LINKS) break;
+		}
+	}
+
+	return [...links.values()];
+}
+
+export function appendDeclaredWebLinks(content: string, links: DeclaredWebLink[]): string {
+	if (links.length === 0) return content;
+	const section = [
+		"## Declared links",
+		"",
+		...links.map(formatDeclaredLink),
+	].join("\n");
+	return content.trim() ? `${content.trim()}\n\n${section}` : section;
+}
+
+function addDeclaredLink(
+	links: Map<string, DeclaredWebLink>,
+	candidate: { url: string | null; relations: string[]; type?: string | null },
+): void {
+	if (!candidate.url || candidate.relations.length === 0) return;
+	const existing = links.get(candidate.url);
+	if (existing) {
+		for (const relation of candidate.relations) {
+			if (!existing.relations.includes(relation)) existing.relations.push(relation);
+		}
+		if (!existing.type) existing.type = normalizeMetadata(candidate.type);
+		return;
+	}
+	if (links.size >= MAX_DECLARED_LINKS) return;
+	const type = normalizeMetadata(candidate.type);
+	links.set(candidate.url, {
+		url: candidate.url,
+		relations: candidate.relations,
+		...(type ? { type } : {}),
+	});
+}
+
+function declaredRelations(value: string | null | undefined): string[] {
+	if (!value) return [];
+	return [...new Set(
+		value.trim().toLowerCase().split(/\s+/).filter((relation) => DECLARATION_RELATIONS.has(relation)),
+	)];
+}
+
+function resolveHttpUrl(value: string | null | undefined, baseUrl: string): string | null {
+	if (!value || value.length > MAX_DECLARED_URL_LENGTH) return null;
+	try {
+		const url = new URL(value, baseUrl);
+		if (url.href.length > MAX_DECLARED_URL_LENGTH) return null;
+		return url.protocol === "http:" || url.protocol === "https:" ? url.href : null;
+	} catch {
+		return null;
+	}
+}
+
+function splitOutsideSyntax(input: string, separator: string, protectTargets: boolean): string[] | null {
+	const parts: string[] = [];
+	let start = 0;
+	let inTarget = false;
+	let inQuotes = false;
+	let escaped = false;
+	for (let index = 0; index < input.length; index++) {
+		const character = input[index];
+		if (inQuotes) {
+			if (escaped) escaped = false;
+			else if (character === "\\") escaped = true;
+			else if (character === '"') inQuotes = false;
+			continue;
+		}
+		if (character === '"' && !inTarget) inQuotes = true;
+		else if (protectTargets && character === "<") inTarget = true;
+		else if (protectTargets && character === ">") inTarget = false;
+		else if (character === separator && !inTarget) {
+			parts.push(input.slice(start, index));
+			start = index + 1;
+		}
+	}
+	if (inQuotes || inTarget) return null;
+	parts.push(input.slice(start));
+	return parts;
+}
+
+function splitLinkHeader(header: string): string[] {
+	return (splitOutsideSyntax(header, ",", true) ?? [])
+		.map((value) => value.trim())
+		.filter(Boolean);
+}
+
+function parseLinkParameters(input: string): Map<string, string> | null {
+	const parts = splitOutsideSyntax(input, ";", false);
+	if (!parts || parts.shift()?.trim()) return null;
+
+	const parameters = new Map<string, string>();
+	for (const part of parts) {
+		const match = /^\s*([!#$%&'*+\-.^_`|~A-Za-z0-9]+)(?:\s*=\s*(?:"((?:\\.|[^"])*)"|(\S+)))?\s*$/.exec(part);
+		if (!match) return null;
+		const name = match[1].toLowerCase();
+		const value = match[2] === undefined ? (match[3] ?? "") : match[2].replace(/\\(.)/g, "$1");
+		if (!parameters.has(name)) parameters.set(name, value);
+	}
+	return parameters;
+}
+
+function normalizeMetadata(value: string | null | undefined): string | undefined {
+	if (!value) return undefined;
+	const normalized = value.replace(/\s+/g, " ").trim().slice(0, 160);
+	return normalized || undefined;
+}
+
+function formatDeclaredLink(link: DeclaredWebLink): string {
+	const relation = link.relations.map(inlineCode).join(", ");
+	const type = link.type ? `; ${inlineCode(link.type)}` : "";
+	const label = RELATION_LABELS[link.relations[0]] ?? "Declared link";
+	return `- ${label} (${relation}${type}): <${link.url}>`;
+}
+
+function inlineCode(value: string): string {
+	return `\`${value.replace(/`/g, "'")}\``;
+}

--- a/extract.ts
+++ b/extract.ts
@@ -13,6 +13,7 @@ import { extractWithParallel, isParallelAvailable } from "./parallel.ts";
 import { extractWithTinyFish, isTinyFishAvailable } from "./tinyfish.ts";
 import { extractWithFirecrawl, isFirecrawlAvailable } from "./firecrawl.ts";
 import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } from "./video-extract.ts";
+import { appendDeclaredWebLinks, discoverDeclaredWebLinks, type DeclaredWebLink } from "./declared-web-links.ts";
 import { fetchRemoteUrl, loadFetchContentDomainPolicy, loadSsrfConfig, validateRemoteUrl, type Lookup } from "./ssrf-protection.ts";
 import { formatSeconds, getWebSearchConfigPath } from "./utils.ts";
 
@@ -70,6 +71,8 @@ export interface ExtractedContent {
 	frames?: VideoFrame[];
 	duration?: number;
 }
+
+type HttpExtractedContent = ExtractedContent & { declaredLinks?: DeclaredWebLink[] };
 
 export interface ExtractOptions {
 	timeoutMs?: number;
@@ -452,7 +455,11 @@ export async function extractContent(
 
 	if (signal?.aborted) return abortedResult(url);
 
-	const httpResult = await extractViaHttp(url, signal, options);
+	const { declaredLinks = [], ...httpResult } = await extractViaHttp(url, signal, options);
+	const withDeclaredLinks = (result: ExtractedContent): ExtractedContent => ({
+		...result,
+		content: appendDeclaredWebLinks(result.content, declaredLinks),
+	});
 
 	if (signal?.aborted) return abortedResult(url);
 	if (!httpResult.error) return httpResult;
@@ -467,7 +474,7 @@ export async function extractContent(
 				...(options?.lookup ? { lookup: options.lookup } : {}),
 				ssrf,
 			});
-			if (firecrawlResult) return firecrawlResult;
+			if (firecrawlResult) return withDeclaredLinks(firecrawlResult);
 		}
 	} catch (err) {
 		if (isAbortError(err)) return abortedResult(url);
@@ -477,14 +484,14 @@ export async function extractContent(
 	if (signal?.aborted) return abortedResult(url);
 
 	const jinaResult = await extractWithJinaReader(url, signal, options?.lookup);
-	if (jinaResult) return jinaResult;
+	if (jinaResult) return withDeclaredLinks(jinaResult);
 	if (signal?.aborted) return abortedResult(url);
 
 	let tinyfishError: string | null = null;
 	try {
 		if (isTinyFishAvailable()) {
 			const tinyfishResult = await extractWithTinyFish(url, signal, options);
-			if (tinyfishResult) return tinyfishResult;
+			if (tinyfishResult) return withDeclaredLinks(tinyfishResult);
 		}
 	} catch (err) {
 		if (isAbortError(err)) return abortedResult(url);
@@ -499,7 +506,7 @@ export async function extractContent(
 	try {
 		if (isParallelAvailable()) {
 			const parallelResult = await extractWithParallel(url, signal, options);
-			if (parallelResult) return parallelResult;
+			if (parallelResult) return withDeclaredLinks(parallelResult);
 		}
 	} catch (err) {
 		if (isAbortError(err)) return abortedResult(url);
@@ -521,8 +528,9 @@ export async function extractContent(
 		}
 	}
 
-	if (geminiResult) return geminiResult;
+	if (geminiResult) return withDeclaredLinks(geminiResult);
 	if (signal?.aborted) return abortedResult(url);
+	if (declaredLinks.length > 0) return { ...httpResult, error: null };
 
 	const guidance = [
 		httpResult.error,
@@ -567,7 +575,7 @@ async function extractViaHttp(
 	url: string,
 	signal?: AbortSignal,
 	options?: ExtractOptions,
-): Promise<ExtractedContent> {
+): Promise<HttpExtractedContent> {
 	const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	const activityId = activityMonitor.logStart({ type: "fetch", url });
 
@@ -673,6 +681,12 @@ async function extractViaHttp(
 		}
 
 		const { document } = parseHTML(text);
+		const documentTitle = document.title?.trim() ?? "";
+		const declaredLinks = discoverDeclaredWebLinks(
+			document as unknown as Document,
+			response.headers.get("link"),
+			response.url || url,
+		);
 		const reader = new Readability(document as unknown as Document);
 		const article = reader.parse();
 
@@ -680,12 +694,16 @@ async function extractViaHttp(
 			const rscResult = extractRSCContent(text);
 			if (rscResult) {
 				activityMonitor.logComplete(activityId, response.status);
-				return { url, title: rscResult.title, content: rscResult.content, error: null };
+				return {
+					url,
+					title: rscResult.title,
+					content: appendDeclaredWebLinks(rscResult.content, declaredLinks),
+					error: null,
+					declaredLinks,
+				};
 			}
 
 			activityMonitor.logComplete(activityId, response.status);
-
-			// Provide more specific error message
 			const jsRendered = isLikelyJSRendered(text);
 			const errorMsg = jsRendered
 				? "Page appears to be JavaScript-rendered (content loads dynamically)"
@@ -693,9 +711,10 @@ async function extractViaHttp(
 
 			return {
 				url,
-				title: "",
-				content: "",
+				title: documentTitle,
+				content: appendDeclaredWebLinks("", declaredLinks),
 				error: errorMsg,
+				declaredLinks,
 			};
 		}
 
@@ -708,15 +727,22 @@ async function extractViaHttp(
 		if (markdown.length < MIN_USEFUL_CONTENT) {
 			return {
 				url,
-				title: article.title || "",
-				content: markdown,
+				title: article.title || documentTitle,
+				content: appendDeclaredWebLinks(markdown, declaredLinks),
 				error: isLikelyJSRendered(text)
 					? "Page appears to be JavaScript-rendered (content loads dynamically)"
 					: "Extracted content appears incomplete",
+				declaredLinks,
 			};
 		}
 
-		return { url, title: article.title || "", content: markdown, error: null };
+		return {
+			url,
+			title: article.title || documentTitle,
+			content: appendDeclaredWebLinks(markdown, declaredLinks),
+			error: null,
+			declaredLinks,
+		};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		if (message.toLowerCase().includes("abort")) {

--- a/test/declared-web-links.test.mjs
+++ b/test/declared-web-links.test.mjs
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { parseHTML } from "linkedom";
+import { appendDeclaredWebLinks, discoverDeclaredWebLinks } from "../declared-web-links.ts";
+
+const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
+
+function runChild(script) {
+	const home = mkdtempSync(join(tmpdir(), "pi-web-access-declared-links-"));
+	writeFileSync(join(home, "web-search.json"), "{}\n", "utf8");
+	const childEnv = { ...process.env, HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home };
+	for (const key of [
+		"GEMINI_API_KEY", "GOOGLE_GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GEMINI_BASE_URL",
+		"CLOUDFLARE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "FIRECRAWL_BASE_URL",
+		"FIRECRAWL_API_KEY", "PI_ALLOW_BROWSER_COOKIES",
+	]) delete childEnv[key];
+	try {
+		return spawnSync(process.execPath, ["--input-type=module"], {
+			input: script,
+			encoding: "utf8",
+			env: childEnv,
+			maxBuffer: 2 * 1024 * 1024,
+		});
+	} finally {
+		rmSync(home, { recursive: true, force: true });
+	}
+}
+
+test("discovers registered relations from Link headers and HTML declarations", () => {
+	const { document } = parseHTML(`<!doctype html><html><head>
+		<base href="/v2/">
+		<link rel="stylesheet service-doc" href="docs" type="text/html">
+		<link rel="alternate" href="/feed.xml">
+	</head><body>
+		<a rel="describedby" href="/schema">Schema</a>
+		<a href="/developers">Developer careers</a>
+		<a rel="service-desc" href="javascript:alert(1)">Unsafe</a>
+	</body></html>`);
+	const links = discoverDeclaredWebLinks(
+		document,
+		'</catalog>; title="API, <catalog>"; rel="API-CATALOG"; type="application/linkset+json", ' +
+		'</schema>; rel="service-desc"; type="application/schema+json", ' +
+		'</metadata>; rel="service-meta"; optional, ' +
+		'</quoted>; title="x; rel=service-doc"; rel="alternate", ' +
+		'</anchored>; rel="service-doc"; anchor="/other", ' +
+		'</ignored>; rel="alternate"',
+		"https://example.com/root/start",
+	);
+
+	assert.deepEqual(links, [
+		{
+			url: "https://example.com/catalog",
+			relations: ["api-catalog"],
+			type: "application/linkset+json",
+		},
+		{
+			url: "https://example.com/schema",
+			relations: ["service-desc", "describedby"],
+			type: "application/schema+json",
+		},
+		{
+			url: "https://example.com/metadata",
+			relations: ["service-meta"],
+		},
+		{
+			url: "https://example.com/v2/docs",
+			relations: ["service-doc"],
+			type: "text/html",
+		},
+	]);
+});
+
+test("bounds declarations while preserving their relation annotations", () => {
+	const declarations = Array.from({ length: 25 }, (_, index) =>
+		`<link rel="service-doc" href="/docs/${index}">`
+	).join("");
+	const { document } = parseHTML(`<html><head>${declarations}</head></html>`);
+	const links = discoverDeclaredWebLinks(document, null, "https://example.com/");
+	assert.equal(links.length, 20);
+
+	const oversized = discoverDeclaredWebLinks(
+		parseHTML("<html></html>").document,
+		`<https://example.com/${"x".repeat(4096)}>; rel="service-doc"`,
+		"https://example.com/",
+	);
+	assert.deepEqual(oversized, []);
+
+	const content = appendDeclaredWebLinks("Existing: https://example.com/docs/0-extra", links.slice(0, 2));
+	assert.match(content, /<https:\/\/example\.com\/docs\/0>/);
+	assert.match(content, /<https:\/\/example\.com\/docs\/1>/);
+});
+
+test("HTML extraction surfaces declared documentation links without broad URL heuristics", () => {
+	const child = runChild(`
+		const { extractContent } = await import(${JSON.stringify(extractModuleUrl)});
+		const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
+		const article = "Readable article content remains the primary result. ".repeat(20);
+		const fixtures = {
+			"https://example.com/readable": {
+				html: \`<!doctype html><html><head><title>Readable</title></head><body><article><h1>Readable</h1><p>\${article}</p></article></body></html>\`,
+				link: '</openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json;version=3.1"',
+			},
+			"https://example.com/shell": {
+				html: '<!doctype html><html><head><title>API shell</title><link rel="service-doc" href="/docs"></head><body><div id="app"></div></body></html>',
+			},
+			"https://example.com/fallback": {
+				html: '<!doctype html><html><head><title>Rendered API</title></head><body><div id="app"></div></body></html>',
+				link: '</openapi.json>; rel="service-desc"',
+			},
+			"https://example.com/generic": {
+				html: '<!doctype html><html><head><title>Company</title></head><body><a href="/developers">Developer careers</a></body></html>',
+			},
+		};
+		let calls = [];
+		globalThis.fetch = async (input) => {
+			const url = String(input);
+			calls.push(url);
+			if (url === "https://r.jina.ai/https://example.com/fallback") {
+				return new Response("Title: Rendered API\\nMarkdown Content:\\n# Rendered API\\n\\n" + article, { status: 200 });
+			}
+			const fixture = fixtures[url];
+			if (!fixture) return new Response("not available", { status: 404, statusText: "Not Found" });
+			return new Response(fixture.html, {
+				status: 200,
+				headers: {
+					"content-type": "text/html; charset=utf-8",
+					...(fixture.link ? { link: fixture.link } : {}),
+				},
+			});
+		};
+
+		const readable = await extractContent("https://example.com/readable", undefined, { lookup });
+		const readableCalls = calls.splice(0);
+		const shell = await extractContent("https://example.com/shell", undefined, { lookup });
+		const shellCalls = calls.splice(0);
+		const fallback = await extractContent("https://example.com/fallback", undefined, { lookup });
+		const fallbackCalls = calls.splice(0);
+		const generic = await extractContent("https://example.com/generic", undefined, { lookup });
+		console.log(JSON.stringify({ readable, readableCalls, shell, shellCalls, fallback, fallbackCalls, generic }));
+	`);
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+
+	assert.equal(output.readable.error, null);
+	assert.match(output.readable.content, /Readable article content/);
+	assert.match(output.readable.content, /## Declared links/);
+	assert.match(output.readable.content, /service-desc/);
+	assert.match(output.readable.content, /https:\/\/example\.com\/openapi\.json/);
+	assert.deepEqual(output.readableCalls, ["https://example.com/readable"]);
+
+	assert.equal(output.shell.error, null);
+	assert.match(output.shell.content, /service-doc/);
+	assert.match(output.shell.content, /https:\/\/example\.com\/docs/);
+	assert.deepEqual(output.shellCalls, [
+		"https://example.com/shell",
+		"https://r.jina.ai/https://example.com/shell",
+	]);
+
+	assert.equal(output.fallback.error, null);
+	assert.match(output.fallback.content, /Rendered API/);
+	assert.match(output.fallback.content, /service-desc/);
+	assert.match(output.fallback.content, /https:\/\/example\.com\/openapi\.json/);
+	assert.deepEqual(output.fallbackCalls, [
+		"https://example.com/fallback",
+		"https://r.jina.ai/https://example.com/fallback",
+	]);
+
+	assert.doesNotMatch(output.generic.content, /https:\/\/example\.com\/developers/);
+	assert.ok(output.generic.error);
+});


### PR DESCRIPTION
## Summary

`fetch_content` currently returns only extracted page body text. That drops machine-readable discovery links that APIs can publish through:

- HTTP `Link` headers (`service-desc`, `service-doc`, `service-meta`, `api-catalog`, `describedby`)
- matching HTML `link[rel]` / `a[rel]` markup

A clean upstream `0.15.0` reproduction confirms that readable HTML loses a `service-desc` target and an empty API shell loses its `service-doc` target entirely.

This PR surfaces only those registered relations under `## Declared links`. Readable or rendered content remains primary; incomplete local extraction still follows the existing Firecrawl → Jina → TinyFish → Parallel → Gemini chain, and declarations are returned alone only if all richer extraction fails.

## What changed

- Added a focused discovery/formatting module for RFC-style `Link` values and matching HTML declarations.
- Resolve relative targets against the effective response URL and HTML `base` URL.
- Ignore foreign `anchor` contexts, non-HTTP(S) targets, malformed parameters, unsupported relations, and oversized output.
- Carry declarations through the existing extraction chain without adding or reordering fallbacks.
- Added focused parser and extraction regression tests.
- Documented the behavior in `CHANGELOG.md` and `README.md`.

## Deliberate narrowing

This intentionally does **not**:

- treat bare `/docs`, `/api`, `/developers`, OpenAPI path substrings, or sitemap anchors as discovery
- fetch discovered URLs automatically
- change fallback availability or ordering
- modify direct JSON/text responses

## Validation

- `node --test test/declared-web-links.test.mjs` — 3/3 pass
- `npm run typecheck` — pass
- `git diff --check` — pass
- `npm pack --dry-run --json` — new runtime module included
- `npm test` — 216/218 pass; the same two workstation-sensitive failures reproduce unchanged on an `origin/main` archive (`chrome-cookie-extraction` finds local cookies, and `source-check` sees the TUN fake-IP DNS answer for `example.com`)

## Test plan

- [x] Clean `0.15.0` reproduction proves HTTP and HTML declarations are currently discarded
- [x] Readable HTML keeps article text and adds its declared `service-desc`
- [x] Empty shell runs normal hosted fallback before returning declared links alone
- [x] Successful Jina rendering remains primary and receives the declaration afterward
- [x] Generic `/developers` anchor without a registered relation still fails extraction
- [x] Quoted commas/semicolons, valueless extensions, foreign anchors, HTML base resolution, duplicate targets, unsafe schemes, URL bounds, and the 20-link cap are covered