### PR TITLE
fix: support safe custom SearXNG headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - `fetch_content` can now answer a question about a single fetched page with `mode: "answer"`, while still saving the original page text so you can inspect it later.
 - Direct image links now work for PNG, JPEG, WebP, and GIF files. The tool downloads them safely, resizes large images, and returns an inline image result.
 - `get_search_content` now accepts `findText` and `findMode`, so you can search saved content for the passage you need instead of paging through a long page by hand. Inspired by `@xl0`'s `pi-lovely-web` project.
+- Added optional `searxngHeaders` so self-hosted SearXNG requests can carry reverse-proxy or Zero Trust auth headers. Thanks `@preinpost` for PR #202.
 
 ### Changed
 - Long `fetch_content` results are easier to continue reading. The first response now stops on cleaner line boundaries and tells you the character, byte, and line totals plus the exact offset to request next.

--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "serpdiveApiKey": "sd_live_...",
   "serpdiveModel": "krill",
   "searxngBaseUrl": "https://search.example.com",
+  "searxngHeaders": {
+    "CF-Access-Client-Id": "xxxxxxxx.access",
+    "CF-Access-Client-Secret": "xxxxxxxx"
+  },
   "firecrawlBaseUrl": "https://crawl.example.com",
   "firecrawlApiKey": "fc-...",
   "firecrawlApiVersion": "v2",
@@ -376,7 +380,7 @@ A command source is not run while the extension loads or registers tools. Each s
 
 `fetchContent.domainPolicy` is an optional hostname allow/deny policy for `fetch_content` target URLs. It is off when omitted. Each bare hostname matches itself and its subdomains; `deny` wins when a hostname matches both lists. The policy is checked before HTTP(S) target handling and before each redirect followed by this extension's own fetch path. Local file paths and non-HTTP sources are not subject to this policy. It is an additional restriction: the existing SSRF guard still blocks private and internal destinations. Remote extraction services can still perform their own DNS, redirects, and egress after this extension preflights the submitted target URL, so keep their deployments separately isolated.
 
-Set `searxngBaseUrl` or `SEARXNG_BASE_URL` to use a self-hosted SearXNG JSON API. A configured endpoint is preferred first in `auto` mode for local/private search. Its base URL and redirects remain subject to the SSRF guard; add only the narrowest self-hosted range to `ssrf.allowRanges` when it resolves to a private or synthetic range. Thanks to Marcos A. Núñez (@marnunez) for PR #107 and Avinash Kanaujiya (@avinashkanaujiya) for issue #105.
+Set `searxngBaseUrl` or `SEARXNG_BASE_URL` to use a self-hosted SearXNG JSON API. A configured endpoint is preferred first in `auto` mode for local/private search. Its base URL and redirects remain subject to the SSRF guard; add only the narrowest self-hosted range to `ssrf.allowRanges` when it resolves to a private or synthetic range. Optional `searxngHeaders` merges extra HTTP headers into each SearXNG request (string values only; invalid header names are ignored), which is useful for reverse-proxy or Zero Trust auth such as Cloudflare Access service tokens (`CF-Access-Client-Id` / `CF-Access-Client-Secret`). Configured headers override the default `Accept: application/json` when the same name is supplied. Thanks to Marcos A. Núñez (@marnunez) for PR #107 and Avinash Kanaujiya (@avinashkanaujiya) for issue #105.
 
 Set `firecrawlBaseUrl` or `FIRECRAWL_BASE_URL` to use Firecrawl as an extraction-only fallback for `fetch_content`. It calls `/v2/scrape` by default; set `firecrawlApiVersion` or `FIRECRAWL_API_VERSION` to `v1` for older self-hosted images. Firecrawl requests are cache-only by default (`lockdown: true`), so the Firecrawl server does not make fresh outbound target requests unless you explicitly set `firecrawlFreshScrape: true` or `FIRECRAWL_FRESH_SCRAPE=1`. Enable fresh scraping only for a Firecrawl deployment whose own egress, redirects, DNS rebinding behavior, and internal-network access are isolated or allowlisted; this extension can preflight the submitted URL but cannot control network requests made by the Firecrawl server. The configured Firecrawl API base URL and redirects are still validated by the same SSRF guard as other remote requests, and Firecrawl credentials are stripped from cross-origin API redirects.
 

--- a/searxng.ts
+++ b/searxng.ts
@@ -9,6 +9,7 @@ const SEARCH_TIMEOUT_MS = 30_000;
 
 interface WebSearchConfig {
 	searxngBaseUrl?: unknown;
+	searxngHeaders?: unknown;
 }
 
 interface NormalizedDomainFilters {
@@ -68,6 +69,23 @@ function getBaseUrl(): string | null {
 	return configured !== undefined
 		? normalizeBaseUrl(configured)
 		: normalizeBaseUrl(loadConfig().searxngBaseUrl);
+}
+
+function normalizeHeaders(value: unknown): Record<string, string> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+	const headers: Record<string, string> = {};
+	for (const [key, headerValue] of Object.entries(value as Record<string, unknown>)) {
+		if (typeof headerValue !== "string") continue;
+		const name = key.trim();
+		// RFC 7230 token chars only — reject empty or malformed header names.
+		if (!name || !/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(name)) continue;
+		headers[name] = headerValue;
+	}
+	return headers;
+}
+
+function getConfiguredHeaders(): Record<string, string> {
+	return normalizeHeaders(loadConfig().searxngHeaders);
 }
 
 function requireBaseUrl(): string {
@@ -168,7 +186,7 @@ export async function searchWithSearXNG(query: string, options: SearchOptions = 
 	try {
 		const response = await fetchRemoteUrl(url, {
 			method: "GET",
-			headers: { Accept: "application/json" },
+			headers: { Accept: "application/json", ...getConfiguredHeaders() },
 			signal: options.signal
 				? AbortSignal.any([AbortSignal.timeout(SEARCH_TIMEOUT_MS), options.signal])
 				: AbortSignal.timeout(SEARCH_TIMEOUT_MS),

--- a/searxng.ts
+++ b/searxng.ts
@@ -71,6 +71,15 @@ function getBaseUrl(): string | null {
 		: normalizeBaseUrl(loadConfig().searxngBaseUrl);
 }
 
+function isValidHeaderValue(value: string): boolean {
+	try {
+		new Headers({ "x-pi-web-access-validation": value });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function normalizeHeaders(value: unknown): Record<string, string> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
 	const headers: Record<string, string> = {};
@@ -79,6 +88,7 @@ function normalizeHeaders(value: unknown): Record<string, string> {
 		const name = key.trim();
 		// RFC 7230 token chars only — reject empty or malformed header names.
 		if (!name || !/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(name)) continue;
+		if (!isValidHeaderValue(headerValue)) continue;
 		headers[name] = headerValue;
 	}
 	return headers;
@@ -86,6 +96,17 @@ function normalizeHeaders(value: unknown): Record<string, string> {
 
 function getConfiguredHeaders(): Record<string, string> {
 	return normalizeHeaders(loadConfig().searxngHeaders);
+}
+
+function mergeDefaultHeaders(configured: Record<string, string>): Record<string, string> {
+	const headers: Record<string, string> = { Accept: "application/json" };
+	for (const [name, value] of Object.entries(configured)) {
+		for (const existing of Object.keys(headers)) {
+			if (existing.toLowerCase() === name.toLowerCase()) delete headers[existing];
+		}
+		headers[name] = value;
+	}
+	return headers;
 }
 
 function requireBaseUrl(): string {
@@ -184,13 +205,17 @@ export async function searchWithSearXNG(query: string, options: SearchOptions = 
 	const activityId = activityMonitor.logStart({ type: "api", query: searchQuery });
 
 	try {
+		const headers = mergeDefaultHeaders(getConfiguredHeaders());
 		const response = await fetchRemoteUrl(url, {
 			method: "GET",
-			headers: { Accept: "application/json", ...getConfiguredHeaders() },
+			headers,
 			signal: options.signal
 				? AbortSignal.any([AbortSignal.timeout(SEARCH_TIMEOUT_MS), options.signal])
 				: AbortSignal.timeout(SEARCH_TIMEOUT_MS),
-		}, loadSsrfConfig());
+		}, {
+			...loadSsrfConfig(),
+			onRedirect: ({ from, to, init }) => from.origin === to.origin ? init : { ...init, headers: { Accept: "application/json" } },
+		});
 
 		if (!response.ok) {
 			activityMonitor.logError(activityId, `HTTP ${response.status}`);

--- a/ssrf-protection.ts
+++ b/ssrf-protection.ts
@@ -160,9 +160,17 @@ interface ParsedCidr {
 	prefix: number;
 }
 
+interface RedirectRequestInitArgs {
+	from: URL;
+	to: URL;
+	init: RequestInit;
+	response: Response;
+}
+
 interface FetchRemoteOptions extends ValidationOptions {
 	fetch?: Fetch;
 	maxRedirects?: number;
+	onRedirect?: (args: RedirectRequestInitArgs) => RequestInit;
 }
 
 async function defaultLookup(hostname: string): Promise<LookupAddress[]> {
@@ -224,11 +232,13 @@ export async function fetchRemoteUrl(
 		if (!location) return response;
 		if (redirects === maxRedirects) throw new Error(`Too many redirects fetching ${current.toString()}`);
 
+		const from = current;
 		current = await validateRemoteUrl(new URL(location, current), options);
 		if (response.status === 303 || ((response.status === 301 || response.status === 302) && requestInit.method?.toUpperCase() === "POST")) {
 			const { body: _body, ...nextInit } = requestInit;
 			requestInit = { ...nextInit, method: "GET" };
 		}
+		if (options.onRedirect) requestInit = options.onRedirect({ from, to: current, init: requestInit, response });
 	}
 
 	throw new Error(`Too many redirects fetching ${current.toString()}`);

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -202,6 +202,45 @@ test("SearXNG search is SSRF-guarded and preferred first when configured", async
 	assert.equal(output.auto.provider, "searxng");
 });
 
+test("SearXNG search merges configured custom headers", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-searxng-headers-"));
+	const child = runChild(`
+		const { writeFileSync } = await import("node:fs");
+		writeFileSync(${JSON.stringify(home)} + "/web-search.json", JSON.stringify({
+			searxngBaseUrl: "http://127.0.0.1:8443/",
+			searxngHeaders: {
+				"CF-Access-Client-Id": "client-id.access",
+				"CF-Access-Client-Secret": "client-secret",
+				"X-Empty-Skip": 123,
+				"Bad Name": "nope",
+			},
+			ssrf: { allowRanges: ["127.0.0.1"] },
+		}));
+		let capturedHeaders = null;
+		globalThis.fetch = async (_url, init = {}) => {
+			capturedHeaders = init.headers ?? null;
+			return new Response(JSON.stringify({
+				results: [{ title: "Allowed", url: "https://docs.example.com/a", content: "allowed" }],
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+		const { searchWithSearXNG } = await import(${JSON.stringify(searxngModuleUrl)});
+		await searchWithSearXNG("headers");
+		console.log(JSON.stringify({ capturedHeaders }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.capturedHeaders, {
+		Accept: "application/json",
+		"CF-Access-Client-Id": "client-id.access",
+		"CF-Access-Client-Secret": "client-secret",
+	});
+});
+
 test("SearXNG redirect validation rejects an unapproved private target", async () => {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-searxng-redirect-"));
 	const child = runChild(`

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -212,6 +212,7 @@ test("SearXNG search merges configured custom headers", async () => {
 				"CF-Access-Client-Id": "client-id.access",
 				"CF-Access-Client-Secret": "client-secret",
 				"X-Empty-Skip": 123,
+				"X-Bad-Value": "bad\\r\\nvalue",
 				"Bad Name": "nope",
 			},
 			ssrf: { allowRanges: ["127.0.0.1"] },
@@ -239,6 +240,72 @@ test("SearXNG search merges configured custom headers", async () => {
 		"CF-Access-Client-Id": "client-id.access",
 		"CF-Access-Client-Secret": "client-secret",
 	});
+
+	const overrideHome = await mkdtemp(join(tmpdir(), "pi-web-access-searxng-headers-override-"));
+	const overrideChild = runChild(`
+		const { writeFileSync } = await import("node:fs");
+		writeFileSync(${JSON.stringify(overrideHome)} + "/web-search.json", JSON.stringify({
+			searxngBaseUrl: "http://127.0.0.1:8443/",
+			searxngHeaders: { accept: "application/custom-json" },
+			ssrf: { allowRanges: ["127.0.0.1"] },
+		}));
+		let capturedHeaders = null;
+		globalThis.fetch = async (_url, init = {}) => {
+			capturedHeaders = init.headers ?? null;
+			return new Response(JSON.stringify({ results: [] }), { status: 200, headers: { "content-type": "application/json" } });
+		};
+		const { searchWithSearXNG } = await import(${JSON.stringify(searxngModuleUrl)});
+		await searchWithSearXNG("headers");
+		console.log(JSON.stringify({ capturedHeaders }));
+	`, {
+		HOME: overrideHome,
+		USERPROFILE: overrideHome,
+		PI_CODING_AGENT_DIR: overrideHome,
+	});
+
+	assert.equal(overrideChild.status, 0, overrideChild.stderr);
+	assert.deepEqual(JSON.parse(overrideChild.stdout.trim()).capturedHeaders, { accept: "application/custom-json" });
+});
+
+test("SearXNG search strips configured headers on cross-origin redirects", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-searxng-headers-redirect-"));
+	const child = runChild(`
+		const { writeFileSync } = await import("node:fs");
+		writeFileSync(${JSON.stringify(home)} + "/web-search.json", JSON.stringify({
+			searxngBaseUrl: "http://127.0.0.1:8443/",
+			searxngHeaders: {
+				"CF-Access-Client-Id": "client-id.access",
+				"CF-Access-Client-Secret": "client-secret",
+			},
+			ssrf: { allowRanges: ["127.0.0.1"] },
+		}));
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			calls.push({ url: String(url), headers: init.headers ?? null });
+			if (calls.length === 1) {
+				return new Response(null, { status: 302, headers: { location: "http://127.0.0.1:8444/search" } });
+			}
+			return new Response(JSON.stringify({
+				results: [{ title: "Allowed", url: "https://docs.example.com/a", content: "allowed" }],
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+		const { searchWithSearXNG } = await import(${JSON.stringify(searxngModuleUrl)});
+		await searchWithSearXNG("headers redirect");
+		console.log(JSON.stringify({ calls }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.calls[0].headers, {
+		Accept: "application/json",
+		"CF-Access-Client-Id": "client-id.access",
+		"CF-Access-Client-Secret": "client-secret",
+	});
+	assert.deepEqual(output.calls[1].headers, { Accept: "application/json" });
 });
 
 test("SearXNG redirect validation rejects an unapproved private target", async () => {


### PR DESCRIPTION
## Summary

This is a maintainer replacement for #202. It preserves @preinpost's custom SearXNG header support, rebased on current main, and adds the missing safety around redirects.

It adds `searxngHeaders` config for deployments behind proxies such as Cloudflare Access, validates configured header values before use, and strips those custom headers whenever a request follows a cross-origin redirect. Default `Accept` handling remains intact unless the configured headers override it case-insensitively.

## Validation

- `node --test test/search-providers.test.mjs`
- `npm run typecheck`
- `npm test`
- `git diff --check`

Supersedes #202 while preserving contributor credit in the changelog and commit authorship.