### PR TITLE
fix: render fetch url when urls is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Long `fetch_content` results are easier to continue reading. The first response now stops on cleaner line boundaries and tells you the character, byte, and line totals plus the exact offset to request next.
 
+### Fixed
+- Fixed the `fetch_content` call header showing `fetch (no URL)` when Pi supplied `url` together with an empty `urls` array. Thanks `@Vergil824` for issue #192.
+
 ## [0.17.1] - 2026-07-31
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -2355,8 +2355,8 @@ export default function (pi: ExtensionAPI) {
 		},
 
 		renderCall(args, theme) {
-			const { url, urls, prompt, timestamp, frames, model, mode, answerModel } = args as { url?: string; urls?: string[]; prompt?: string; timestamp?: string; frames?: number; model?: string; mode?: "readable" | "raw" | "answer"; answerModel?: string };
-			const urlList = urls ?? (url ? [url] : []);
+			const { urlList, options } = normalizeFetchContentParams(args);
+			const { prompt, timestamp, frames, model, mode, answerModel } = options;
 			if (urlList.length === 0) {
 				return new Text(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("error", "(no URL)"), 0, 0);
 			}

--- a/test/fetch-render-call.test.mjs
+++ b/test/fetch-render-call.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import initializeExtension from "../index.ts";
+
+function getFetchTool() {
+	const tools = [];
+	initializeExtension({
+		registerTool(tool) { tools.push(tool); },
+		registerCommand() {},
+		registerShortcut() {},
+		on() {},
+		appendEntry() {},
+	});
+	return tools.find(tool => tool.name === "fetch_content");
+}
+
+const theme = {
+	bold: text => text,
+	fg: (_name, text) => text,
+};
+
+test("fetch_content renderCall falls back to url when urls is empty", () => {
+	const tool = getFetchTool();
+	const lines = tool.renderCall({
+		url: "https://example.com/docs",
+		urls: [],
+		frames: 1,
+		prompt: "",
+		model: "",
+	}, theme).render(120).map(line => line.trimEnd());
+
+	assert.deepEqual(lines, ["fetch https://example.com/docs"]);
+});


### PR DESCRIPTION
This fixes a display bug in the `fetch_content` tool call header. When Pi sends a singular `url` plus an empty `urls` array, the fetch already works, but the header could show `fetch (no URL)`.

The renderer now uses the same parameter normalization as execution, so it shows the actual URL and also hides bridge-filled defaults like `frames: 1` for normal page fetches.

Fixes #192.

Thanks `@Vergil824` for the detailed report.

Validation:

- `node --test test/fetch-render-call.test.mjs test/fetch-params.test.mjs`
- `npm run typecheck`
- `npm test` (279 tests)
- fresh read-only review found no blockers.