### PR TITLE
fix: write extracted PDFs to a temp dir instead of ~/Downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Write extracted PDF markdown to a temporary `pi-web-pdf` directory by default instead of `~/Downloads`, while preserving explicit output directories. Thanks `@ahalekelly` for PR #183.
+
 ## [0.15.0] - 2026-07-28
 
 ### Added

--- a/pdf-extract.ts
+++ b/pdf-extract.ts
@@ -7,7 +7,7 @@
 
 import { writeFile, mkdir } from "node:fs/promises";
 import { join, basename } from "node:path";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 
 export interface PDFExtractResult {
   title: string;
@@ -23,7 +23,7 @@ export interface PDFExtractOptions {
 }
 
 const DEFAULT_MAX_PAGES = 100;
-const DEFAULT_OUTPUT_DIR = join(homedir(), "Downloads");
+const DEFAULT_OUTPUT_DIR = join(tmpdir(), "pi-web-pdf");
 
 async function getUnpdf() {
   if (typeof (Promise as PromiseConstructor & { try?: unknown }).try !== "function") {


### PR DESCRIPTION
`pdf-extract`'s `DEFAULT_OUTPUT_DIR` is `~/Downloads`, so every PDF extraction quietly drops markdown files into the user's Downloads folder — surprising for an agent tool, especially in background/headless sessions where the user never sees it happen. This changes the default to `join(tmpdir(), "pi-web-pdf")`; the existing `mkdir(outputDir, { recursive: true })` creates it, and callers passing an explicit `outputDir` are unaffected.

`npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)