### PR TITLE
Add remote-accessible curator URL via curatorHost config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Added `curatorRemote` and `autoOpenBrowser` controls for remote-accessible curator sessions, defaulting remote mode to a printed manual URL unless browser auto-open is explicitly requested. Thanks `@tylerdavis` for PR #178.
 - Resolve the OpenAI search model from Pi’s model registry, with an `openaiSearchModel` override and preserved API-key fallback for partial registries. Thanks `@ahalekelly` for PR #182.
 - Surfaced RFC Link / HTML discovery relations (`service-desc`, `service-doc`, `service-meta`, `api-catalog`, `describedby`) from HTTP `Link` headers and matching `link`/`a[rel]` markup during `fetch_content` HTML extraction, including empty SPA shells, without broad `/docs` URL heuristics. Thanks `@XWIlluDelu` for PR #175.
 - Expand leading `~` and `$HOME`-style environment variables in `githubClone.clonePath` before cloning repositories. Thanks `@unship` for PR #184.

--- a/README.md
+++ b/README.md
@@ -304,6 +304,11 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "summaryModel": "anthropic/claude-haiku-4-5",
   "workflow": "summary-review",
   "curatorTimeoutSeconds": 20,
+  "curatorRemote": {
+    "host": "my-box.tailnet.ts.net",
+    "bind": "100.101.102.103"
+  },
+  "autoOpenBrowser": true,
   "githubClone": {
     "enabled": true,
     "maxRepoSizeMB": 350,
@@ -404,6 +409,57 @@ Two behaviours worth knowing, both consequences of the API surface:
 - **Domain filters are applied locally.** SERPdive has no include/exclude domain parameter, so `domainFilter` is applied to the results that come back. It can narrow a page of results, not ask the engine for more from a given domain.
 
 `numResults` maps to `max_results`, which the API treats as a cap between 1 and 10 — never a minimum. Values above 10 are clamped; the engine returns what it judges relevant, which is often fewer.
+
+### Remote curator access
+
+By default the curator HTTP server binds to `127.0.0.1` and hands out a `http://localhost:<port>/?session=<token>` URL, so it is reachable only from the machine running Pi. That is the right default and nothing below changes it unless you opt in.
+
+Opt in when Pi runs somewhere other than where your browser is — a dev box you SSH into, a container, a remote workstation on a Tailscale/WireGuard network:
+
+```json
+{
+  "curatorRemote": true
+}
+```
+
+`true` derives both values: the URL host becomes `os.hostname()` and the server binds `0.0.0.0`. Either can be overridden, and you should usually override `bind`:
+
+```json
+{
+  "curatorRemote": {
+    "host": "my-box.tailnet.ts.net",
+    "bind": "100.101.102.103"
+  }
+}
+```
+
+| Value | URL host | Bind address |
+| --- | --- | --- |
+| omitted or `false` | `localhost` | `127.0.0.1` |
+| `true` | `os.hostname()` | `0.0.0.0` |
+| `{ "host": "h" }` | `h` | `0.0.0.0` |
+| `{ "bind": "b" }` | `os.hostname()` | `b` |
+| `{ "host": "h", "bind": "b" }` | `h` | `b` |
+
+Anything else — a string, `null`, an array — is treated as not configured and stays local.
+
+`host` only changes the URL that gets printed; `bind` is what actually determines who can reach the server. Set them to a matching pair — a `host` that does not resolve to the interface you bound produces a link that looks right and does not load.
+
+**Security.** Enabling this exposes the curator beyond the local machine, and `bind: "0.0.0.0"` exposes it on every interface, including untrusted networks. The only access control is the unguessable session token in the URL, carried over plain HTTP with no TLS — so the token and everything you curate are readable by anyone able to observe that traffic. Anyone who reaches the port with the token can run searches against your configured providers (spending your API credits) and edit the summary that gets returned into the agent's context. Prefer binding to one private-network interface, as in the example above, over `0.0.0.0`, and treat the curator URL as a secret. The server is short-lived — it exists only for the duration of a curation session — but it is unauthenticated apart from that token.
+
+Remote curator sessions print the URL instead of trying to open a browser by default. Turning remote access on also raises the default curator idle timeout from 20 to 60 seconds, giving you time to notice and click that link; set `curatorTimeoutSeconds` explicitly to override. If you do want Pi to launch a browser on the remote host anyway, set `autoOpenBrowser: true` explicitly.
+
+#### Disabling browser auto-open
+
+`autoOpenBrowser` is also useful on its own for local sessions:
+
+```json
+{
+  "autoOpenBrowser": false
+}
+```
+
+When `false`, the extension never tries to open a Glimpse window or a browser and always prints the URL for you to open manually. For local-only sessions it defaults to `true`; remote curator sessions print the URL unless you set `autoOpenBrowser: true` explicitly. This is worth setting locally when you would rather paste the link into a specific browser than have one launched for you. It changes nothing about where the server binds; that is `curatorRemote`'s job alone.
 
 ### Shortcuts
 

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -1,6 +1,7 @@
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import { generateCuratorPage } from "./curator-page.ts";
 import type { SummaryMeta } from "./summary-review.ts";
+import { resolveCuratorNetworkConfig } from "./utils.ts";
 
 const STALE_THRESHOLD_MS = 30000;
 const WATCHDOG_INTERVAL_MS = 1000;
@@ -629,15 +630,17 @@ export function startCuratorServer(
 			reject(new Error(`Curator server failed to start: ${err.message}`));
 		};
 
+		const networkConfig = resolveCuratorNetworkConfig();
+
 		server.once("error", onError);
-		server.listen(0, "127.0.0.1", () => {
+		server.listen(0, networkConfig.bind, () => {
 			server.off("error", onError);
 			const addr = server.address();
 			if (!addr || typeof addr === "string") {
 				reject(new Error("Curator server: invalid address"));
 				return;
 			}
-			const url = `http://localhost:${addr.port}/?session=${sessionToken}`;
+			const url = `http://${networkConfig.host}:${addr.port}/?session=${sessionToken}`;
 
 			watchdog = setInterval(() => {
 				if (completed) return;

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import { normalizeFetchContentParams } from "./fetch-params.ts";
 import { clearCloneCache } from "./github-extract.ts";
 import { getConfiguredSearchRouting, search, type AttributedSearchResponse, type SearchProvider, type ResolvedSearchProvider } from "./gemini-search.ts";
 import type { SearchResult } from "./perplexity.ts";
-import { formatSeconds, getWebSearchConfigDir, getWebSearchConfigPath } from "./utils.ts";
+import { formatSeconds, getWebSearchConfigDir, getWebSearchConfigPath, resolveCuratorNetworkConfig } from "./utils.ts";
 import {
 	clearResults,
 	deleteResult,
@@ -100,6 +100,8 @@ interface WebSearchConfig {
 	searchProvider?: string;
 	workflow?: string;
 	curatorTimeoutSeconds?: unknown;
+	autoOpenBrowser?: unknown;
+	curatorRemote?: unknown;
 	summaryModel?: string;
 	webSearch?: {
 		enabled?: boolean;
@@ -190,6 +192,7 @@ const DEFAULT_TOOL_NAMES: ToolNames = {
 const TOOL_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 const DEFAULT_SHORTCUTS = { curate: "ctrl+shift+s", activity: "ctrl+shift+w" } satisfies Record<string, KeyId>;
 const DEFAULT_CURATOR_TIMEOUT_SECONDS = 20;
+const DEFAULT_REMOTE_CURATOR_TIMEOUT_SECONDS = 60;
 const MAX_CURATOR_TIMEOUT_SECONDS = 600;
 
 function resolveToolNames(config: WebSearchConfig): ToolNames {
@@ -278,7 +281,16 @@ function normalizeQueryList(queryList: unknown[]): string[] {
 
 function getCuratorTimeoutSeconds(): number {
 	const source = loadConfig();
-	return normalizeCuratorTimeoutSeconds(source.curatorTimeoutSeconds) ?? DEFAULT_CURATOR_TIMEOUT_SECONDS;
+	const explicit = normalizeCuratorTimeoutSeconds(source.curatorTimeoutSeconds);
+	if (explicit !== undefined) return explicit;
+	// Remote users must notice and click a printed link, so allow more idle time.
+	return resolveCuratorNetworkConfig().enabled ? DEFAULT_REMOTE_CURATOR_TIMEOUT_SECONDS : DEFAULT_CURATOR_TIMEOUT_SECONDS;
+}
+
+function shouldAutoOpenCuratorBrowser(config: WebSearchConfig): boolean {
+	if (config.autoOpenBrowser === false) return false;
+	if (resolveCuratorNetworkConfig().enabled && config.autoOpenBrowser !== true) return false;
+	return true;
 }
 
 async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderAvailability> {
@@ -1348,6 +1360,11 @@ export default function (pi: ExtensionAPI) {
 					shortcut: curateKey,
 				},
 			});
+
+			if (!shouldAutoOpenCuratorBrowser(loadConfig())) {
+				sendCuratorFallbackUpdate("Search curator is running. Open the curator URL manually.");
+				return;
+			}
 
 			const open = platform() === "darwin" ? await getGlimpseOpen() : null;
 			if (open) {
@@ -2761,38 +2778,42 @@ export default function (pi: ExtensionAPI) {
 
 				commandHandle = handle;
 				activeCurators.set(commandCallId, handle);
-				const open = platform() === "darwin" ? await getGlimpseOpen() : null;
 				let browserOpenError: string | null = null;
-				if (open) {
-					try {
-						const win = openInGlimpse(open, handle.url, "Search Curator");
-						glimpseWins.set(commandCallId, win);
-						win.on("closed", () => {
-							if (glimpseWins.get(commandCallId) === win) {
-								glimpseWins.delete(commandCallId);
-								closeCurator(commandCallId);
+				if (!shouldAutoOpenCuratorBrowser(loadConfig())) {
+					ctx.ui.notify(`Search curator is running. Open manually: ${handle.url}`, "info");
+				} else {
+					const open = platform() === "darwin" ? await getGlimpseOpen() : null;
+					if (open) {
+						try {
+							const win = openInGlimpse(open, handle.url, "Search Curator");
+							glimpseWins.set(commandCallId, win);
+							win.on("closed", () => {
+								if (glimpseWins.get(commandCallId) === win) {
+									glimpseWins.delete(commandCallId);
+									closeCurator(commandCallId);
+								}
+							});
+						} catch (err) {
+							const message = err instanceof Error ? err.message : String(err);
+							console.error(`Failed to open Glimpse curator window: ${message}`);
+							glimpseWins.delete(commandCallId);
+							try {
+								await openInBrowser(pi, handle.url);
+							} catch (browserErr) {
+								browserOpenError = browserErr instanceof Error ? browserErr.message : String(browserErr);
 							}
-						});
-					} catch (err) {
-						const message = err instanceof Error ? err.message : String(err);
-						console.error(`Failed to open Glimpse curator window: ${message}`);
-						glimpseWins.delete(commandCallId);
+						}
+					} else {
 						try {
 							await openInBrowser(pi, handle.url);
 						} catch (browserErr) {
 							browserOpenError = browserErr instanceof Error ? browserErr.message : String(browserErr);
 						}
 					}
-				} else {
-					try {
-						await openInBrowser(pi, handle.url);
-					} catch (browserErr) {
-						browserOpenError = browserErr instanceof Error ? browserErr.message : String(browserErr);
+					if (browserOpenError) {
+						console.error(`Failed to open curator UI: ${browserOpenError}`);
+						ctx.ui.notify(`Search curator is running, but the browser did not open automatically. Open manually: ${handle.url}`, "info");
 					}
-				}
-				if (browserOpenError) {
-					console.error(`Failed to open curator UI: ${browserOpenError}`);
-					ctx.ui.notify(`Search curator is running, but the browser did not open automatically. Open manually: ${handle.url}`, "info");
 				}
 
 				if (queries.length > 0) {

--- a/test/curator-fallback.test.mjs
+++ b/test/curator-fallback.test.mjs
@@ -46,7 +46,15 @@ test("manual websearch command reports browser-open fallback without closing cur
 	assert.match(indexSrc, /if \(queries\.length > 0\) \{/);
 });
 
+test("remote curator mode prints the manual URL unless auto-open is explicit", () => {
+	assert.match(indexSrc, /function shouldAutoOpenCuratorBrowser\(config: WebSearchConfig\): boolean \{/);
+	assert.match(indexSrc, /if \(resolveCuratorNetworkConfig\(\)\.enabled && config\.autoOpenBrowser !== true\) return false;/);
+	assert.ok(indexSrc.includes('sendCuratorFallbackUpdate("Search curator is running. Open the curator URL manually.")'));
+	assert.ok(indexSrc.includes('ctx.ui.notify(`Search curator is running. Open manually: ${handle.url}`, "info")'));
+});
+
 test("README documents manual browser fallback", () => {
 	assert.match(readmeSrc, /Docker, WSL, SSH, or headless environments/);
 	assert.match(readmeSrc, /Copy it into a browser that can reach the Pi host/);
+	assert.match(readmeSrc, /Remote curator sessions print the URL instead of trying to open a browser by default/);
 });

--- a/utils.ts
+++ b/utils.ts
@@ -1,4 +1,5 @@
-import { homedir } from "node:os";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir, hostname } from "node:os";
 import { join } from "node:path";
 
 export function getWebSearchConfigDir(): string {
@@ -9,6 +10,49 @@ export function getWebSearchConfigDir(): string {
 
 export function getWebSearchConfigPath(): string {
 	return join(getWebSearchConfigDir(), "web-search.json");
+}
+
+export interface CuratorNetworkConfig {
+	/** Whether remote access was opted into via curatorRemote. */
+	enabled: boolean;
+	host: string;
+	bind: string;
+}
+
+const LOCAL_CURATOR_NETWORK_DEFAULTS: CuratorNetworkConfig = { enabled: false, host: "localhost", bind: "127.0.0.1" };
+
+function trimmedString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** Resolves the curator server bind address and URL host from `curatorRemote`. */
+export function resolveCuratorNetworkConfig(): CuratorNetworkConfig {
+	const configPath = getWebSearchConfigPath();
+	if (!existsSync(configPath)) return LOCAL_CURATOR_NETWORK_DEFAULTS;
+
+	let raw: unknown;
+	try {
+		raw = JSON.parse(readFileSync(configPath, "utf-8"));
+	} catch {
+		return LOCAL_CURATOR_NETWORK_DEFAULTS;
+	}
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return LOCAL_CURATOR_NETWORK_DEFAULTS;
+
+	const curatorRemote = (raw as Record<string, unknown>).curatorRemote;
+	if (curatorRemote === true) return { enabled: true, host: hostname(), bind: "0.0.0.0" };
+
+	if (curatorRemote && typeof curatorRemote === "object" && !Array.isArray(curatorRemote)) {
+		const obj = curatorRemote as Record<string, unknown>;
+		return {
+			enabled: true,
+			host: trimmedString(obj.host) ?? hostname(),
+			bind: trimmedString(obj.bind) ?? "0.0.0.0",
+		};
+	}
+
+	return LOCAL_CURATOR_NETWORK_DEFAULTS;
 }
 
 export function formatSeconds(s: number): string {


### PR DESCRIPTION
I was running into QOL issues using the curator on a remote host. The only option seems to be bypass the curator, which feels like a missed opportunity.

This change adds an option to update the rendered curator server host, allowing for remote access to the curator.

Two options.  

1. Simple turnkey that uses the box's hostname when rendering:

```json
{
  "curatorRemote": true
}
```

2. Explicitly binds an IP and sets a host for more exotic networking like Tailscale:

```json
{
  "curatorRemote": {
    "host": "my-box.tailnet.ts.net",
    "bind": "100.101.102.103"
  }
}
```

---

- Bind curator HTTP server to 0.0.0.0 instead of 127.0.0.1 so it's accessible from the local network / tailnet.
- Use hostname-based URLs instead of localhost.  Added getCuratorHost() which reads curatorHost from web-search.json config, falling back to os.hostname().
- This allows the curator link to be clickable when accessed over SSH.