### PR TITLE
fix: googlesearch tool gemma model compatibility

### DIFF
--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -622,7 +622,7 @@ async function searchWithGeminiApi(query: string, options: SearchOptions = {}): 
 		const model = getSearchConfig().searchModel ?? DEFAULT_SEARCH_MODEL;
 		const body = {
 			contents: [{ role: "user", parts: [{ text: query }] }],
-			tools: [{ google_search: {} }],
+			tools: [{ googlesearch: {} }],
 		};
 
 		const res = await fetchGeminiApi(`${getVersionedApiBase()}/models/${model}:generateContent`, {


### PR DESCRIPTION
now compatible with gemini AND gemma-4-31b-it, gemma-4-26b-a4b-it