### PR TITLE
fix: prevent GitHub clones from capturing terminal input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- GitHub clone subprocesses now disable interactive credential prompts and terminate their process trees on timeout or cancellation, preventing orphaned Git helpers from capturing terminal input.
+
 ## [0.17.1] - 2026-07-31
 
 ### Fixed

--- a/github-extract.ts
+++ b/github-extract.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, rmSync, statSync, readdirSync, openSync, readSync, closeSync, realpathSync } from "node:fs";
-import { execFile } from "node:child_process";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { extname, join, resolve as resolvePath, sep as pathSep } from "node:path";
 import { activityMonitor } from "./activity.ts";
 import type { ExtractedContent } from "./extract.ts";
@@ -186,10 +186,45 @@ function cloneDir(config: GitHubCloneConfig, owner: string, repo: string, ref?: 
 	return join(config.clonePath, owner, dirName);
 }
 
+function terminateProcessTree(child: ChildProcess): void {
+	const pid = child.pid;
+	if (!pid) return;
+
+	if (process.platform === "win32") {
+		const killer = execFile(
+			"taskkill",
+			["/pid", String(pid), "/T", "/F"],
+			{ windowsHide: true },
+			(err) => {
+				if (err) child.kill();
+			},
+		);
+		killer.unref();
+		return;
+	}
+
+	try {
+		// Clone commands run in their own process group so git/gh helpers cannot
+		// survive a timeout or cancellation and keep reading from the host TTY.
+		process.kill(-pid, "SIGTERM");
+	} catch {
+		child.kill();
+	}
+}
+
 function execClone(args: string[], localPath: string, timeoutMs: number, signal?: AbortSignal): Promise<string | null> {
 	return new Promise((resolve) => {
-		const child = execFile(args[0], args.slice(1), { timeout: timeoutMs }, (err) => {
-			if (err) {
+		let settled = false;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		let onAbort: (() => void) | undefined;
+
+		const finish = (success: boolean) => {
+			if (settled) return;
+			settled = true;
+			if (timeout) clearTimeout(timeout);
+			if (signal && onAbort) signal.removeEventListener("abort", onAbort);
+
+			if (!success) {
 				try {
 					rmSync(localPath, { recursive: true, force: true });
 				} catch {
@@ -198,12 +233,33 @@ function execClone(args: string[], localPath: string, timeoutMs: number, signal?
 				return;
 			}
 			resolve(localPath);
+		};
+
+		const child = spawn(args[0], args.slice(1), {
+			detached: process.platform !== "win32",
+			env: {
+				...process.env,
+				GIT_TERMINAL_PROMPT: "0",
+				GCM_INTERACTIVE: "Never",
+				GH_PROMPT_DISABLED: "1",
+			},
+			stdio: "ignore",
+			windowsHide: true,
 		});
 
+		child.once("error", () => finish(false));
+		child.once("close", (code) => finish(code === 0));
+
+		timeout = setTimeout(() => terminateProcessTree(child), timeoutMs);
+		timeout.unref();
+
 		if (signal) {
-			const onAbort = () => child.kill();
-			signal.addEventListener("abort", onAbort, { once: true });
-			child.on("exit", () => signal.removeEventListener("abort", onAbort));
+			onAbort = () => {
+				if (timeout) clearTimeout(timeout);
+				terminateProcessTree(child);
+			};
+			if (signal.aborted) onAbort();
+			else signal.addEventListener("abort", onAbort, { once: true });
 		}
 	});
 }

--- a/github-extract.ts
+++ b/github-extract.ts
@@ -186,6 +186,8 @@ function cloneDir(config: GitHubCloneConfig, owner: string, repo: string, ref?: 
 	return join(config.clonePath, owner, dirName);
 }
 
+const PROCESS_KILL_GRACE_MS = 3000;
+
 function terminateProcessTree(child: ChildProcess): void {
 	const pid = child.pid;
 	if (!pid) return;
@@ -210,6 +212,17 @@ function terminateProcessTree(child: ChildProcess): void {
 	} catch {
 		child.kill();
 	}
+
+	// A credential helper may handle or ignore SIGTERM. Escalate against the
+	// entire process group so neither git nor any descendant can block forever.
+	const forceKill = setTimeout(() => {
+		try {
+			process.kill(-pid, "SIGKILL");
+		} catch {
+			child.kill("SIGKILL");
+		}
+	}, PROCESS_KILL_GRACE_MS);
+	forceKill.unref();
 }
 
 function execClone(args: string[], localPath: string, timeoutMs: number, signal?: AbortSignal): Promise<string | null> {

--- a/test/github-extract.test.mjs
+++ b/test/github-extract.test.mjs
@@ -180,16 +180,16 @@ test("GitHub clones disable interactive credential prompts", { skip: process.pla
 	});
 });
 
-test("GitHub clone timeout terminates descendant processes", { skip: process.platform === "win32" }, async () => {
+test("GitHub clone timeout force-kills the SIGTERM-resistant process group", { skip: process.platform === "win32" }, async () => {
 	const root = await mkdtemp(join(tmpdir(), "pi-web-access-github-timeout-tree-"));
 	const agentDir = join(root, "agent-dir");
 	const binDir = join(root, "bin");
-	const helperPidFile = join(root, "helper.pid");
+	const processPidFile = join(root, "processes.json");
 	await mkdir(agentDir, { recursive: true });
 	await mkdir(binDir, { recursive: true });
 	await writeFile(
 		join(agentDir, "web-search.json"),
-		JSON.stringify({ githubClone: { clonePath: join(root, "repos"), cloneTimeoutSeconds: 0.1 } }),
+		JSON.stringify({ githubClone: { clonePath: join(root, "repos"), cloneTimeoutSeconds: 0.5 } }),
 		"utf8",
 	);
 	await writeFakeExecutable(binDir, "gh", "process.exit(1);");
@@ -198,9 +198,17 @@ test("GitHub clone timeout terminates descendant processes", { skip: process.pla
 		"git",
 		`
 			const { spawn } = require("node:child_process");
-			const { writeFileSync } = require("node:fs");
-			const helper = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
-			writeFileSync(process.env.CLONE_HELPER_PID_FILE, String(helper.pid));
+			process.on("SIGTERM", () => {});
+			const helperSource = ${JSON.stringify(`
+				const { writeFileSync } = require("node:fs");
+				process.on("SIGTERM", () => {});
+				writeFileSync(process.env.CLONE_PROCESS_PID_FILE, JSON.stringify({
+					rootPid: process.ppid,
+					helperPid: process.pid,
+				}));
+				setInterval(() => {}, 1000);
+			`)};
+			spawn(process.execPath, ["-e", helperSource], { stdio: "ignore" });
 			setInterval(() => {}, 1000);
 		`,
 	);
@@ -212,10 +220,10 @@ test("GitHub clone timeout terminates descendant processes", { skip: process.pla
 			console.log(JSON.stringify(result));
 		`,
 		encoding: "utf8",
-		timeout: 5000,
+		timeout: 10000,
 		env: {
 			...process.env,
-			CLONE_HELPER_PID_FILE: helperPidFile,
+			CLONE_PROCESS_PID_FILE: processPidFile,
 			PATH: `${binDir}${delimiter}${process.env.PATH || ""}`,
 			PI_CODING_AGENT_DIR: agentDir,
 		},
@@ -223,10 +231,12 @@ test("GitHub clone timeout terminates descendant processes", { skip: process.pla
 
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(JSON.parse(child.stdout), null);
-	const helperPid = Number.parseInt(await readFile(helperPidFile, "utf8"), 10);
+	const { rootPid, helperPid } = JSON.parse(await readFile(processPidFile, "utf8"));
 	try {
-		assert.equal(await waitForProcessExit(helperPid), true, `clone helper ${helperPid} survived timeout`);
+		assert.equal(await waitForProcessExit(rootPid), true, `clone process ${rootPid} survived SIGKILL fallback`);
+		assert.equal(await waitForProcessExit(helperPid), true, `clone helper ${helperPid} survived SIGKILL fallback`);
 	} finally {
+		if (processIsAlive(rootPid)) process.kill(rootPid, "SIGKILL");
 		if (processIsAlive(helperPid)) process.kill(helperPid, "SIGKILL");
 	}
 });

--- a/test/github-extract.test.mjs
+++ b/test/github-extract.test.mjs
@@ -1,11 +1,44 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { test } from "node:test";
 
 const extractModuleUrl = new URL("../github-extract.ts", import.meta.url).href;
+
+async function writeFakeExecutable(binDir, name, source) {
+	const executable = join(binDir, name);
+	await writeFile(executable, `#!/usr/bin/env node\n${source}\n`, { mode: 0o755 });
+	return executable;
+}
+
+function processIsAlive(pid) {
+	try {
+		process.kill(pid, 0);
+		try {
+			// Container PID 1 may reap orphaned descendants slowly. A zombie is
+			// already terminated and can no longer hold or read from a terminal.
+			const state = readFileSync(`/proc/${pid}/stat`, "utf8").replace(/^.*\) /, "").split(" ")[0];
+			if (state === "Z") return false;
+		} catch {
+			// Non-Linux platforms do not expose /proc; kill(0) remains the check.
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForProcessExit(pid, timeoutMs = 2000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!processIsAlive(pid)) return true;
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	return !processIsAlive(pid);
+}
 
 test("normalizeClonePath expands ~ to HOME", async () => {
 	const root = await mkdtemp(join(tmpdir(), "pi-web-access-github-expand-"));
@@ -89,6 +122,113 @@ test("normalizeClonePath handles absolute paths without expansion", async () => 
 	});
 
 	assert.equal(child.status, 0, child.stderr);
+});
+
+test("GitHub clones disable interactive credential prompts", { skip: process.platform === "win32" }, async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-github-noninteractive-"));
+	const agentDir = join(root, "agent-dir");
+	const binDir = join(root, "bin");
+	const clonePath = join(root, "repos");
+	const envFile = join(root, "clone-env.json");
+	await mkdir(agentDir, { recursive: true });
+	await mkdir(binDir, { recursive: true });
+	await writeFile(
+		join(agentDir, "web-search.json"),
+		JSON.stringify({ githubClone: { clonePath, cloneTimeoutSeconds: 1 } }),
+		"utf8",
+	);
+	await writeFakeExecutable(binDir, "gh", "process.exit(1);");
+	await writeFakeExecutable(
+		binDir,
+		"git",
+		`
+			const { mkdirSync, writeFileSync } = require("node:fs");
+			const { join } = require("node:path");
+			const destination = process.argv.at(-1);
+			mkdirSync(destination, { recursive: true });
+			writeFileSync(join(destination, "README.md"), "fixture");
+			writeFileSync(process.env.CLONE_ENV_FILE, JSON.stringify({
+				gitTerminalPrompt: process.env.GIT_TERMINAL_PROMPT,
+				gcmInteractive: process.env.GCM_INTERACTIVE,
+				ghPromptDisabled: process.env.GH_PROMPT_DISABLED,
+			}));
+		`,
+	);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/test/repo");
+			console.log(JSON.stringify(result !== null));
+		`,
+		encoding: "utf8",
+		timeout: 5000,
+		env: {
+			...process.env,
+			CLONE_ENV_FILE: envFile,
+			PATH: `${binDir}${delimiter}${process.env.PATH || ""}`,
+			PI_CODING_AGENT_DIR: agentDir,
+		},
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(JSON.parse(child.stdout), true);
+	assert.deepEqual(JSON.parse(await readFile(envFile, "utf8")), {
+		gitTerminalPrompt: "0",
+		gcmInteractive: "Never",
+		ghPromptDisabled: "1",
+	});
+});
+
+test("GitHub clone timeout terminates descendant processes", { skip: process.platform === "win32" }, async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-github-timeout-tree-"));
+	const agentDir = join(root, "agent-dir");
+	const binDir = join(root, "bin");
+	const helperPidFile = join(root, "helper.pid");
+	await mkdir(agentDir, { recursive: true });
+	await mkdir(binDir, { recursive: true });
+	await writeFile(
+		join(agentDir, "web-search.json"),
+		JSON.stringify({ githubClone: { clonePath: join(root, "repos"), cloneTimeoutSeconds: 0.1 } }),
+		"utf8",
+	);
+	await writeFakeExecutable(binDir, "gh", "process.exit(1);");
+	await writeFakeExecutable(
+		binDir,
+		"git",
+		`
+			const { spawn } = require("node:child_process");
+			const { writeFileSync } = require("node:fs");
+			const helper = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+			writeFileSync(process.env.CLONE_HELPER_PID_FILE, String(helper.pid));
+			setInterval(() => {}, 1000);
+		`,
+	);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/test/repo");
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		timeout: 5000,
+		env: {
+			...process.env,
+			CLONE_HELPER_PID_FILE: helperPidFile,
+			PATH: `${binDir}${delimiter}${process.env.PATH || ""}`,
+			PI_CODING_AGENT_DIR: agentDir,
+		},
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(JSON.parse(child.stdout), null);
+	const helperPid = Number.parseInt(await readFile(helperPidFile, "utf8"), 10);
+	try {
+		assert.equal(await waitForProcessExit(helperPid), true, `clone helper ${helperPid} survived timeout`);
+	} finally {
+		if (processIsAlive(helperPid)) process.kill(helperPid, "SIGKILL");
+	}
 });
 
 test("githubClone.enabled false skips GitHub clone/API specialization", async () => {


### PR DESCRIPTION
## Summary

- run GitHub clone commands without interactive Git, Git Credential Manager, or GitHub CLI prompts
- isolate clone commands in a POSIX process group and terminate the full process tree on timeout or cancellation (with `taskkill /T` on Windows)
- add regression coverage for non-interactive clone environments and descendant cleanup

## Problem

When `fetch_content` receives a missing, moved, or inaccessible GitHub repository URL, Git can open a credential prompt directly on `/dev/tty`. The prompt is hidden behind Pi's TUI and captures editor input and shortcuts.

The existing `execFile(..., { timeout })` only terminates the direct `git clone` process. Its `git remote-https` / `git-remote-https` descendants can survive, remain attached to the foreground terminal, and keep consuming input after the fetch has already fallen back or returned.

This change uses `spawn` so POSIX clones can run in their own process group, disables interactive credential paths, and terminates the complete clone process tree on timeout or abort.

## Verification

- `node --test test/github-extract.test.mjs` — 6/6 passed
- `npm run typecheck` — passed
- `npm run audit:runtime` — passed
- live missing/moved-repository reproduction returned in 324 ms with no new orphaned Git helper
- full `npm test` — 271/272 passed; the unrelated `failed password lookups are retried instead of cached` Chrome-cookie test fails in this Linux environment

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes orphaned Git helper processes capturing terminal input when a clone times out or the repository is inaccessible. It replaces `execFile` (which only killed the direct child) with `spawn` plus an explicit process-group shutdown: SIGTERM to `-pid` followed by SIGKILL after a 3-second grace period on POSIX, and `taskkill /T /F` on Windows. Three environment variables (`GIT_TERMINAL_PROMPT`, `GCM_INTERACTIVE`, `GH_PROMPT_DISABLED`) suppress interactive credential prompts before the clone even starts.

- **`github-extract.ts`** — New `terminateProcessTree` helper and a fully refactored `execClone` that uses `spawn` with `detached: true` (POSIX) for process-group isolation, manual timeout/abort signal plumbing with a `settled` guard, and SIGTERM→SIGKILL escalation.
- **`test/github-extract.test.mjs`** — Two new regression tests: one verifying the non-interactive env vars reach the child process, and one verifying a SIGTERM-resistant helper is force-killed via SIGKILL escalation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is well-scoped, the new process-group shutdown logic is correct, and the regression tests cover both the non-interactive env-var path and the SIGTERM-resistant process-tree kill.

The refactor from execFile to spawn with explicit SIGTERM→SIGKILL escalation handles all the edge cases correctly: the settled guard prevents double-resolution, the abort/timeout paths are mutually exclusive (onAbort clears the timeout), and unref'd timers won't block the event loop. No logic errors or data-loss paths were found in the changed code.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| github-extract.ts | Core change: replaces execFile with spawn, adds terminateProcessTree with SIGTERM→SIGKILL escalation and Windows taskkill /T /F, suppresses terminal prompts via env vars. Logic is sound — settled guard prevents double resolution, abort/timeout coordination is correct, and forceKill timers are unref'd to avoid blocking the event loop. |
| test/github-extract.test.mjs | Two new regression tests: one checks non-interactive env vars are propagated to the clone subprocess; the other verifies that a SIGTERM-resistant process group (parent + helper both ignoring SIGTERM) is ultimately force-killed via SIGKILL. waitForProcessExit polling and /proc/stat zombie detection are well-handled. |
| CHANGELOG.md | Adds a concise entry under [Unreleased] describing the fix. No issues. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: force-kill stalled clone process gr..."](https://github.com/nicobailon/pi-web-access/commit/6b35ea0d000e0a7d7a9668d10cb6c7ae595a8abc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49333266)</sub>

<!-- /greptile_comment -->