### PR TITLE
fix xai search: classify 403 quota/spending-limit errors as quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Classify xAI `403` spending-limit and quota-exhaustion responses as quota errors so configured search routing can fall back, while preserving ordinary `403` responses as authentication errors. Thanks `@0xmarcinz` for PR #212.
+
 ## [0.18.0] - 2026-08-03
 
 ### Added

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -257,7 +257,7 @@ function classifyProviderError(provider: ResolvedSearchProvider, err: unknown): 
 		kind = "credential";
 	} else if (isAbortError(err)) {
 		kind = "aborted";
-	} else if (provider === "xai" && status === 403 && /spending[- ]limit|out of credits|insufficient quota|quota exceeded/.test(lower)) {
+	} else if (provider === "xai" && status === 403 && /spending[- ]limit|(?:no|out of) credits?|insufficient quota|quota (?:exceeded|exhausted)|credits? (?:exhausted|depleted|used up)/.test(lower)) {
 		kind = "quota";
 	} else if (status === 401 || status === 403) {
 		kind = "auth";

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -257,8 +257,7 @@ function classifyProviderError(provider: ResolvedSearchProvider, err: unknown): 
 		kind = "credential";
 	} else if (isAbortError(err)) {
 		kind = "aborted";
-    } else if (/spending[- ]limit|out of credits|insufficient quota|quota (?:exceeded|exhausted|limit)|billing|no credits?|credits? (?:exhausted|used up|limit|depleted)|rate
- limit|too many requests/.test(lower)) {
+    } else if (/spending[- ]limit|out of credits|insufficient quota|quota (?:exceeded|exhausted|limit)|billing|no credits?|credits? (?:exhausted|used up|limit|depleted)|rate limit|too many requests/.test(lower)) {
        kind = "quota";
 	} else if (status === 401 || status === 403) {
 		kind = "auth";

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -257,6 +257,9 @@ function classifyProviderError(provider: ResolvedSearchProvider, err: unknown): 
 		kind = "credential";
 	} else if (isAbortError(err)) {
 		kind = "aborted";
+    } else if (/spending[- ]limit|out of credits|insufficient quota|quota (?:exceeded|exhausted|limit)|billing|no credits?|credits? (?:exhausted|used up|limit|depleted)|rate
+ limit|too many requests/.test(lower)) {
+       kind = "quota";
 	} else if (status === 401 || status === 403) {
 		kind = "auth";
 	} else if (status === 400 || status === 422) {

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -257,8 +257,8 @@ function classifyProviderError(provider: ResolvedSearchProvider, err: unknown): 
 		kind = "credential";
 	} else if (isAbortError(err)) {
 		kind = "aborted";
-    } else if (/spending[- ]limit|out of credits|insufficient quota|quota (?:exceeded|exhausted|limit)|billing|no credits?|credits? (?:exhausted|used up|limit|depleted)|rate limit|too many requests/.test(lower)) {
-       kind = "quota";
+	} else if (provider === "xai" && status === 403 && /spending[- ]limit|out of credits|insufficient quota|quota exceeded/.test(lower)) {
+		kind = "quota";
 	} else if (status === 401 || status === 403) {
 		kind = "auth";
 	} else if (status === 400 || status === 422) {

--- a/test/search-routing.test.mjs
+++ b/test/search-routing.test.mjs
@@ -121,7 +121,7 @@ test("auth status fails closed even when the response text looks like quota", as
 	assert.deepEqual(output.calls, ["https://api.search.brave.com/res/v1/web/search?q=auth+route&count=5"]);
 });
 
-test("configured routing falls back from an xAI 403 quota response", async () => {
+test("configured routing falls back from an xAI 403 quota-exhausted response", async () => {
 	const home = await createConfig({
 		searchRouting: { providers: ["xai", "tavily"], fallbackOn: ["quota"] },
 	});
@@ -129,7 +129,7 @@ test("configured routing falls back from an xAI 403 quota response", async () =>
 		const calls = [];
 		globalThis.fetch = async (url) => {
 			calls.push(String(url));
-			if (String(url) === "https://api.x.ai/v1/responses") return new Response("spending limit exceeded", { status: 403 });
+			if (String(url) === "https://api.x.ai/v1/responses") return new Response("quota exhausted", { status: 403 });
 			if (String(url) === "https://api.tavily.com/search") {
 				return new Response(JSON.stringify({ answer: "Tavily fallback answer", results: [] }), { status: 200 });
 			}

--- a/test/search-routing.test.mjs
+++ b/test/search-routing.test.mjs
@@ -15,7 +15,7 @@ async function createConfig(config) {
 
 function runChild(script, env) {
 	const childEnv = { ...process.env };
-	for (const key of ["PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME", "OPENAI_API_KEY", "BRAVE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "SEARCH1API_KEY", "SEARCHINFINITY_API_KEY", "QUERIT_API_KEY", "TAVILY_API_KEY", "SERPDIVE_API_KEY", "KAGI_API_KEY", "OLLAMA_API_KEY", "SERPBASE_API_KEY", "BRIGHTDATA_API_KEY", "BRIGHTDATA_SERP_ZONE", "SEARXNG_BASE_URL", "EXA_API_KEY", "PERPLEXITY_API_KEY", "GEMINI_API_KEY"]) {
+	for (const key of ["PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME", "OPENAI_API_KEY", "BRAVE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "SEARCH1API_KEY", "SEARCHINFINITY_API_KEY", "QUERIT_API_KEY", "TAVILY_API_KEY", "SERPDIVE_API_KEY", "KAGI_API_KEY", "OLLAMA_API_KEY", "SERPBASE_API_KEY", "XAI_API_KEY", "BRIGHTDATA_API_KEY", "BRIGHTDATA_SERP_ZONE", "SEARXNG_BASE_URL", "EXA_API_KEY", "PERPLEXITY_API_KEY", "GEMINI_API_KEY"]) {
 		delete childEnv[key];
 	}
 	Object.assign(childEnv, env);
@@ -119,6 +119,68 @@ test("auth status fails closed even when the response text looks like quota", as
 	assert.equal(output.ok, false);
 	assert.match(output.error, /brave search failed \(auth\)/);
 	assert.deepEqual(output.calls, ["https://api.search.brave.com/res/v1/web/search?q=auth+route&count=5"]);
+});
+
+test("configured routing falls back from an xAI 403 quota response", async () => {
+	const home = await createConfig({
+		searchRouting: { providers: ["xai", "tavily"], fallbackOn: ["quota"] },
+	});
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url) => {
+			calls.push(String(url));
+			if (String(url) === "https://api.x.ai/v1/responses") return new Response("spending limit exceeded", { status: 403 });
+			if (String(url) === "https://api.tavily.com/search") {
+				return new Response(JSON.stringify({ answer: "Tavily fallback answer", results: [] }), { status: 200 });
+			}
+			throw new Error("Unexpected fetch " + url);
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("xai quota route", { provider: "auto" });
+		console.log(JSON.stringify({ provider: result.provider, answer: result.answer, calls }));
+	`, {
+		PI_CODING_AGENT_DIR: home,
+		XAI_API_KEY: "xai-test-key",
+		TAVILY_API_KEY: "tavily-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.provider, "tavily");
+	assert.equal(output.answer, "Tavily fallback answer");
+	assert.deepEqual(output.calls, ["https://api.x.ai/v1/responses", "https://api.tavily.com/search"]);
+});
+
+test("configured routing keeps an ordinary xAI 403 response classified as auth", async () => {
+	const home = await createConfig({
+		searchRouting: { providers: ["xai", "tavily"], fallbackOn: ["quota"] },
+	});
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url) => {
+			calls.push(String(url));
+			if (String(url) === "https://api.x.ai/v1/responses") return new Response("invalid API key", { status: 403 });
+			if (String(url) === "https://api.tavily.com/search") throw new Error("Tavily must not run");
+			throw new Error("Unexpected fetch " + url);
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		try {
+			await search("xai auth route", { provider: "auto" });
+			console.log(JSON.stringify({ ok: true, calls }));
+		} catch (error) {
+			console.log(JSON.stringify({ ok: false, error: String(error), calls }));
+		}
+	`, {
+		PI_CODING_AGENT_DIR: home,
+		XAI_API_KEY: "xai-test-key",
+		TAVILY_API_KEY: "tavily-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.ok, false);
+	assert.match(output.error, /xai search failed \(auth\)/i);
+	assert.deepEqual(output.calls, ["https://api.x.ai/v1/responses"]);
 });
 
 test("legacy single-provider config takes precedence over searchRouting", async () => {


### PR DESCRIPTION
   HTTP 403 is overloaded: token/auth failures and quota exhaustion both
   return it. classifyProviderError currently maps any 403 to 'auth', which
   is not in searchRouting.fallbackOn (transient/quota/network only), so an
   out-of-credits xAI error aborts the whole fallback chain instead of
   falling through to the next provider.

   Detect quota-exhaustion signatures from the error body before the generic
   401/403 -> auth branch so these classify as 'quota' and fallback works.