### PR TITLE
fix: honor filters and content on keyless Exa MCP search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed filtered zero-config Exa search silently losing its request options: the default keyless MCP tool (`web_search_exa`) only accepts `query` and `numResults`, so `type`, `livecrawl`, and `contextMaxCharacters` were dropped server-side and `includeContent` never returned page text. Filtered or content-carrying keyless searches now use `web_search_advanced_exa` — served by the same keyless free tier — which applies `includeDomains`/`excludeDomains`, `startPublishedDate`, highlights, and text limits as real parameters instead of `site:` / "past week" strings appended to the semantic query. Plain searches stay on `web_search_exa`, and the advanced path falls back to it if it is unavailable.
+- Stopped requesting citation text on keyed Exa `/answer` calls, which was fetched and then discarded, and stopped requesting page text on keyed `/search` calls that do not ask for content.
+- Exa MCP rate-limit responses (429) now explain that adding `exaApiKey` to `~/.pi/web-search.json` removes the free-tier limit, instead of surfacing a bare status code.
+
 ## [0.16.0] - 2026-07-30
 
 ### Added

--- a/exa.ts
+++ b/exa.ts
@@ -9,6 +9,8 @@ const EXA_ANSWER_URL = "https://api.exa.ai/answer";
 const EXA_SEARCH_URL = "https://api.exa.ai/search";
 const EXA_MCP_URL = "https://mcp.exa.ai/mcp";
 const CONFIG_PATH = getWebSearchConfigPath();
+const EXA_MCP_ADVANCED_TOOL = "web_search_advanced_exa";
+const EXA_MCP_BASIC_TOOL = "web_search_exa";
 
 interface WebSearchConfig {
 	exaApiKey?: unknown;
@@ -78,6 +80,14 @@ async function getApiKey(signal?: AbortSignal): Promise<string | null> {
 	});
 }
 
+function exaApiHeaders(apiKey: string): Record<string, string> {
+	return {
+		"x-api-key": apiKey,
+		"Content-Type": "application/json",
+		"x-exa-integration": "pi-web-access",
+	};
+}
+
 function requestSignal(signal?: AbortSignal): AbortSignal {
 	const timeout = AbortSignal.timeout(60000);
 	return signal ? AbortSignal.any([signal, timeout]) : timeout;
@@ -107,6 +117,17 @@ function mapDomainFilter(domainFilter: string[] | undefined): { includeDomains?:
 	return {
 		...(includeDomains.length ? { includeDomains } : {}),
 		...(excludeDomains.length ? { excludeDomains } : {}),
+	};
+}
+
+function exaSearchArgs(query: string, options: ExaSearchOptions): Record<string, unknown> {
+	const startDate = options.recencyFilter ? recencyToStartDate(options.recencyFilter) : null;
+	return {
+		query,
+		type: "auto",
+		numResults: options.numResults ?? 5,
+		...mapDomainFilter(options.domainFilter),
+		...(startDate ? { startPublishedDate: startDate } : {}),
 	};
 }
 
@@ -160,16 +181,27 @@ function mapInlineContent(results: ExaSearchResponse["results"]): ExtractedConte
 		}));
 }
 
+function toSearchResponse(
+	answer: string,
+	results: SearchResponse["results"],
+	inlineContent: ExtractedContent[] | null,
+): SearchResponse {
+	const response: SearchResponse = { answer, results };
+	if (inlineContent?.length) response.inlineContent = inlineContent;
+	return response;
+}
+
 export async function callExaMcp(
 	toolName: string,
 	args: Record<string, unknown>,
 	signal?: AbortSignal,
 ): Promise<string> {
-	const response = await fetch(EXA_MCP_URL, {
+	const response = await fetch(`${EXA_MCP_URL}?tools=${toolName}`, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
 			"Accept": "application/json, text/event-stream",
+			"x-exa-source": "pi-web-access",
 		},
 		body: JSON.stringify({
 			jsonrpc: "2.0",
@@ -185,6 +217,11 @@ export async function callExaMcp(
 
 	if (!response.ok) {
 		const errorText = await response.text();
+		if (response.status === 429) {
+			throw new Error(
+				`Exa MCP rate limit reached (429). Add "exaApiKey" to ${CONFIG_PATH} for unthrottled Exa search: ${errorText.slice(0, 200)}`,
+			);
+		}
 		throw new Error(`Exa MCP error ${response.status}: ${errorText.slice(0, 300)}`);
 	}
 
@@ -307,45 +344,83 @@ function buildMcpQuery(query: string, options: ExaSearchOptions): string {
 	return parts.join(" ");
 }
 
+function isAbortMessage(message: string): boolean {
+	return message.toLowerCase().includes("abort");
+}
+
+function parseJsonMcpResults(text: string): ExaSearchResponse["results"] | null {
+	try {
+		const results = (JSON.parse(text) as ExaSearchResponse).results;
+		return Array.isArray(results) && results.length > 0 ? results : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Calls one Exa MCP search tool and normalizes its payload. `web_search_advanced_exa`
+ * returns the raw Exa search JSON; `web_search_exa` returns a formatted text block.
+ */
+async function searchWithExaMcpTool(
+	tool: string,
+	args: Record<string, unknown>,
+	options: ExaSearchOptions,
+): Promise<SearchResponse | null> {
+	const text = await callExaMcp(tool, args, options.signal);
+
+	const jsonResults = parseJsonMcpResults(text);
+	if (jsonResults) {
+		return toSearchResponse(
+			buildAnswerFromSearchResults(jsonResults),
+			mapResults(jsonResults),
+			options.includeContent ? mapInlineContent(jsonResults) : null,
+		);
+	}
+
+	const textResults = parseMcpResults(text);
+	if (!textResults) return null;
+
+	return toSearchResponse(
+		buildAnswerFromMcpResults(textResults),
+		mapResults(textResults),
+		options.includeContent ? mapMcpInlineContent(textResults) : null,
+	);
+}
+
+/** Filtered searches need the advanced tool, which not every deployment exposes. */
+async function searchWithFilteredExaMcp(
+	query: string,
+	options: ExaSearchOptions,
+	basicArgs: Record<string, unknown>,
+): Promise<SearchResponse | null> {
+	try {
+		return await searchWithExaMcpTool(EXA_MCP_ADVANCED_TOOL, {
+			...exaSearchArgs(query, options),
+			enableHighlights: true,
+			textMaxCharacters: options.includeContent ? 50000 : 3000,
+		}, options);
+	} catch (err) {
+		if (isAbortMessage(err instanceof Error ? err.message : String(err))) throw err;
+		// The basic tool ignores every argument except query/numResults, so the
+		// filters degrade into the query text.
+		return searchWithExaMcpTool(EXA_MCP_BASIC_TOOL, basicArgs, options);
+	}
+}
+
 async function searchWithExaMcp(query: string, options: ExaSearchOptions = {}): Promise<SearchResponse | null> {
-	const enrichedQuery = buildMcpQuery(query, options);
-	const activityId = activityMonitor.logStart({ type: "api", query: enrichedQuery });
+	const activityId = activityMonitor.logStart({ type: "api", query });
+	const basicArgs = { query: buildMcpQuery(query, options), numResults: options.numResults ?? 5 };
+	const filtered = !!options.includeContent || !!options.recencyFilter || !!options.domainFilter?.length;
 
 	try {
-		const text = await callExaMcp(
-			"web_search_exa",
-			{
-				query: enrichedQuery,
-				numResults: options.numResults ?? 5,
-				livecrawl: "fallback",
-				type: "auto",
-				contextMaxCharacters: options.includeContent ? 50000 : 3000,
-			},
-			options.signal,
-		);
-		const parsedResults = parseMcpResults(text);
+		const response = filtered
+			? await searchWithFilteredExaMcp(query, options, basicArgs)
+			: await searchWithExaMcpTool(EXA_MCP_BASIC_TOOL, basicArgs, options);
 		activityMonitor.logComplete(activityId, 200);
-
-		if (!parsedResults) return null;
-
-		const response: SearchResponse = {
-			answer: buildAnswerFromMcpResults(parsedResults),
-			results: parsedResults.map((result, index) => ({
-				title: result.title || `Source ${index + 1}`,
-				url: result.url,
-				snippet: "",
-			})),
-		};
-
-		if (options.includeContent) {
-			const inlineContent = mapMcpInlineContent(parsedResults);
-			if (inlineContent.length > 0) response.inlineContent = inlineContent;
-		}
-
 		return response;
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		if (message.toLowerCase().includes("abort")) {
+		if (isAbortMessage(message)) {
 			activityMonitor.logComplete(activityId, 0);
 		} else {
 			activityMonitor.logError(activityId, message);
@@ -383,14 +458,8 @@ export async function searchWithExa(query: string, options: ExaSearchOptions = {
 		if (!useSearch) {
 			const response = await fetch(EXA_ANSWER_URL, {
 				method: "POST",
-				headers: {
-					"x-api-key": apiKey,
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({
-					query,
-					text: true,
-				}),
+				headers: exaApiHeaders(apiKey),
+				body: JSON.stringify({ query }),
 				signal: requestSignal(options.signal),
 			});
 
@@ -407,24 +476,14 @@ export async function searchWithExa(query: string, options: ExaSearchOptions = {
 			};
 		}
 
-		const startDate = options.recencyFilter ? recencyToStartDate(options.recencyFilter) : null;
-		const domainFilters = mapDomainFilter(options.domainFilter);
 		const response = await fetch(EXA_SEARCH_URL, {
 			method: "POST",
-			headers: {
-				"x-api-key": apiKey,
-				"Content-Type": "application/json",
-			},
+			headers: exaApiHeaders(apiKey),
 			body: JSON.stringify({
-				query,
-				type: "auto",
-				numResults: options.numResults ?? 5,
-				...domainFilters,
-				...(startDate ? { startPublishedDate: startDate } : {}),
-				contents: {
-					text: options.includeContent ? true : { maxCharacters: 3000 },
-					highlights: true,
-				},
+				...exaSearchArgs(query, options),
+				contents: options.includeContent
+					? { text: true, highlights: true }
+					: { highlights: true },
 			}),
 			signal: requestSignal(options.signal),
 		});
@@ -437,19 +496,15 @@ export async function searchWithExa(query: string, options: ExaSearchOptions = {
 		const data = await response.json() as ExaSearchResponse;
 		activityMonitor.logComplete(activityId, response.status);
 
-		const mapped: SearchResponse = {
-			answer: buildAnswerFromSearchResults(data.results),
-			results: mapResults(data.results),
-		};
-		if (options.includeContent) {
-			const inlineContent = mapInlineContent(data.results);
-			if (inlineContent.length > 0) mapped.inlineContent = inlineContent;
-		}
-		return mapped;
+		return toSearchResponse(
+			buildAnswerFromSearchResults(data.results),
+			mapResults(data.results),
+			options.includeContent ? mapInlineContent(data.results) : null,
+		);
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		const redactedMessage = redactCredential(message, apiKey);
-		if (redactedMessage.toLowerCase().includes("abort")) {
+		if (isAbortMessage(redactedMessage)) {
 			activityMonitor.logComplete(activityId, 0);
 		} else {
 			activityMonitor.logError(activityId, redactedMessage);

--- a/test/all-provider.test.mjs
+++ b/test/all-provider.test.mjs
@@ -60,7 +60,7 @@ test('provider "all" starts every eligible provider together, excludes AnySearch
 			if (target.startsWith("https://api.anysearch.com/")) {
 				throw new Error("AnySearch must not run for provider all");
 			}
-			if (target === "https://mcp.exa.ai/mcp") {
+			if (target.startsWith("https://mcp.exa.ai/mcp")) {
 				await waitForPeers("exa");
 				return new Response(JSON.stringify({
 					jsonrpc: "2.0",
@@ -142,7 +142,7 @@ test('provider array searches only the selected providers concurrently and prese
 
 		globalThis.fetch = async (url) => {
 			const target = String(url);
-			if (target === "https://mcp.exa.ai/mcp") {
+			if (target.startsWith("https://mcp.exa.ai/mcp")) {
 				await waitForPeer("exa");
 				return new Response(JSON.stringify({
 					jsonrpc: "2.0",
@@ -188,7 +188,7 @@ test('provider array reports an unavailable selection without discarding success
 	const child = runChild(`
 		globalThis.fetch = async (url) => {
 			const target = String(url);
-			if (target === "https://mcp.exa.ai/mcp") {
+			if (target.startsWith("https://mcp.exa.ai/mcp")) {
 				return new Response(JSON.stringify({
 					jsonrpc: "2.0",
 					id: 1,
@@ -221,7 +221,7 @@ test('provider "all" uses Gemini API without falling back to Gemini Web', async 
 	const child = runChild(`
 		globalThis.fetch = async (url) => {
 			const target = String(url);
-			if (target === "https://mcp.exa.ai/mcp") {
+			if (target.startsWith("https://mcp.exa.ai/mcp")) {
 				return new Response(JSON.stringify({
 					jsonrpc: "2.0",
 					id: 1,
@@ -264,7 +264,7 @@ test('provider "all" keeps successful providers when another available provider 
 	const child = runChild(`
 		globalThis.fetch = async (url) => {
 			const target = String(url);
-			if (target === "https://mcp.exa.ai/mcp") {
+			if (target.startsWith("https://mcp.exa.ai/mcp")) {
 				return new Response(JSON.stringify({
 					jsonrpc: "2.0",
 					id: 1,

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -269,7 +269,7 @@ test("auto provider falls through to Tavily after unavailable earlier providers"
 		globalThis.fetch = async (url, init = {}) => {
 			const urlText = String(url);
 			calls.push(urlText);
-			if (urlText === "https://mcp.exa.ai/mcp") {
+			if (urlText.startsWith("https://mcp.exa.ai/mcp")) {
 				return new Response("Exa unavailable", { status: 503 });
 			}
 			if (urlText === "https://api.tavily.com/search") {
@@ -292,7 +292,7 @@ test("auto provider falls through to Tavily after unavailable earlier providers"
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
-	assert.ok(output.calls.includes("https://mcp.exa.ai/mcp"));
+	assert.ok(output.calls.some((call) => call.startsWith("https://mcp.exa.ai/mcp")));
 	assert.ok(output.calls.includes("https://api.tavily.com/search"));
 	assert.equal(output.result.provider, "tavily");
 	assert.equal(output.result.answer, "Auto Tavily answer");
@@ -308,9 +308,11 @@ test("Exa direct API key ignores full legacy usage counter", async () => {
 
 		let capturedUrl = "";
 		let capturedHeaders = null;
+		let capturedBody = null;
 		globalThis.fetch = async (url, init) => {
 			capturedUrl = String(url);
 			capturedHeaders = init.headers;
+			capturedBody = JSON.parse(init.body);
 			return new Response(JSON.stringify({
 				answer: "Paid Exa answer",
 				citations: [{ title: "Exa Docs", url: "https://exa.ai/docs" }],
@@ -324,7 +326,9 @@ test("Exa direct API key ignores full legacy usage counter", async () => {
 		console.log(JSON.stringify({
 			available,
 			capturedUrl,
+			capturedBody,
 			apiKey: capturedHeaders["x-api-key"],
+			integration: capturedHeaders["x-exa-integration"],
 			result,
 			usage,
 		}));
@@ -338,7 +342,9 @@ test("Exa direct API key ignores full legacy usage counter", async () => {
 	const output = JSON.parse(child.stdout.trim());
 	assert.equal(output.available, true);
 	assert.equal(output.capturedUrl, "https://api.exa.ai/answer");
+	assert.deepEqual(output.capturedBody, { query: "paid exa query" });
 	assert.equal(output.apiKey, "exa-paid-key");
+	assert.equal(output.integration, "pi-web-access");
 	assert.equal(output.result.answer, "Paid Exa answer");
 	assert.deepEqual(output.result.results, [{ title: "Exa Docs", url: "https://exa.ai/docs", snippet: "" }]);
 	assert.equal(output.usage.count, 1000);
@@ -441,6 +447,104 @@ test("Exa provider errors redact the resolved credential", async () => {
 	const { message } = JSON.parse(child.stdout.trim());
 	assert.equal(message.includes(secret), false);
 	assert.equal(message.includes("[redacted]"), true);
+});
+
+test("keyless Exa search sends filters to the advanced MCP tool as parameters", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-exa-mcp-advanced-"));
+	const child = runChild(`
+		let captured = null;
+		globalThis.fetch = async (url, init) => {
+			captured = { url: String(url), body: JSON.parse(init.body) };
+			return new Response(JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				result: { content: [{ type: "text", text: JSON.stringify({ results: [{
+					title: "Advanced result",
+					url: "https://docs.example.com/advanced",
+					text: "full page text",
+					highlights: ["relevant highlight"],
+				}] }) }] },
+			}), { status: 200 });
+		};
+
+		const { searchWithExa } = await import(${JSON.stringify(exaModuleUrl)});
+		const result = await searchWithExa("semantic query", {
+			numResults: 3,
+			recencyFilter: "week",
+			domainFilter: ["docs.example.com", "-spam.example.net"],
+			includeContent: true,
+		});
+		console.log(JSON.stringify({ captured, result }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const { captured, result } = JSON.parse(child.stdout.trim());
+	assert.equal(captured.url, "https://mcp.exa.ai/mcp?tools=web_search_advanced_exa");
+	assert.equal(captured.body.params.name, "web_search_advanced_exa");
+
+	const { startPublishedDate, ...args } = captured.body.params.arguments;
+	assert.ok(startPublishedDate);
+	assert.deepEqual(args, {
+		query: "semantic query",
+		type: "auto",
+		numResults: 3,
+		includeDomains: ["docs.example.com"],
+		excludeDomains: ["spam.example.net"],
+		enableHighlights: true,
+		textMaxCharacters: 50000,
+	});
+
+	assert.deepEqual(result.results, [{ title: "Advanced result", url: "https://docs.example.com/advanced", snippet: "" }]);
+	assert.match(result.answer, /relevant highlight/);
+	assert.deepEqual(result.inlineContent, [{
+		url: "https://docs.example.com/advanced",
+		title: "Advanced result",
+		content: "full page text",
+		error: null,
+	}]);
+});
+
+test("keyless Exa search falls back to the default MCP tool when the advanced tool is missing", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-exa-mcp-fallback-"));
+	const child = runChild(`
+		const tools = [];
+		globalThis.fetch = async (url, init) => {
+			const target = String(url);
+			tools.push(JSON.parse(init.body).params.name);
+			if (target.includes("web_search_advanced_exa")) {
+				return new Response(JSON.stringify({
+					jsonrpc: "2.0",
+					id: 1,
+					error: { code: -32602, message: "Tool web_search_advanced_exa not found" },
+				}), { status: 200 });
+			}
+			return new Response(JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				result: { content: [{
+					type: "text",
+					text: "Title: Basic result\\nURL: https://example.com/basic\\nText: basic text\\n---",
+				}] },
+			}), { status: 200 });
+		};
+
+		const { searchWithExa } = await import(${JSON.stringify(exaModuleUrl)});
+		const result = await searchWithExa("fallback query", { domainFilter: ["example.com"] });
+		console.log(JSON.stringify({ tools, result }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const { tools, result } = JSON.parse(child.stdout.trim());
+	assert.deepEqual(tools, ["web_search_advanced_exa", "web_search_exa"]);
+	assert.deepEqual(result.results, [{ title: "Basic result", url: "https://example.com/basic", snippet: "" }]);
 });
 
 test("failed Gemini command source is redacted and blocks browser fallback", async () => {


### PR DESCRIPTION
Keyless Exa search was sending filters and content options to `web_search_exa`, which only accepts `query` and `numResults`, so those options were dropped server-side. Filtered or content-carrying keyless searches now use `web_search_advanced_exa` (same free tier), with fallback to the basic tool if it is unavailable.

Also stops requesting unused text on keyed `/answer` and `/search`, and turns MCP 429s into a clearer "add exaApiKey" hint.