### PR TITLE
feat: add Search1API search and crawl provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added Search1API as a first-class search and extraction provider with `search1apiApiKey` / `SEARCH1API_KEY` credentials, native domain and recency filters, opt-in Deep Search inline content, provider-array/all-provider routing, curator selection, and a hosted `fetch_content` fallback through the Crawl API. Thanks `@fatwang2` for PR #176.
+
 ### Fixed
 - Accept explicit provider arrays for `web_search` and `source_check`, running only the selected providers concurrently while preserving `auto`, `all`, and sequential routing behavior. Thanks `@XWIlluDelu` for PR #179.
 - Added `curatorRemote` and `autoOpenBrowser` controls for remote-accessible curator sessions, defaulting remote mode to a printed manual URL unless browser auto-open is explicitly requested. Thanks `@tylerdavis` for PR #178.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Pi Web Access
 
-**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, TinyFish, Tavily, SERPdive, AnySearch, self-hosted SearXNG, optional browser-cookie Gemini Web, or bring your own API keys.**
+**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, TinyFish, Search1API, Tavily, SERPdive, AnySearch, self-hosted SearXNG, optional browser-cookie Gemini Web, or bring your own API keys.**
 
 [![npm version](https://img.shields.io/npm/v/pi-web-access?style=for-the-badge)](https://www.npmjs.com/package/pi-web-access)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
@@ -14,11 +14,11 @@ https://github.com/user-attachments/assets/cac6a17a-1eeb-4dde-9818-cdf85d8ea98f
 
 ## Why Pi Web Access
 
-**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, TinyFish, Tavily, SERPdive, Exa, Perplexity, or Gemini API for more control; configure a self-hosted SearXNG endpoint for private search; or opt into browser-cookie access for Gemini Web.
+**Zero Config** — Works out of the box with Exa MCP (no API key needed). If you're signed into Pi with a Codex subscription, OpenAI web search can reuse that auth. Add API keys for OpenAI, Brave, Parallel, TinyFish, Search1API, Tavily, SERPdive, Exa, Perplexity, or Gemini API for more control; configure a self-hosted SearXNG endpoint for private search; or opt into browser-cookie access for Gemini Web.
 
 **Video Understanding** — Point it at a YouTube video or local screen recording and ask questions about what's on screen. Full transcripts, visual descriptions, and frame extraction at exact timestamps.
 
-**Smart Fallbacks** — Every capability has a fallback chain. Search tries configured SearXNG first for local/private search, then OpenAI when suitable and available, Exa, Brave, Parallel, TinyFish, Tavily, SERPdive, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. With no SearXNG configured, the existing zero-config order is unchanged. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages try configured self-hosted Firecrawl first, then Jina Reader, TinyFish, Parallel, and Gemini extraction. Something always works.
+**Smart Fallbacks** — Every capability has a fallback chain. Search tries configured SearXNG first for local/private search, then OpenAI when suitable and available, Exa, Brave, Parallel, TinyFish, Search1API, Tavily, SERPdive, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. With no SearXNG configured, the existing zero-config order is unchanged. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages try configured self-hosted Firecrawl first, then Jina Reader, TinyFish, Search1API, Parallel, and Gemini extraction. Something always works.
 
 **GitHub Cloning** — GitHub URLs are cloned locally instead of scraped. The agent gets real file contents and a local path to explore, not rendered HTML.
 
@@ -36,12 +36,13 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
   "braveApiKey": "BSA_...",
   "exaApiKey": "exa-...",
   "tinyfishApiKey": "sk-tinyfish-...",
+  "search1apiApiKey": "...",
   "perplexityApiKey": "pplx-...",
   "geminiApiKey": "AIza..."
 }
 ```
 
-In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first for local/private search, then OpenAI when suitable and available, Exa (direct API if keyed, MCP if not), Brave, Parallel, TinyFish, Tavily, SERPdive, Perplexity, Gemini API, and Gemini Web when browser-cookie access is enabled. With no SearXNG configured, the existing zero-config order is unchanged. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
+In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first for local/private search, then OpenAI when suitable and available, Exa (direct API if keyed, MCP if not), Brave, Parallel, TinyFish, Search1API, Tavily, SERPdive, Perplexity, Gemini API, and Gemini Web when browser-cookie access is enabled. With no SearXNG configured, the existing zero-config order is unchanged. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
 
 If your OpenAI key belongs to a third-party Responses-compatible gateway, set `openaiResponsesUrl` to that gateway's full Responses endpoint. The default remains `https://api.openai.com/v1/responses`.
 
@@ -91,7 +92,7 @@ fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on sc
 
 ### web_search
 
-Search the web via OpenAI, Brave, Parallel, TinyFish, Tavily, SERPdive, AnySearch, self-hosted SearXNG, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
+Search the web via OpenAI, Brave, Parallel, TinyFish, Search1API, Tavily, SERPdive, AnySearch, self-hosted SearXNG, Exa, Perplexity AI, or Gemini. Returns a synthesized answer with source citations.
 
 ```typescript
 web_search({ query: "rust async programming" })
@@ -112,7 +113,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "auto-summary" })
 | `numResults` | Results per query (default: 5, max: 20) |
 | `recencyFilter` | `day`, `week`, `month`, or `year` |
 | `domainFilter` | Limit to domains (prefix with `-` to exclude) |
-| `provider` | Configured provider when omitted or set to `auto`; `all` searches every eligible provider except AnySearch simultaneously; otherwise `openai`, `brave`, `parallel`, `tinyfish`, `tavily`, `serpdive`, `anysearch`, `searxng`, `exa`, `perplexity`, or `gemini` (auto-selects when no provider or routing is configured; AnySearch is explicit-only) |
+| `provider` | Configured provider when omitted or set to `auto`; `all` searches every eligible provider except AnySearch simultaneously; otherwise `openai`, `brave`, `parallel`, `tinyfish`, `search1api`, `tavily`, `serpdive`, `anysearch`, `searxng`, `exa`, `perplexity`, or `gemini` (auto-selects when no provider or routing is configured; AnySearch is explicit-only) |
 | `includeContent` | Fetch full page content from sources in background |
 | `workflow` | `none` (skip curator), `summary-review` (open curator and auto-generate a summary draft, default), or `auto-summary` (generate a summary without opening the curator) |
 
@@ -203,20 +204,20 @@ PDF URLs are extracted as text and saved to `~/Downloads/` as markdown. The agen
 
 ### Blocked pages
 
-When Readability fails or returns only a cookie notice, the extension retries configured Firecrawl extraction first, then Jina Reader (handles JS rendering server-side, no API key needed), TinyFish, Parallel, Gemini URL Context API, and Gemini Web extraction when browser cookies are enabled. Firecrawl requests are cache-only by default and require an explicit fresh-scrape opt-in before the Firecrawl server can fetch target URLs. Handles SPAs, JS-heavy pages, and anti-bot protections transparently. Also parses Next.js RSC flight data when present. HTML extraction also surfaces registered discovery relations (`service-desc`, `service-doc`, `service-meta`, `api-catalog`, `describedby`) from the HTTP `Link` header and matching `link`/`a[rel]` markup. Readable or rendered content remains primary; on an empty shell, the normal extraction fallbacks run before declared links are returned on their own.
+When Readability fails or returns only a cookie notice, the extension retries configured Firecrawl extraction first, then Jina Reader (handles JS rendering server-side, no API key needed), TinyFish, Search1API, Parallel, Gemini URL Context API, and Gemini Web extraction when browser cookies are enabled. Firecrawl requests are cache-only by default and require an explicit fresh-scrape opt-in before the Firecrawl server can fetch target URLs. Handles SPAs, JS-heavy pages, and anti-bot protections transparently. Also parses Next.js RSC flight data when present. HTML extraction also surfaces registered discovery relations (`service-desc`, `service-doc`, `service-meta`, `api-catalog`, `describedby`) from the HTTP `Link` header and matching `link`/`a[rel]` markup. Readable or rendered content remains primary; on an empty shell, the normal extraction fallbacks run before declared links are returned on their own.
 
 ## How It Works
 
 ```
 web_search(query)
-  → SearXNG (if configured) → OpenAI (when suitable) → Exa → Brave → Parallel → TinyFish → Tavily → SERPdive → Perplexity → Gemini
+  → SearXNG (if configured) → OpenAI (when suitable) → Exa → Brave → Parallel → TinyFish → Search1API → Tavily → SERPdive → Perplexity → Gemini
 
 fetch_content(url)
   → Video file?  Gemini API (Files API) → Gemini Web (if browser cookies enabled)
   → GitHub URL?  Clone repo, return file contents + local path
   → YouTube URL? Gemini Web (if browser cookies enabled) → Gemini API → Perplexity
   → HTTP fetch → PDF? Extract text, save to ~/Downloads/
-               → HTML? Readability (+ declared Link/rel discovery) → RSC parser → Firecrawl (if configured, cache-only by default) → Jina Reader → TinyFish → Parallel → Gemini fallback
+               → HTML? Readability (+ declared Link/rel discovery) → RSC parser → Firecrawl (if configured, cache-only by default) → Jina Reader → TinyFish → Search1API → Parallel → Gemini fallback
                → Text/JSON/Markdown? Return directly
 ```
 
@@ -278,6 +279,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "exaApiKey": "exa-...",
   "parallelApiKey": "...",
   "tinyfishApiKey": "sk-tinyfish-...",
+  "search1apiApiKey": "...",
   "tavilyApiKey": "tvly-...",
   "serpdiveApiKey": "sd_live_...",
   "serpdiveModel": "krill",
@@ -341,7 +343,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
 }
 ```
 
-All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `tinyfishApiKey`, `tavilyApiKey`, `serpdiveApiKey`, `anysearchApiKey`, `firecrawlApiKey`, `exaApiKey`, `perplexityApiKey`, `geminiApiKey`, and `cloudflareApiKey`) accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time. Escape `$$` as a literal leading `$` and `$!` as a literal leading `!`:
+All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `tinyfishApiKey`, `search1apiApiKey`, `tavilyApiKey`, `serpdiveApiKey`, `anysearchApiKey`, `firecrawlApiKey`, `exaApiKey`, `perplexityApiKey`, `geminiApiKey`, and `cloudflareApiKey`) accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time. Escape `$$` as a literal leading `$` and `$!` as a literal leading `!`:
 
 ```json
 {
@@ -362,7 +364,7 @@ Set `searxngBaseUrl` or `SEARXNG_BASE_URL` to use a self-hosted SearXNG JSON API
 
 Set `firecrawlBaseUrl` or `FIRECRAWL_BASE_URL` to use Firecrawl as an extraction-only fallback for `fetch_content`. It calls `/v2/scrape` by default; set `firecrawlApiVersion` or `FIRECRAWL_API_VERSION` to `v1` for older self-hosted images. Firecrawl requests are cache-only by default (`lockdown: true`), so the Firecrawl server does not make fresh outbound target requests unless you explicitly set `firecrawlFreshScrape: true` or `FIRECRAWL_FRESH_SCRAPE=1`. Enable fresh scraping only for a Firecrawl deployment whose own egress, redirects, DNS rebinding behavior, and internal-network access are isolated or allowlisted; this extension can preflight the submitted URL but cannot control network requests made by the Firecrawl server. The configured Firecrawl API base URL and redirects are still validated by the same SSRF guard as other remote requests, and Firecrawl credentials are stripped from cross-origin API redirects.
 
-Without an explicit `$` or `!` source, `OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TINYFISH_API_KEY`, `TAVILY_API_KEY`, `SERPDIVE_API_KEY`, `ANYSEARCH_API_KEY`, `FIRECRAWL_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars retain their existing precedence over literal config file values. `openaiResponsesUrl` can point OpenAI `web_search` and `source_check` at a third-party gateway that supports the OpenAI Responses API and web search tool; it is an explicit endpoint override, not derived from Pi model provider settings, and defaults to `https://api.openai.com/v1/responses`. `openaiSearchModel` pins the model id used for OpenAI `web_search`, bypassing automatic selection (newest terra-tier model); the id is sent verbatim with whichever OpenAI auth resolves, so gateway-only model ids work too. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` or `searchProvider` sets the default search provider and is used when a tool call omits `provider` or sends `"auto"`: `"all"`, `"openai"`, `"brave"`, `"parallel"`, `"tinyfish"`, `"tavily"`, `"serpdive"`, `"anysearch"`, `"searxng"`, `"exa"`, `"perplexity"`, or `"gemini"`. AnySearch is never selected by `auto`; choose it explicitly or place it in `searchRouting`. If either single-provider field is configured, it takes precedence over `searchRouting`. Otherwise, `searchRouting` can opt into an ordered `providers` list and an explicit `fallbackOn` list containing `"transient"`, `"quota"`, and/or `"network"`; only those typed failures continue to the next available candidate. `"all"` is not valid inside `searchRouting.providers`, because that list defines sequential fallback rather than multi-provider aggregation. Named providers remain strict, and exhausted routes return per-provider diagnostics. `provider` can also be a non-empty array of named providers such as `["brave", "exa"]`; those providers run concurrently using the same aggregation path as `"all"`, while `"auto"` and `"all"` are invalid inside arrays. Random, weighted, sticky, and cooldown routing are not enabled. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the configured search and source-check tools while leaving fetch/content tools available. `toolNames` can opt into alternate public tool names for environments where another extension or model reserves the defaults, without changing behavior: `webSearch`, `sourceCheck`, `fetchContent`, and `getSearchContent` default to `web_search`, `source_check`, `fetch_content`, and `get_search_content`. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on the configured search tool, or toggled at runtime with `/curator`. `chromeProfile` pins Gemini Web cookie lookup to a specific Chromium profile. When omitted, detected Chromium profiles are scanned in stable order and the first profile containing the required Gemini cookies is used. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid browser data access and surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. Cookie databases are copied to a temporary read-only working copy; the reader uses `node:sqlite` when available and otherwise tries the `sqlite3` CLI or Python's standard-library SQLite module. `searchModel` overrides the Gemini API model used by the configured search tool without changing URL, YouTube, or video extraction defaults. Gemini API grounded search uses `gemini-2.5-flash` by default; set `searchModel` to choose another model. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected. `ssrf.trustEnvProxy` is a separate opt-in for sandboxed environments with valid HTTP(S) proxy env vars; it skips local DNS preflight only for proxied hostnames and still blocks localhost, literal private IPs, and `NO_PROXY` matches. It does not configure proxy transport.
+Without an explicit `$` or `!` source, `OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TINYFISH_API_KEY`, `SEARCH1API_KEY`, `TAVILY_API_KEY`, `SERPDIVE_API_KEY`, `ANYSEARCH_API_KEY`, `FIRECRAWL_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars retain their existing precedence over literal config file values. `openaiResponsesUrl` can point OpenAI `web_search` and `source_check` at a third-party gateway that supports the OpenAI Responses API and web search tool; it is an explicit endpoint override, not derived from Pi model provider settings, and defaults to `https://api.openai.com/v1/responses`. `openaiSearchModel` pins the model id used for OpenAI `web_search`, bypassing automatic selection (newest terra-tier model); the id is sent verbatim with whichever OpenAI auth resolves, so gateway-only model ids work too. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` or `searchProvider` sets the default search provider and is used when a tool call omits `provider` or sends `"auto"`: `"all"`, `"openai"`, `"brave"`, `"parallel"`, `"tinyfish"`, `"search1api"`, `"tavily"`, `"serpdive"`, `"anysearch"`, `"searxng"`, `"exa"`, `"perplexity"`, or `"gemini"`. AnySearch is never selected by `auto`; choose it explicitly or place it in `searchRouting`. If either single-provider field is configured, it takes precedence over `searchRouting`. Otherwise, `searchRouting` can opt into an ordered `providers` list and an explicit `fallbackOn` list containing `"transient"`, `"quota"`, and/or `"network"`; only those typed failures continue to the next available candidate. `"all"` is not valid inside `searchRouting.providers`, because that list defines sequential fallback rather than multi-provider aggregation. Named providers remain strict, and exhausted routes return per-provider diagnostics. `provider` can also be a non-empty array of named providers such as `["brave", "exa"]`; those providers run concurrently using the same aggregation path as `"all"`, while `"auto"` and `"all"` are invalid inside arrays. Random, weighted, sticky, and cooldown routing are not enabled. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the configured search and source-check tools while leaving fetch/content tools available. `toolNames` can opt into alternate public tool names for environments where another extension or model reserves the defaults, without changing behavior: `webSearch`, `sourceCheck`, `fetchContent`, and `getSearchContent` default to `web_search`, `source_check`, `fetch_content`, and `get_search_content`. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on the configured search tool, or toggled at runtime with `/curator`. `chromeProfile` pins Gemini Web cookie lookup to a specific Chromium profile. When omitted, detected Chromium profiles are scanned in stable order and the first profile containing the required Gemini cookies is used. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid browser data access and surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. Cookie databases are copied to a temporary read-only working copy; the reader uses `node:sqlite` when available and otherwise tries the `sqlite3` CLI or Python's standard-library SQLite module. `searchModel` overrides the Gemini API model used by the configured search tool without changing URL, YouTube, or video extraction defaults. Gemini API grounded search uses `gemini-2.5-flash` by default; set `searchModel` to choose another model. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected. `ssrf.trustEnvProxy` is a separate opt-in for sandboxed environments with valid HTTP(S) proxy env vars; it skips local DNS preflight only for proxied hostnames and still blocks localhost, literal private IPs, and `NO_PROXY` matches. It does not configure proxy transport.
 
 ### All providers
 
@@ -381,11 +383,28 @@ Successful provider answers are preserved separately while source URLs and inlin
 }
 ```
 
-Setting `provider` is optional. In `auto` mode, an available TinyFish provider is tried after Parallel and before Tavily. You can also select it per request with `provider: "tinyfish"` or place `"tinyfish"` in `searchRouting.providers`.
+Setting `provider` is optional. In `auto` mode, an available TinyFish provider is tried after Parallel and before Search1API. You can also select it per request with `provider: "tinyfish"` or place `"tinyfish"` in `searchRouting.providers`.
 
-TinyFish Search supports the shared `numResults`, `recencyFilter`, and include/exclude `domainFilter` options. Requests above 10 results use TinyFish pagination. When `includeContent` is true, result URLs are sent to TinyFish Fetch in batches of up to 10 and returned as inline Markdown content. TinyFish Fetch is also used as a hosted `fetch_content` fallback after Jina Reader and before Parallel.
+TinyFish Search supports the shared `numResults`, `recencyFilter`, and include/exclude `domainFilter` options. Requests above 10 results use TinyFish pagination. When `includeContent` is true, result URLs are sent to TinyFish Fetch in batches of up to 10 and returned as inline Markdown content. TinyFish Fetch is also used as a hosted `fetch_content` fallback after Jina Reader and before Search1API.
 
 The stable Search (`https://api.search.tinyfish.ai`) and Fetch (`https://api.fetch.tinyfish.ai`) endpoints are built in, so no base URL setting is required. TinyFish currently documents both APIs as credit-free, with Free-plan limits of 30 search requests per minute and 150 fetched URLs per minute; an API key is still required. See the [TinyFish Search reference](https://docs.tinyfish.ai/search-api/reference) and [TinyFish Fetch reference](https://docs.tinyfish.ai/fetch-api/reference).
+
+### Search1API
+
+`search1apiApiKey` enables [Search1API](https://www.search1api.com) Search and Crawl; alternatively, set `SEARCH1API_KEY`. Create a key in the [Search1API dashboard](https://dashboard.search1api.com). Like the other provider keys, `search1apiApiKey` can contain a literal key, an environment-variable reference, or a trusted command credential source:
+
+```json
+{
+  "search1apiApiKey": "$SEARCH1API_KEY",
+  "provider": "search1api"
+}
+```
+
+Setting `provider` is optional. In `auto` mode, an available Search1API provider is tried after TinyFish and before Tavily. You can also select it per request with `provider: "search1api"`, include it in provider arrays or `provider: "all"`, or place `"search1api"` in `searchRouting.providers`.
+
+Search1API Search supports the shared `numResults`, `recencyFilter`, and include/exclude `domainFilter` options. When `includeContent` is true, it maps to Search1API Deep Search and returns successfully crawled result content inline. The Search1API Crawl endpoint is also used as a hosted `fetch_content` fallback after Jina Reader and TinyFish, before Parallel.
+
+Search1API is credit-based. A basic search costs 1 credit; Deep Search adds 1 credit for each result page crawled successfully, and a Crawl request costs 1 credit. The extension never enables Deep Search unless `includeContent` is true. See the [Search API guide](https://www.search1api.com/docs/basic/search), [Crawl API guide](https://www.search1api.com/docs/basic/crawl), and [credit rules](https://www.search1api.com/docs/essentials/credits-and-limits).
 
 ### AnySearch
 
@@ -478,7 +497,7 @@ Values use the same format as pi keybindings (e.g. `ctrl+s`, `ctrl+shift+s`, `al
 
 Set `"enabled": false` under any feature to disable it. For GitHub specifically, `githubClone.enabled: false` only skips clone/API specialization; it does not unregister `fetch_content` or block generic URL extraction. Config changes require a Pi restart.
 
-Rate limits: Perplexity is capped at 10 requests/minute (client-side). TinyFish applies the plan limits documented by its API. Content fetches run 3 concurrent with a 30s timeout per URL.
+Rate limits: Perplexity is capped at 10 requests/minute (client-side). TinyFish and Search1API apply the plan limits documented by their APIs. Content fetches run 3 concurrent with a 30s timeout per URL.
 
 ## Limitations
 
@@ -503,6 +522,7 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). TinyFish 
 | `brave.ts` | Brave Search API provider |
 | `parallel.ts` | Parallel search provider and extraction fallback |
 | `tinyfish.ts` | TinyFish Search and Fetch API provider |
+| `search1api.ts` | Search1API Search and Crawl API provider |
 | `tavily.ts` | Tavily Search API provider |
 | `serpdive.ts` | SERPdive Search API provider |
 | `anysearch.ts` | Explicit-only AnySearch search provider |

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -8,7 +8,7 @@ function safeInlineJSON(data: unknown): string {
 }
 
 function buildProviderButtons(
-	available: { all: boolean; openai: boolean; brave: boolean; parallel: boolean; tinyfish: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean },
+	available: { all: boolean; openai: boolean; brave: boolean; parallel: boolean; tinyfish: boolean; search1api: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean },
 	selected: string,
 	hasInitialQueries: boolean,
 ): string {
@@ -19,6 +19,7 @@ function buildProviderButtons(
 		{ value: "brave", label: "Brave", available: available.brave },
 		{ value: "parallel", label: "Parallel", available: available.parallel },
 		{ value: "tinyfish", label: "TinyFish", available: available.tinyfish },
+		{ value: "search1api", label: "Search1API", available: available.search1api },
 		{ value: "tavily", label: "Tavily", available: available.tavily },
 		{ value: "serpdive", label: "SERPdive", available: available.serpdive },
 		{ value: "searxng", label: "SearXNG", available: available.searxng },
@@ -43,7 +44,7 @@ export function generateCuratorPage(
 	queries: string[],
 	sessionToken: string,
 	timeout: number,
-	availableProviders: { all: boolean; openai: boolean; brave: boolean; parallel: boolean; tinyfish: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean },
+	availableProviders: { all: boolean; openai: boolean; brave: boolean; parallel: boolean; tinyfish: boolean; search1api: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean },
 	defaultProvider: string,
 	searchProvider: string,
 	summaryModels: Array<{ value: string; label: string }>,
@@ -680,6 +681,11 @@ main {
   color: #74c7ec;
   background: rgba(116, 199, 236, 0.14);
   border-color: rgba(116, 199, 236, 0.3);
+}
+.provider-tag.provider-search1api {
+  color: #89b4fa;
+  background: rgba(137, 180, 250, 0.14);
+  border-color: rgba(137, 180, 250, 0.3);
 }
 .provider-tag.provider-tavily {
   color: #a6e3a1;
@@ -1414,7 +1420,7 @@ const SCRIPT = `(function() {
   var token = DATA.sessionToken;
   var timeoutSec = DATA.timeout;
   var queries = Array.isArray(DATA.queries) ? DATA.queries : [];
-  var providers = ["all", "openai", "exa", "brave", "parallel", "tinyfish", "tavily", "serpdive", "searxng", "perplexity", "gemini", "anysearch"];
+  var providers = ["all", "openai", "exa", "brave", "parallel", "tinyfish", "search1api", "tavily", "serpdive", "searxng", "perplexity", "gemini", "anysearch"];
   var availProviders = DATA.availableProviders && typeof DATA.availableProviders === "object" ? DATA.availableProviders : {};
   var workflow = "summary-review";
   var initialDefaultProvider = typeof DATA.defaultProvider === "string" ? DATA.defaultProvider : "exa";
@@ -1619,6 +1625,7 @@ const SCRIPT = `(function() {
     if (provider === "brave") return "Brave";
     if (provider === "parallel") return "Parallel";
     if (provider === "tinyfish") return "TinyFish";
+    if (provider === "search1api") return "Search1API";
     if (provider === "tavily") return "Tavily";
     if (provider === "serpdive") return "SERPdive";
     if (provider === "searxng") return "SearXNG";

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -13,7 +13,7 @@ export interface CuratorServerOptions {
 	queries: string[];
 	sessionToken: string;
 	timeout: number;
-	availableProviders: { all: boolean; openai: boolean; brave: boolean; parallel: boolean; tinyfish: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean };
+	availableProviders: { all: boolean; openai: boolean; brave: boolean; parallel: boolean; tinyfish: boolean; search1api: boolean; tavily: boolean; serpdive: boolean; searxng: boolean; perplexity: boolean; exa: boolean; gemini: boolean; anysearch: boolean };
 	defaultProvider: string;
 	searchProvider: string;
 	summaryModels: Array<{ value: string; label: string }>;
@@ -270,6 +270,7 @@ export function startCuratorServer(
 		if (provider === "brave") return availableProviders.brave;
 		if (provider === "parallel") return availableProviders.parallel;
 		if (provider === "tinyfish") return availableProviders.tinyfish;
+		if (provider === "search1api") return availableProviders.search1api;
 		if (provider === "tavily") return availableProviders.tavily;
 		if (provider === "serpdive") return availableProviders.serpdive;
 		if (provider === "searxng") return availableProviders.searxng;

--- a/extract.ts
+++ b/extract.ts
@@ -11,6 +11,7 @@ import { CredentialResolutionError } from "./credential-source.ts";
 import { extractWithUrlContext, extractWithGeminiWeb } from "./gemini-url-context.ts";
 import { extractWithParallel, isParallelAvailable } from "./parallel.ts";
 import { extractWithTinyFish, isTinyFishAvailable } from "./tinyfish.ts";
+import { extractWithSearch1API, isSearch1APIAvailable } from "./search1api.ts";
 import { extractWithFirecrawl, isFirecrawlAvailable } from "./firecrawl.ts";
 import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } from "./video-extract.ts";
 import { appendDeclaredWebLinks, discoverDeclaredWebLinks, type DeclaredWebLink } from "./declared-web-links.ts";
@@ -502,6 +503,21 @@ export async function extractContent(
 	}
 	if (signal?.aborted) return abortedResult(url);
 
+	let search1apiError: string | null = null;
+	try {
+		if (isSearch1APIAvailable()) {
+			const search1apiResult = await extractWithSearch1API(url, signal, options);
+			if (search1apiResult) return withDeclaredLinks(search1apiResult);
+		}
+	} catch (err) {
+		if (isAbortError(err)) return abortedResult(url);
+		search1apiError = errorMessage(err);
+		if (isConfigParseError(err)) {
+			return { ...httpResult, error: search1apiError };
+		}
+	}
+	if (signal?.aborted) return abortedResult(url);
+
 	let parallelError: string | null = null;
 	try {
 		if (isParallelAvailable()) {
@@ -536,6 +552,7 @@ export async function extractContent(
 		httpResult.error,
 		...(firecrawlError ? [`Firecrawl fallback failed: ${firecrawlError}`] : []),
 		...(tinyfishError ? [`TinyFish fallback failed: ${tinyfishError}`] : []),
+		...(search1apiError ? [`Search1API fallback failed: ${search1apiError}`] : []),
 		...(parallelError ? [`Parallel fallback failed: ${parallelError}`] : []),
 		"",
 		"Fallback options:",

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -10,13 +10,14 @@ import { isBraveAvailable, searchWithBrave } from "./brave.ts";
 import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
 import { isParallelAvailable, searchWithParallel } from "./parallel.ts";
 import { isTinyFishAvailable, searchWithTinyFish } from "./tinyfish.ts";
+import { isSearch1APIAvailable, searchWithSearch1API } from "./search1api.ts";
 import { isTavilyAvailable, searchWithTavily } from "./tavily.ts";
 import { isSerpdiveAvailable, searchWithSerpdive } from "./serpdive.ts";
 import { isSearXNGAvailable, searchWithSearXNG } from "./searxng.ts";
 import { isAnySearchAvailable, searchWithAnySearch } from "./anysearch.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-export const RESOLVED_SEARCH_PROVIDERS = ["openai", "brave", "parallel", "tinyfish", "tavily", "searxng", "perplexity", "gemini", "exa", "serpdive", "anysearch"] as const;
+export const RESOLVED_SEARCH_PROVIDERS = ["openai", "brave", "parallel", "tinyfish", "search1api", "tavily", "searxng", "perplexity", "gemini", "exa", "serpdive", "anysearch"] as const;
 export const SEARCH_PROVIDERS = ["auto", "all", ...RESOLVED_SEARCH_PROVIDERS] as const;
 
 export type ResolvedSearchProvider = typeof RESOLVED_SEARCH_PROVIDERS[number];
@@ -78,7 +79,7 @@ export interface AttributedSearchResponse extends SearchResponse {
 
 const CONFIG_PATH = getWebSearchConfigPath();
 const DEFAULT_SEARCH_MODEL = "gemini-2.5-flash";
-const ALL_SEARCH_PROVIDERS: ResolvedSearchProvider[] = ["searxng", "openai", "exa", "brave", "parallel", "tinyfish", "tavily", "serpdive", "perplexity", "gemini"];
+const ALL_SEARCH_PROVIDERS: ResolvedSearchProvider[] = ["searxng", "openai", "exa", "brave", "parallel", "tinyfish", "search1api", "tavily", "serpdive", "perplexity", "gemini"];
 const VALID_ROUTING_KINDS = ["transient", "quota", "network"] as const;
 
 type SearchConfig = {
@@ -285,6 +286,7 @@ async function searchWithResolvedProvider(
 	if (provider === "brave") return { ...(await searchWithBrave(query, options)), provider };
 	if (provider === "parallel") return { ...(await searchWithParallel(query, options)), provider };
 	if (provider === "tinyfish") return { ...(await searchWithTinyFish(query, options)), provider };
+	if (provider === "search1api") return { ...(await searchWithSearch1API(query, options)), provider };
 	if (provider === "tavily") return { ...(await searchWithTavily(query, options)), provider };
 	if (provider === "serpdive") return { ...(await searchWithSerpdive(query, options)), provider };
 	if (provider === "anysearch") return { ...(await searchWithAnySearch(query, options)), provider };
@@ -310,6 +312,7 @@ async function isResolvedProviderAvailable(provider: ResolvedSearchProvider, opt
 	if (provider === "brave") return isBraveAvailable();
 	if (provider === "parallel") return isParallelAvailable();
 	if (provider === "tinyfish") return isTinyFishAvailable();
+	if (provider === "search1api") return isSearch1APIAvailable();
 	if (provider === "tavily") return isTavilyAvailable();
 	if (provider === "serpdive") return isSerpdiveAvailable();
 	if (provider === "anysearch") return isAnySearchAvailable();
@@ -322,6 +325,7 @@ async function isResolvedProviderAvailable(provider: ResolvedSearchProvider, opt
 function providerLabel(provider: ResolvedSearchProvider): string {
 	if (provider === "openai") return "OpenAI";
 	if (provider === "tinyfish") return "TinyFish";
+	if (provider === "search1api") return "Search1API";
 	if (provider === "serpdive") return "SERPdive";
 	if (provider === "searxng") return "SearXNG";
 	return provider.charAt(0).toUpperCase() + provider.slice(1);
@@ -513,6 +517,16 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
+	if (isSearch1APIAvailable()) {
+		try {
+			const result = await searchWithSearch1API(query, options);
+			return { ...result, provider: "search1api" };
+		} catch (err) {
+			if (isAbortError(err)) throw err;
+			fallbackErrors.push(`Search1API: ${errorMessage(err)}`);
+		}
+	}
+
 	if (isTavilyAvailable()) {
 		try {
 			const result = await searchWithTavily(query, options);
@@ -558,8 +572,8 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 	throw new Error(
 		"No search provider available. Either:\n" +
 		"  1. Use /login to sign in with a Codex subscription for OpenAI web search\n" +
-		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, tinyfishApiKey, tavilyApiKey, serpdiveApiKey, searxngBaseUrl, perplexityApiKey, exaApiKey, geminiApiKey, or cloudflareApiKey in ${CONFIG_PATH}\n` +
-		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TINYFISH_API_KEY, TAVILY_API_KEY, SERPDIVE_API_KEY, SEARXNG_BASE_URL, EXA_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, or CLOUDFLARE_API_KEY env vars\n" +
+		`  2. Set openaiApiKey, braveApiKey, parallelApiKey, tinyfishApiKey, search1apiApiKey, tavilyApiKey, serpdiveApiKey, searxngBaseUrl, perplexityApiKey, exaApiKey, geminiApiKey, or cloudflareApiKey in ${CONFIG_PATH}\n` +
+		"  3. Set OPENAI_API_KEY, BRAVE_API_KEY, PARALLEL_API_KEY, TINYFISH_API_KEY, SEARCH1API_KEY, TAVILY_API_KEY, SERPDIVE_API_KEY, SEARXNG_BASE_URL, EXA_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, or CLOUDFLARE_API_KEY env vars\n" +
 		"  4. Set GOOGLE_GEMINI_BASE_URL with CLOUDFLARE_API_KEY for Cloudflare AI Gateway routing\n" +
 		"  5. Sign into gemini.google.com in a supported Chromium-based browser\n" +
 		"  6. Explicitly select provider: \"anysearch\" for anonymous AnySearch"

--- a/index.ts
+++ b/index.ts
@@ -42,6 +42,7 @@ import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
 import { isParallelAvailable } from "./parallel.ts";
 import { isTinyFishAvailable } from "./tinyfish.ts";
+import { isSearch1APIAvailable } from "./search1api.ts";
 import { isTavilyAvailable } from "./tavily.ts";
 import { isSerpdiveAvailable } from "./serpdive.ts";
 import { isSearXNGAvailable } from "./searxng.ts";
@@ -125,6 +126,7 @@ interface ProviderAvailability {
 	brave: boolean;
 	parallel: boolean;
 	tinyfish: boolean;
+	search1api: boolean;
 	tavily: boolean;
 	serpdive: boolean;
 	searxng: boolean;
@@ -317,6 +319,7 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 		brave: isBraveAvailable(),
 		parallel: isParallelAvailable(),
 		tinyfish: isTinyFishAvailable(),
+		search1api: isSearch1APIAvailable(),
 		tavily: isTavilyAvailable(),
 		serpdive: isSerpdiveAvailable(),
 		searxng: isSearXNGAvailable(),
@@ -362,6 +365,7 @@ function firstAvailableProvider(available: ProviderAvailability, preferOpenAI: b
 	if (available.brave) return "brave";
 	if (available.parallel) return "parallel";
 	if (available.tinyfish) return "tinyfish";
+	if (available.search1api) return "search1api";
 	if (available.tavily) return "tavily";
 	if (available.serpdive) return "serpdive";
 	if (available.perplexity) return "perplexity";
@@ -401,6 +405,9 @@ function resolveProvider(
 	}
 	if (provider === "tinyfish" && !available.tinyfish) {
 		return firstAvailableProvider(available, preferOpenAI, "tinyfish");
+	}
+	if (provider === "search1api" && !available.search1api) {
+		return firstAvailableProvider(available, preferOpenAI, "search1api");
 	}
 	if (provider === "tavily" && !available.tavily) {
 		return firstAvailableProvider(available, preferOpenAI, "tavily");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-access",
   "version": "0.15.0",
-  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, TinyFish, Tavily, SERPdive, AnySearch, SearXNG, Firecrawl extraction, Exa, Perplexity, and Gemini.",
+  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, TinyFish, Search1API, Tavily, SERPdive, AnySearch, SearXNG, Firecrawl extraction, Exa, Perplexity, and Gemini.",
   "type": "module",
   "scripts": {
     "test": "node --test",
@@ -15,6 +15,7 @@
     "extension",
     "web-search",
     "tinyfish",
+    "search1api",
     "perplexity",
     "fetch",
     "scraping"

--- a/search1api.ts
+++ b/search1api.ts
@@ -1,0 +1,304 @@
+import { existsSync, readFileSync } from "node:fs";
+import { activityMonitor } from "./activity.ts";
+import { hasCredentialSource, redactCredential, resolveCredential } from "./credential-source.ts";
+import type { ExtractedContent, ExtractOptions } from "./extract.ts";
+import type { SearchOptions, SearchResponse } from "./perplexity.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const SEARCH1API_SEARCH_URL = "https://api.search1api.com/search";
+const SEARCH1API_CRAWL_URL = "https://api.search1api.com/crawl";
+const CONFIG_PATH = getWebSearchConfigPath();
+const SEARCH_TIMEOUT_MS = 60_000;
+const CRAWL_TIMEOUT_MS = 60_000;
+
+interface WebSearchConfig {
+	search1apiApiKey?: unknown;
+}
+
+interface Search1APISearchResult {
+	title?: string | null;
+	link?: string | null;
+	snippet?: string | null;
+	content?: string | null;
+}
+
+interface Search1APISearchResponse {
+	searchParameters?: Record<string, unknown>;
+	results?: Search1APISearchResult[];
+}
+
+interface Search1APICrawlResult {
+	title?: string | null;
+	link?: string | null;
+	content?: string | null;
+	metadata?: Record<string, unknown>;
+}
+
+interface Search1APICrawlResponse {
+	crawlParameters?: { url?: string };
+	results?: Search1APICrawlResult;
+}
+
+interface Search1APISearchOptions extends SearchOptions {
+	includeContent?: boolean;
+}
+
+let cachedConfig: WebSearchConfig | null = null;
+
+function loadConfig(): WebSearchConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const raw = readFileSync(CONFIG_PATH, "utf-8");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error(`Invalid config in ${CONFIG_PATH}: expected a JSON object`);
+	}
+	cachedConfig = parsed as WebSearchConfig;
+	return cachedConfig;
+}
+
+async function getApiKey(signal?: AbortSignal): Promise<string> {
+	const key = await resolveCredential({
+		provider: "Search1API",
+		configuredValue: loadConfig().search1apiApiKey,
+		environmentValue: process.env.SEARCH1API_KEY,
+		signal,
+	});
+	if (!key) {
+		throw new Error(
+			"Search1API key not found. Either:\n" +
+			`  1. Create ${CONFIG_PATH} with { "search1apiApiKey": "your-key" }\n` +
+			"  2. Set SEARCH1API_KEY environment variable\n" +
+			"Create a key at https://dashboard.search1api.com",
+		);
+	}
+	return key;
+}
+
+export function isSearch1APIAvailable(): boolean {
+	return hasCredentialSource({
+		provider: "Search1API",
+		configuredValue: loadConfig().search1apiApiKey,
+		environmentValue: process.env.SEARCH1API_KEY,
+	});
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function requestSignal(signal: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+	const timeout = AbortSignal.timeout(timeoutMs);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function normalizeNumResults(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return 5;
+	return Math.max(1, Math.min(Math.floor(value), 20));
+}
+
+function normalizeDomain(value: string): string | null {
+	let input = value.trim().toLowerCase();
+	if (!input) return null;
+	if (input.startsWith("-")) input = input.slice(1).trim();
+	if (!input) return null;
+	try {
+		const parsed = input.includes("://") ? new URL(input) : new URL(`https://${input}`);
+		input = parsed.hostname;
+	} catch {
+		input = input.split("/")[0]?.split(":")[0] ?? "";
+	}
+	input = input.replace(/^\.+|\.+$/g, "");
+	return /^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(input) ? input : null;
+}
+
+function mapDomainFilter(domainFilter: string[] | undefined): { includeSites: string[]; excludeSites: string[] } {
+	const includeSites: string[] = [];
+	const excludeSites: string[] = [];
+	for (const raw of domainFilter ?? []) {
+		const domain = normalizeDomain(raw);
+		if (!domain) continue;
+		const target = raw.trim().startsWith("-") ? excludeSites : includeSites;
+		if (!target.includes(domain)) target.push(domain);
+	}
+	return { includeSites, excludeSites };
+}
+
+function buildSearchBody(query: string, options: Search1APISearchOptions): Record<string, unknown> {
+	const numResults = normalizeNumResults(options.numResults);
+	const { includeSites, excludeSites } = mapDomainFilter(options.domainFilter);
+	return {
+		query,
+		max_results: numResults,
+		crawl_results: options.includeContent ? numResults : 0,
+		...(includeSites.length > 0 ? { include_sites: includeSites } : {}),
+		...(excludeSites.length > 0 ? { exclude_sites: excludeSites } : {}),
+		...(options.recencyFilter ? { time_range: options.recencyFilter } : {}),
+	};
+}
+
+async function search1APIJsonRequest<T>(
+	label: "Search" | "Crawl",
+	url: string,
+	apiKey: string,
+	body: Record<string, unknown>,
+	timeoutMs: number,
+	signal?: AbortSignal,
+): Promise<T> {
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(body),
+			signal: requestSignal(signal, timeoutMs),
+		});
+	} catch (err) {
+		const message = errorMessage(err);
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
+	}
+
+	const raw = await response.text();
+	if (!response.ok) {
+		throw new Error(`Search1API ${label} API error ${response.status}: ${redactCredential(raw, apiKey).slice(0, 300)}`);
+	}
+	try {
+		return JSON.parse(raw) as T;
+	} catch (err) {
+		throw new Error(`Search1API ${label} API returned invalid JSON: ${errorMessage(err)}`);
+	}
+}
+
+function mapSearchResults(results: Search1APISearchResult[] | undefined): SearchResponse["results"] {
+	if (!Array.isArray(results)) {
+		throw new Error("Search1API Search API returned an unexpected response shape");
+	}
+	return results.flatMap((item) => {
+		if (!item || typeof item.link !== "string" || item.link.trim().length === 0) return [];
+		const url = item.link.trim();
+		return [{
+			title: typeof item.title === "string" && item.title.trim() ? item.title.trim() : url,
+			url,
+			snippet: typeof item.snippet === "string" ? item.snippet.replace(/\s+/g, " ").trim() : "",
+		}];
+	});
+}
+
+function mapInlineContent(results: Search1APISearchResult[] | undefined): ExtractedContent[] {
+	if (!Array.isArray(results)) return [];
+	return results.flatMap((item) => {
+		if (!item || typeof item.link !== "string" || item.link.trim().length === 0) return [];
+		if (typeof item.content !== "string" || item.content.trim().length === 0) return [];
+		return [{
+			url: item.link.trim(),
+			title: typeof item.title === "string" ? item.title.trim() : "",
+			content: item.content,
+			error: null,
+		}];
+	});
+}
+
+function buildAnswer(results: SearchResponse["results"]): string {
+	return results.map((result) => {
+		if (result.snippet) return `${result.snippet}\nSource: ${result.title} (${result.url})`;
+		return `Source: ${result.title} (${result.url})`;
+	}).join("\n\n");
+}
+
+export async function searchWithSearch1API(
+	query: string,
+	options: Search1APISearchOptions = {},
+): Promise<SearchResponse> {
+	const apiKey = await getApiKey(options.signal);
+	const activityId = activityMonitor.logStart({ type: "api", query });
+	try {
+		const data = await search1APIJsonRequest<Search1APISearchResponse>(
+			"Search",
+			SEARCH1API_SEARCH_URL,
+			apiKey,
+			buildSearchBody(query, options),
+			SEARCH_TIMEOUT_MS,
+			options.signal,
+		);
+		const results = mapSearchResults(data.results);
+		const response: SearchResponse = { answer: buildAnswer(results), results };
+		if (options.includeContent) {
+			const inlineContent = mapInlineContent(data.results);
+			if (inlineContent.length > 0) response.inlineContent = inlineContent;
+		}
+		activityMonitor.logComplete(activityId, 200);
+		return response;
+	} catch (err) {
+		const message = errorMessage(err);
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
+		else activityMonitor.logError(activityId, redactedMessage);
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
+	}
+}
+
+export async function extractWithSearch1API(
+	url: string,
+	signal?: AbortSignal,
+	options: ExtractOptions = {},
+): Promise<ExtractedContent | null> {
+	const apiKey = await getApiKey(signal);
+	const activityId = activityMonitor.logStart({ type: "fetch", url });
+	try {
+		const data = await search1APIJsonRequest<Search1APICrawlResponse>(
+			"Crawl",
+			SEARCH1API_CRAWL_URL,
+			apiKey,
+			{ url },
+			typeof options.timeoutMs === "number" && Number.isFinite(options.timeoutMs)
+				? Math.max(1, Math.floor(options.timeoutMs))
+				: CRAWL_TIMEOUT_MS,
+			signal,
+		);
+		const result = data.results;
+		if (!result || typeof result !== "object") {
+			throw new Error("Search1API Crawl API returned an unexpected response shape");
+		}
+		const content = typeof result.content === "string" ? result.content.trim() : "";
+		if (!content) {
+			activityMonitor.logComplete(activityId, 200);
+			return null;
+		}
+		activityMonitor.logComplete(activityId, 200);
+		return {
+			url,
+			title: typeof result.title === "string" ? result.title.trim() : "",
+			content,
+			error: null,
+		};
+	} catch (err) {
+		const message = errorMessage(err);
+		const redactedMessage = redactCredential(message, apiKey);
+		if (redactedMessage.toLowerCase().includes("abort")) activityMonitor.logComplete(activityId, 0);
+		else activityMonitor.logError(activityId, redactedMessage);
+		if (redactedMessage === message) throw err;
+		const redactedError = new Error(redactedMessage);
+		if (err instanceof Error) redactedError.name = err.name;
+		throw redactedError;
+	}
+}

--- a/test/all-provider.test.mjs
+++ b/test/all-provider.test.mjs
@@ -17,6 +17,7 @@ function runChild(script, env = {}) {
 		"BRAVE_API_KEY",
 		"PARALLEL_API_KEY",
 		"TINYFISH_API_KEY",
+		"SEARCH1API_KEY",
 		"TAVILY_API_KEY",
 		"SERPDIVE_API_KEY",
 		"ANYSEARCH_API_KEY",
@@ -42,7 +43,7 @@ test('provider "all" starts every eligible provider together, excludes AnySearch
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-all-"));
 	const child = runChild(`
 		const started = [];
-		const expected = new Set(["exa", "brave", "tinyfish"]);
+		const expected = new Set(["exa", "brave", "tinyfish", "search1api"]);
 		let releaseGate;
 		const gate = new Promise((resolve) => { releaseGate = resolve; });
 
@@ -87,6 +88,13 @@ test('provider "all" starts every eligible provider together, excludes AnySearch
 					page: 0,
 				}), { status: 200 });
 			}
+			if (target === "https://api.search1api.com/search") {
+				await waitForPeers("search1api");
+				return new Response(JSON.stringify({
+					searchParameters: { query: "combined" },
+					results: [{ title: "Search1API result", link: "https://example.com/search1api", snippet: "Search1API answer" }],
+				}), { status: 200 });
+			}
 			throw new Error("Unexpected fetch " + target);
 		};
 
@@ -99,20 +107,23 @@ test('provider "all" starts every eligible provider together, excludes AnySearch
 		PI_CODING_AGENT_DIR: home,
 		BRAVE_API_KEY: "brave-test-key",
 		TINYFISH_API_KEY: "tinyfish-test-key",
+		SEARCH1API_KEY: "search1api-test-key",
 	});
 
 	assert.equal(child.status, 0, child.stderr || child.error?.message);
 	const output = JSON.parse(child.stdout.trim());
-	assert.deepEqual([...output.started].sort(), ["brave", "exa", "tinyfish"]);
+	assert.deepEqual([...output.started].sort(), ["brave", "exa", "search1api", "tinyfish"]);
 	assert.equal(output.result.provider, "all");
-	assert.deepEqual(output.result.providerResponses.map((result) => result.provider), ["exa", "brave", "tinyfish"]);
+	assert.deepEqual(output.result.providerResponses.map((result) => result.provider), ["exa", "brave", "tinyfish", "search1api"]);
 	assert.deepEqual(output.result.results.map((result) => result.url), [
 		"https://example.com/shared",
 		"https://example.com/tinyfish",
+		"https://example.com/search1api",
 	]);
 	assert.match(output.result.answer, /## Exa/);
 	assert.match(output.result.answer, /## Brave/);
 	assert.match(output.result.answer, /## TinyFish/);
+	assert.match(output.result.answer, /## Search1API/);
 	assert.doesNotMatch(output.result.answer, /AnySearch/);
 });
 
@@ -313,6 +324,7 @@ test('"all" is a Curator provider but remains invalid inside sequential searchRo
 			brave: true,
 			parallel: false,
 			tinyfish: true,
+			search1api: false,
 			tavily: false,
 			serpdive: false,
 			searxng: false,
@@ -344,6 +356,7 @@ test('"all" is a Curator provider but remains invalid inside sequential searchRo
 			brave: false,
 			parallel: false,
 			tinyfish: false,
+			search1api: false,
 			tavily: false,
 			serpdive: false,
 			searxng: false,

--- a/test/curator-server-timeout.test.mjs
+++ b/test/curator-server-timeout.test.mjs
@@ -32,7 +32,7 @@ function baseOptions(timeout = 1) {
 		queries: ["test query"],
 		sessionToken: "test-token",
 		timeout,
-		availableProviders: { all: true, openai: false, brave: false, parallel: false, tinyfish: false, tavily: false, serpdive: false, searxng: false, perplexity: false, exa: true, gemini: false, anysearch: false },
+		availableProviders: { all: true, openai: false, brave: false, parallel: false, tinyfish: false, search1api: false, tavily: false, serpdive: false, searxng: false, perplexity: false, exa: true, gemini: false, anysearch: false },
 		defaultProvider: "exa",
 		searchProvider: "exa",
 		summaryModels: [],

--- a/test/provider-credential-source.test.mjs
+++ b/test/provider-credential-source.test.mjs
@@ -34,6 +34,7 @@ function runChild(script, env) {
 		"OPENAI_API_KEY",
 		"PARALLEL_API_KEY",
 		"TINYFISH_API_KEY",
+		"SEARCH1API_KEY",
 		"PERPLEXITY_API_KEY",
 		"TAVILY_API_KEY",
 	]) delete childEnv[key];

--- a/test/provider-precedence.test.mjs
+++ b/test/provider-precedence.test.mjs
@@ -24,7 +24,7 @@ async function createConfig(config = {
 function runTool(agentDir, provider) {
 	const providerSource = provider === undefined ? "undefined" : JSON.stringify(provider);
 	const childEnv = { ...process.env, PI_CODING_AGENT_DIR: agentDir, OPENAI_API_KEY: "openai-test-key" };
-	for (const key of ["BRAVE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY", "GEMINI_API_KEY", "PERPLEXITY_API_KEY"]) {
+	for (const key of ["BRAVE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "SEARCH1API_KEY", "TAVILY_API_KEY", "EXA_API_KEY", "GEMINI_API_KEY", "PERPLEXITY_API_KEY"]) {
 		delete childEnv[key];
 	}
 	const child = spawnSync(process.execPath, ["--input-type=module"], {

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -22,6 +22,7 @@ function runChild(script, env) {
 		"BRAVE_API_KEY",
 		"PARALLEL_API_KEY",
 		"TINYFISH_API_KEY",
+		"SEARCH1API_KEY",
 		"TAVILY_API_KEY",
 		"SEARXNG_BASE_URL",
 		"EXA_API_KEY",

--- a/test/search-routing.test.mjs
+++ b/test/search-routing.test.mjs
@@ -15,7 +15,7 @@ async function createConfig(config) {
 
 function runChild(script, env) {
 	const childEnv = { ...process.env };
-	for (const key of ["PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME", "OPENAI_API_KEY", "BRAVE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "TAVILY_API_KEY", "SERPDIVE_API_KEY", "SEARXNG_BASE_URL", "EXA_API_KEY", "PERPLEXITY_API_KEY", "GEMINI_API_KEY"]) {
+	for (const key of ["PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME", "OPENAI_API_KEY", "BRAVE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "SEARCH1API_KEY", "TAVILY_API_KEY", "SERPDIVE_API_KEY", "SEARXNG_BASE_URL", "EXA_API_KEY", "PERPLEXITY_API_KEY", "GEMINI_API_KEY"]) {
 		delete childEnv[key];
 	}
 	Object.assign(childEnv, env);

--- a/test/search1api.test.mjs
+++ b/test/search1api.test.mjs
@@ -1,0 +1,349 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const search1apiModuleUrl = new URL("../search1api.ts", import.meta.url).href;
+const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
+const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
+const curatorPageModuleUrl = new URL("../curator-page.ts", import.meta.url).href;
+
+const PROVIDER_ENV_KEYS = [
+	"OPENAI_API_KEY",
+	"BRAVE_API_KEY",
+	"PARALLEL_API_KEY",
+	"TINYFISH_API_KEY",
+	"SEARCH1API_KEY",
+	"TAVILY_API_KEY",
+	"SERPDIVE_API_KEY",
+	"ANYSEARCH_API_KEY",
+	"SEARXNG_BASE_URL",
+	"EXA_API_KEY",
+	"PERPLEXITY_API_KEY",
+	"GEMINI_API_KEY",
+	"GOOGLE_GEMINI_API_KEY",
+	"GOOGLE_API_KEY",
+	"CLOUDFLARE_API_KEY",
+	"FIRECRAWL_BASE_URL",
+	"FIRECRAWL_API_KEY",
+];
+
+async function createHome(config = {}) {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-search1api-"));
+	await mkdir(join(home, ".pi"), { recursive: true });
+	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	return home;
+}
+
+function runChild(script, env = {}) {
+	const childEnv = { ...process.env };
+	delete childEnv.PI_CODING_AGENT_DIR;
+	delete childEnv.XDG_CONFIG_HOME;
+	for (const key of PROVIDER_ENV_KEYS) delete childEnv[key];
+	Object.assign(childEnv, env);
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+}
+
+test("Search1API availability reads environment and config credentials", async () => {
+	const emptyHome = await createHome();
+	let child = runChild(`
+		const { isSearch1APIAvailable } = await import(${JSON.stringify(search1apiModuleUrl)});
+		console.log(String(isSearch1APIAvailable()));
+	`, { HOME: emptyHome, USERPROFILE: emptyHome });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(child.stdout.trim(), "false");
+
+	child = runChild(`
+		const { isSearch1APIAvailable } = await import(${JSON.stringify(search1apiModuleUrl)});
+		console.log(String(isSearch1APIAvailable()));
+	`, { HOME: emptyHome, USERPROFILE: emptyHome, SEARCH1API_KEY: "synthetic-search1api-env-key" });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(child.stdout.trim(), "true");
+
+	const configHome = await createHome({ search1apiApiKey: "synthetic-search1api-config-key" });
+	child = runChild(`
+		const { isSearch1APIAvailable } = await import(${JSON.stringify(search1apiModuleUrl)});
+		console.log(String(isSearch1APIAvailable()));
+	`, { HOME: configHome, USERPROFILE: configHome });
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(child.stdout.trim(), "true");
+});
+
+test("Search1API resolves command credentials only when a request starts", async () => {
+	const markerDir = await mkdtemp(join(tmpdir(), "pi-web-access-search1api-marker-"));
+	const marker = join(markerDir, "ran");
+	const home = await createHome({
+		search1apiApiKey: `!touch ${marker} && printf synthetic-search1api-command-key`,
+	});
+	const child = runChild(`
+		import { existsSync } from "node:fs";
+		const { isSearch1APIAvailable, searchWithSearch1API } = await import(${JSON.stringify(search1apiModuleUrl)});
+		const availableBefore = isSearch1APIAvailable();
+		const ranBefore = existsSync(${JSON.stringify(marker)});
+		let authorization = "";
+		globalThis.fetch = async (_url, init) => {
+			authorization = new Headers(init.headers).get("authorization") || "";
+			return new Response(JSON.stringify({ searchParameters: {}, results: [] }), { status: 200 });
+		};
+		await searchWithSearch1API("credential timing");
+		console.log(JSON.stringify({ availableBefore, ranBefore, ranAfter: existsSync(${JSON.stringify(marker)}), authorization }));
+	`, { HOME: home, USERPROFILE: home });
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout.trim()), {
+		availableBefore: true,
+		ranBefore: false,
+		ranAfter: true,
+		authorization: "Bearer synthetic-search1api-command-key",
+	});
+	assert.equal(existsSync(marker), true);
+});
+
+test("explicit Search1API search maps filters, deep content, and results", async () => {
+	const home = await createHome({ provider: "search1api" });
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			calls.push({
+				url: String(url),
+				headers: Object.fromEntries(new Headers(init.headers)),
+				body: JSON.parse(init.body),
+			});
+			return new Response(JSON.stringify({
+				searchParameters: { query: "search1api docs", max_results: 1 },
+				results: [{
+					title: "Search1API Docs",
+					link: "https://www.search1api.com/docs",
+					snippet: "  Search,   crawl, and extract. ",
+					content: "# Full Search1API documentation",
+				}],
+			}), { status: 200 });
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("search1api docs", {
+			provider: "search1api",
+			includeContent: true,
+			numResults: 1,
+			recencyFilter: "week",
+			domainFilter: ["https://www.search1api.com/docs", "-example.com"],
+		});
+		console.log(JSON.stringify({ calls, result }));
+	`, { HOME: home, USERPROFILE: home, SEARCH1API_KEY: "synthetic-search1api-test-key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.calls, [{
+		url: "https://api.search1api.com/search",
+		headers: {
+			authorization: "Bearer synthetic-search1api-test-key",
+			"content-type": "application/json",
+		},
+		body: {
+			query: "search1api docs",
+			max_results: 1,
+			crawl_results: 1,
+			include_sites: ["www.search1api.com"],
+			exclude_sites: ["example.com"],
+			time_range: "week",
+		},
+	}]);
+	assert.equal(output.result.provider, "search1api");
+	assert.deepEqual(output.result.results, [{
+		title: "Search1API Docs",
+		url: "https://www.search1api.com/docs",
+		snippet: "Search, crawl, and extract.",
+	}]);
+	assert.deepEqual(output.result.inlineContent, [{
+		url: "https://www.search1api.com/docs",
+		title: "Search1API Docs",
+		content: "# Full Search1API documentation",
+		error: null,
+	}]);
+});
+
+test("Search1API search does not request paid page crawling unless includeContent is true", async () => {
+	const home = await createHome();
+	const child = runChild(`
+		let body = null;
+		globalThis.fetch = async (_url, init) => {
+			body = JSON.parse(init.body);
+			return new Response(JSON.stringify({ searchParameters: {}, results: [] }), { status: 200 });
+		};
+		const { searchWithSearch1API } = await import(${JSON.stringify(search1apiModuleUrl)});
+		await searchWithSearch1API("basic search", { numResults: 20 });
+		console.log(JSON.stringify(body));
+	`, { HOME: home, USERPROFILE: home, SEARCH1API_KEY: "synthetic-search1api-test-key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout.trim()), {
+		query: "basic search",
+		max_results: 20,
+		crawl_results: 0,
+	});
+});
+
+test("Search1API Crawl maps extracted content", async () => {
+	const home = await createHome();
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url, init) => {
+			calls.push({
+				url: String(url),
+				headers: Object.fromEntries(new Headers(init.headers)),
+				body: JSON.parse(init.body),
+			});
+			return new Response(JSON.stringify({
+				crawlParameters: { url: "https://example.com/article" },
+				results: {
+					title: "Example article",
+					link: "https://example.com/article",
+					content: "# Article body",
+					metadata: { language: "en" },
+				},
+			}), { status: 200 });
+		};
+		const { extractWithSearch1API } = await import(${JSON.stringify(search1apiModuleUrl)});
+		const result = await extractWithSearch1API("https://example.com/article", undefined, { timeoutMs: 45000 });
+		console.log(JSON.stringify({ calls, result }));
+	`, { HOME: home, USERPROFILE: home, SEARCH1API_KEY: "synthetic-search1api-test-key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.calls, [{
+		url: "https://api.search1api.com/crawl",
+		headers: {
+			authorization: "Bearer synthetic-search1api-test-key",
+			"content-type": "application/json",
+		},
+		body: { url: "https://example.com/article" },
+	}]);
+	assert.deepEqual(output.result, {
+		url: "https://example.com/article",
+		title: "Example article",
+		content: "# Article body",
+		error: null,
+	});
+});
+
+test("Search1API errors redact credentials", async () => {
+	const home = await createHome();
+	const child = runChild(`
+		globalThis.fetch = async () => new Response("rejected synthetic-search1api-secret", { status: 401 });
+		const { searchWithSearch1API } = await import(${JSON.stringify(search1apiModuleUrl)});
+		let error = "";
+		try { await searchWithSearch1API("redact me"); }
+		catch (err) { error = err.message; }
+		console.log(JSON.stringify({ error }));
+	`, { HOME: home, USERPROFILE: home, SEARCH1API_KEY: "synthetic-search1api-secret" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.match(output.error, /Search1API Search API error 401/);
+	assert.equal(output.error.includes("synthetic-search1api-secret"), false);
+	assert.match(output.error, /\[redacted\]/i);
+});
+
+test("fetch_content uses Search1API after local and Jina extraction fail", async () => {
+	const home = await createHome();
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			const urlText = String(url);
+			calls.push(urlText);
+			if (urlText === "https://example.com/app") {
+				return new Response("<html><body><script></script><script></script><script></script><script></script>Loading</body></html>", { status: 200, headers: { "content-type": "text/html" } });
+			}
+			if (urlText.startsWith("https://r.jina.ai/")) return new Response("", { status: 503 });
+			if (urlText === "https://api.search1api.com/crawl") {
+				return new Response(JSON.stringify({
+					crawlParameters: { url: "https://example.com/app" },
+					results: { title: "Rendered", link: "https://example.com/app", content: "# Search1API rendered content" },
+				}), { status: 200 });
+			}
+			if (urlText === "https://api.parallel.ai/v1/extract") throw new Error("Parallel must not run");
+			throw new Error("Unexpected fetch " + urlText + " " + String(init.method || "GET"));
+		};
+		const { extractContent } = await import(${JSON.stringify(extractModuleUrl)});
+		const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
+		const result = await extractContent("https://example.com/app", undefined, { lookup });
+		console.log(JSON.stringify({ calls, result }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		SEARCH1API_KEY: "synthetic-search1api-test-key",
+		PARALLEL_API_KEY: "synthetic-parallel-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.calls, [
+		"https://example.com/app",
+		"https://r.jina.ai/https://example.com/app",
+		"https://api.search1api.com/crawl",
+	]);
+	assert.deepEqual(output.result, {
+		url: "https://example.com/app",
+		title: "Rendered",
+		content: "# Search1API rendered content",
+		error: null,
+	});
+});
+
+test("configured searchRouting can select Search1API", async () => {
+	const home = await createHome({
+		searchRouting: { providers: ["search1api"], fallbackOn: ["network"] },
+	});
+	const child = runChild(`
+		globalThis.fetch = async () => new Response(JSON.stringify({
+			searchParameters: { query: "route" },
+			results: [{ title: "Routed", snippet: "Search1API route", link: "https://example.com/routed" }],
+		}), { status: 200 });
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("route", { provider: "auto" });
+		console.log(JSON.stringify({ provider: result.provider, results: result.results }));
+	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: join(home, ".pi"), SEARCH1API_KEY: "synthetic-search1api-test-key" });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.provider, "search1api");
+	assert.equal(output.results[0].title, "Routed");
+});
+
+test("curator page exposes Search1API as a manual provider", async () => {
+	const { generateCuratorPage } = await import(curatorPageModuleUrl);
+	const page = generateCuratorPage(
+		["search1api query"],
+		"session-token",
+		20,
+		{
+			all: false,
+			openai: false,
+			brave: false,
+			parallel: false,
+			tinyfish: false,
+			search1api: true,
+			tavily: false,
+			serpdive: false,
+			searxng: false,
+			perplexity: false,
+			exa: false,
+			gemini: false,
+			anysearch: false,
+		},
+		"search1api",
+		"search1api",
+		[],
+		null,
+	);
+	assert.match(page, /data-provider="search1api"/);
+	assert.match(page, />Search1API<\/button>/);
+	assert.match(page, /provider-tag\.provider-search1api/);
+});


### PR DESCRIPTION
## Summary

- add Search1API as a first-class `web_search` provider with `search1apiApiKey` / `SEARCH1API_KEY` credentials
- map result count, recency, and include/exclude domain filters to the Search API
- expose Deep Search page content inline only when `includeContent` is enabled
- add Search1API Crawl as a hosted `fetch_content` fallback
- wire Search1API into auto, ordered, all-provider, and curator routing
- document configuration, credit behavior, and official Search1API resources

## Why

Search1API provides both web discovery and page extraction, but Pi Web Access did not have a native adapter for either API. This adds a single provider integration that follows the extension's existing credential, routing, activity, redaction, and extraction patterns.

Users can select `provider: "search1api"`, include it in ordered or all-provider searches, or let `auto` use it when a key is configured. Blocked pages can also fall back to Search1API Crawl after local extraction, Jina Reader, and TinyFish.

## Cost behavior

- basic searches explicitly send `crawl_results: 0`
- Deep Search is enabled only when `includeContent` is true
- Crawl is called only after earlier content extraction paths fail
- README documents Search1API's credit behavior and links to the official Search and Crawl guides

## Validation

- `npm run typecheck`
- `npm test` — 224/224 passing
- `npm pack --dry-run`
- `git diff --check`
- live Search1API Search smoke test
- live Search1API Crawl smoke test
