### PR TITLE
feat: support custom headers for SearXNG requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added optional `searxngHeaders` so self-hosted SearXNG requests can carry reverse-proxy or Zero Trust auth headers (for example Cloudflare Access service tokens).
+
 ## [0.17.1] - 2026-07-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -286,6 +286,10 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "serpdiveApiKey": "sd_live_...",
   "serpdiveModel": "krill",
   "searxngBaseUrl": "https://search.example.com",
+  "searxngHeaders": {
+    "CF-Access-Client-Id": "xxxxxxxx.access",
+    "CF-Access-Client-Secret": "xxxxxxxx"
+  },
   "firecrawlBaseUrl": "https://crawl.example.com",
   "firecrawlApiKey": "fc-...",
   "firecrawlApiVersion": "v2",
@@ -365,7 +369,7 @@ A command source is not run while the extension loads or registers tools. Each s
 
 `fetchContent.domainPolicy` is an optional hostname allow/deny policy for `fetch_content` target URLs. It is off when omitted. Each bare hostname matches itself and its subdomains; `deny` wins when a hostname matches both lists. The policy is checked before HTTP(S) target handling and before each redirect followed by this extension's own fetch path. Local file paths and non-HTTP sources are not subject to this policy. It is an additional restriction: the existing SSRF guard still blocks private and internal destinations. Remote extraction services can still perform their own DNS, redirects, and egress after this extension preflights the submitted target URL, so keep their deployments separately isolated.
 
-Set `searxngBaseUrl` or `SEARXNG_BASE_URL` to use a self-hosted SearXNG JSON API. A configured endpoint is preferred first in `auto` mode for local/private search. Its base URL and redirects remain subject to the SSRF guard; add only the narrowest self-hosted range to `ssrf.allowRanges` when it resolves to a private or synthetic range. Thanks to Marcos A. Núñez (@marnunez) for PR #107 and Avinash Kanaujiya (@avinashkanaujiya) for issue #105.
+Set `searxngBaseUrl` or `SEARXNG_BASE_URL` to use a self-hosted SearXNG JSON API. A configured endpoint is preferred first in `auto` mode for local/private search. Its base URL and redirects remain subject to the SSRF guard; add only the narrowest self-hosted range to `ssrf.allowRanges` when it resolves to a private or synthetic range. Optional `searxngHeaders` merges extra HTTP headers into each SearXNG request (string values only; invalid header names are ignored), which is useful for reverse-proxy or Zero Trust auth such as Cloudflare Access service tokens (`CF-Access-Client-Id` / `CF-Access-Client-Secret`). Configured headers override the default `Accept: application/json` when the same name is supplied. Thanks to Marcos A. Núñez (@marnunez) for PR #107 and Avinash Kanaujiya (@avinashkanaujiya) for issue #105.
 
 Set `firecrawlBaseUrl` or `FIRECRAWL_BASE_URL` to use Firecrawl as an extraction-only fallback for `fetch_content`. It calls `/v2/scrape` by default; set `firecrawlApiVersion` or `FIRECRAWL_API_VERSION` to `v1` for older self-hosted images. Firecrawl requests are cache-only by default (`lockdown: true`), so the Firecrawl server does not make fresh outbound target requests unless you explicitly set `firecrawlFreshScrape: true` or `FIRECRAWL_FRESH_SCRAPE=1`. Enable fresh scraping only for a Firecrawl deployment whose own egress, redirects, DNS rebinding behavior, and internal-network access are isolated or allowlisted; this extension can preflight the submitted URL but cannot control network requests made by the Firecrawl server. The configured Firecrawl API base URL and redirects are still validated by the same SSRF guard as other remote requests, and Firecrawl credentials are stripped from cross-origin API redirects.
 

--- a/searxng.ts
+++ b/searxng.ts
@@ -9,6 +9,7 @@ const SEARCH_TIMEOUT_MS = 30_000;
 
 interface WebSearchConfig {
 	searxngBaseUrl?: unknown;
+	searxngHeaders?: unknown;
 }
 
 interface NormalizedDomainFilters {
@@ -68,6 +69,23 @@ function getBaseUrl(): string | null {
 	return configured !== undefined
 		? normalizeBaseUrl(configured)
 		: normalizeBaseUrl(loadConfig().searxngBaseUrl);
+}
+
+function normalizeHeaders(value: unknown): Record<string, string> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+	const headers: Record<string, string> = {};
+	for (const [key, headerValue] of Object.entries(value as Record<string, unknown>)) {
+		if (typeof headerValue !== "string") continue;
+		const name = key.trim();
+		// RFC 7230 token chars only — reject empty or malformed header names.
+		if (!name || !/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(name)) continue;
+		headers[name] = headerValue;
+	}
+	return headers;
+}
+
+function getConfiguredHeaders(): Record<string, string> {
+	return normalizeHeaders(loadConfig().searxngHeaders);
 }
 
 function requireBaseUrl(): string {
@@ -168,7 +186,7 @@ export async function searchWithSearXNG(query: string, options: SearchOptions = 
 	try {
 		const response = await fetchRemoteUrl(url, {
 			method: "GET",
-			headers: { Accept: "application/json" },
+			headers: { Accept: "application/json", ...getConfiguredHeaders() },
 			signal: options.signal
 				? AbortSignal.any([AbortSignal.timeout(SEARCH_TIMEOUT_MS), options.signal])
 				: AbortSignal.timeout(SEARCH_TIMEOUT_MS),

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -202,6 +202,45 @@ test("SearXNG search is SSRF-guarded and preferred first when configured", async
 	assert.equal(output.auto.provider, "searxng");
 });
 
+test("SearXNG search merges configured custom headers", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-searxng-headers-"));
+	const child = runChild(`
+		const { writeFileSync } = await import("node:fs");
+		writeFileSync(${JSON.stringify(home)} + "/web-search.json", JSON.stringify({
+			searxngBaseUrl: "http://127.0.0.1:8443/",
+			searxngHeaders: {
+				"CF-Access-Client-Id": "client-id.access",
+				"CF-Access-Client-Secret": "client-secret",
+				"X-Empty-Skip": 123,
+				"Bad Name": "nope",
+			},
+			ssrf: { allowRanges: ["127.0.0.1"] },
+		}));
+		let capturedHeaders = null;
+		globalThis.fetch = async (_url, init = {}) => {
+			capturedHeaders = init.headers ?? null;
+			return new Response(JSON.stringify({
+				results: [{ title: "Allowed", url: "https://docs.example.com/a", content: "allowed" }],
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+		const { searchWithSearXNG } = await import(${JSON.stringify(searxngModuleUrl)});
+		await searchWithSearXNG("headers");
+		console.log(JSON.stringify({ capturedHeaders }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.capturedHeaders, {
+		Accept: "application/json",
+		"CF-Access-Client-Id": "client-id.access",
+		"CF-Access-Client-Secret": "client-secret",
+	});
+});
+
 test("SearXNG redirect validation rejects an unapproved private target", async () => {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-searxng-redirect-"));
 	const child = runChild(`


### PR DESCRIPTION
## Summary
- Add optional `searxngHeaders` config so self-hosted SearXNG requests can include reverse-proxy / Zero Trust auth headers (e.g. Cloudflare Access `CF-Access-Client-Id` / `CF-Access-Client-Secret`).
- Merge validated string headers into the existing SearXNG `fetch` call while keeping the default `Accept: application/json`.
- Document the option and cover it with a provider test.

Self-hosted SearXNG deployments protected by Cloudflare Access Service Auth cannot authenticate today because `searchWithSearXNG()` hardcodes headers and `normalizeBaseUrl()` strips query strings / basic-auth credentials. Header support is the minimal fix that keeps SSRF guards intact.

## Config example
```json
{
  "searxngBaseUrl": "https://search.example.com",
  "searxngHeaders": {
    "CF-Access-Client-Id": "xxxxxxxx.access",
    "CF-Access-Client-Secret": "xxxxxxxx"
  }
}
```

## Test plan
- [x] `node --test test/search-providers.test.mjs` (21 passed, including new `SearXNG search merges configured custom headers`)
- [ ] Configure a Zero Trust-protected SearXNG endpoint with service-token headers and confirm `provider: "searxng"` succeeds
- [ ] Confirm invalid header names / non-string values are ignored and do not break search