### PR TITLE
Fix Google Gemini API HTTP 400 error caused by unsupported uniqueItems schema keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Removed the unsupported JSON Schema `uniqueItems` keyword from provider-array tool schemas so Gemini-compatible tool validators can register pi-web-access tools. Thanks `@akmaldira` for PR #191.
+
 ## [0.17.0] - 2026-07-30
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -204,7 +204,7 @@ const MAX_CURATOR_TIMEOUT_SECONDS = 600;
 function searchProviderSchema(description: string) {
 	return Type.Union([
 		StringEnum([...SEARCH_PROVIDERS]),
-		Type.Array(StringEnum([...RESOLVED_SEARCH_PROVIDERS]), { minItems: 1, uniqueItems: true }),
+		Type.Array(StringEnum([...RESOLVED_SEARCH_PROVIDERS]), { minItems: 1 }),
 	], { description });
 }
 


### PR DESCRIPTION
🚀 Summary

 Fixes an issue where registering pi-web-access causes pi agent sessions using Google Gemini models (e.g. via Antigravity / 9router / Google Vertex) to fail
 immediately with an HTTP 400 Bad Request (INVALID_ARGUMENT) on every message turn.

 🐛 Problem Statement

 Google Gemini API validates tool function_declarations against strict Protobuf definitions. The standard JSON Schema keyword "uniqueItems" is not supported by
 Google's API schema parser for array properties.

 When pi-web-access registered searchProviderSchema for web_search and source_check tools:

 ```ts
   Type.Array(StringEnum([...RESOLVED_SEARCH_PROVIDERS]), { minItems: 1, uniqueItems: true })
 ```

 TypeBox compiled this into "uniqueItems": true under the provider tool property. As pi agent includes all registered tool specifications in every request payload to
 the model endpoint, Google Gemini rejected the payload with:

 ```text
   HTTP 400 Bad Request
   "Invalid JSON payload received. Unknown name \"uniqueItems\" at 'request.tools[0].function_declarations[36].parameters.properties[6].value': Cannot find field."
 ```

 🛠️ Changes

 - Removed { uniqueItems: true } from searchProviderSchema in index.ts.
 - Retained { minItems: 1 } for schema validation.
 - Array deduplication is already handled safely at runtime via resolveRequestedProvider.