### PR TITLE
fix: route local video upload/status/delete through configured geminiBaseUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Route local video Gemini upload, polling, and deletion requests through configured `geminiBaseUrl` / `GOOGLE_GEMINI_BASE_URL` relays. Thanks Mr. (`@Liemo99`) for PR #213.
 - Classify xAI `403` spending-limit and quota-exhaustion responses as quota errors so configured search routing can fall back, while preserving ordinary `403` responses as authentication errors. Thanks `@0xmarcinz` for PR #212.
 
 ## [0.18.0] - 2026-08-03

--- a/gemini-api.ts
+++ b/gemini-api.ts
@@ -76,7 +76,7 @@ export function getVersionedApiBase(): string {
 }
 
 export function getUploadBase(): string {
-	return `${getApiHost()}/upload/v1beta`;
+	return `${getApiHost()}/upload/${API_VERSION}`;
 }
 
 function getLegacyCloudflareApiKey(): string | null {

--- a/gemini-api.ts
+++ b/gemini-api.ts
@@ -75,6 +75,10 @@ export function getVersionedApiBase(): string {
 	return `${getApiHost()}/${API_VERSION}`;
 }
 
+export function getUploadBase(): string {
+	return `${getApiHost()}/upload/v1beta`;
+}
+
 function getLegacyCloudflareApiKey(): string | null {
 	return normalizeApiKey(process.env.CLOUDFLARE_API_KEY) ?? normalizeApiKey(loadConfig().cloudflareApiKey);
 }

--- a/test/gemini-api-transport.test.mjs
+++ b/test/gemini-api-transport.test.mjs
@@ -96,3 +96,75 @@ test("Gemini generate, upload, status, and delete use only shared header auth", 
 		assert.equal(request.url.includes("synthetic-gemini-key"), false);
 	}
 });
+
+test("Gemini video upload, status, and delete respect a configured geminiBaseUrl relay", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gemini-relay-"));
+	const mediaPath = join(root, "synthetic.webm");
+	await writeFile(mediaPath, "synthetic media", "utf8");
+	await writeFile(join(root, "web-search.json"), JSON.stringify({ geminiApiKey: "synthetic-gemini-key", geminiBaseUrl: "https://relay.example.com" }) + "\n", "utf8");
+
+	const child = runChild(`
+		const requests = [];
+		globalThis.fetch = async (url, init = {}) => {
+			const request = {
+				url: String(url),
+				method: init.method ?? "GET",
+				headers: Object.fromEntries(new Headers(init.headers)),
+			};
+			requests.push(request);
+			if (request.url.endsWith("/upload/v1beta/files")) {
+				return new Response("", {
+					status: 200,
+					headers: { "x-goog-upload-url": "https://relay.example.com/upload/v1beta/files?upload_id=synthetic" },
+				});
+			}
+			if (request.url.includes("upload_id=synthetic")) {
+				return new Response(JSON.stringify({ file: { name: "files/synthetic", uri: "files/synthetic" } }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			if (request.url.endsWith("/v1beta/files/synthetic") && request.method === "GET") {
+				return new Response(JSON.stringify({ state: "ACTIVE" }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			if (request.url.includes(":generateContent")) {
+				return new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text: "# Relay video" }] } }] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			if (request.url.endsWith("/v1beta/files/synthetic") && request.method === "DELETE") {
+				return new Response("", { status: 204 });
+			}
+			throw new Error("Unexpected fetch: " + request.url);
+		};
+
+		const { extractVideo } = await import(${JSON.stringify(videoModuleUrl)});
+		const result = await extractVideo({
+			absolutePath: ${JSON.stringify(mediaPath)},
+			mimeType: "video/webm",
+			sizeBytes: 15,
+			maxSizeBytes: 50 * 1024 * 1024,
+			withinUploadLimit: true,
+		});
+		await new Promise(resolve => setImmediate(resolve));
+		console.log(JSON.stringify({ result, requests }));
+	`, {
+		HOME: root,
+		USERPROFILE: root,
+		PI_CODING_AGENT_DIR: root,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.result.content, "# Relay video");
+	assert.deepEqual(output.requests.map(request => request.method), ["POST", "PUT", "GET", "POST", "DELETE"]);
+	for (const request of output.requests) {
+		assert.equal(new URL(request.url).origin, "https://relay.example.com", request.url);
+		assert.equal(request.headers["x-goog-api-key"], "synthetic-gemini-key");
+		assert.equal(request.url.includes("generativelanguage.googleapis.com"), false);
+	}
+});

--- a/video-extract.ts
+++ b/video-extract.ts
@@ -4,12 +4,11 @@ import { readFile } from "node:fs/promises";
 import { resolve, extname, basename, join, dirname } from "node:path";
 import { activityMonitor } from "./activity.ts";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.ts";
-import { queryGeminiApiWithVideo, getApiKey, fetchGeminiApi, API_BASE, redactGeminiApiResponse } from "./gemini-api.ts";
+import { queryGeminiApiWithVideo, getApiKey, fetchGeminiApi, getVersionedApiBase, getUploadBase, redactGeminiApiResponse } from "./gemini-api.ts";
 import { extractHeadingTitle, type ExtractedContent, type ExtractOptions, type FrameResult } from "./extract.ts";
 import { readExecError, trimErrorText, mapFfmpegError, getWebSearchConfigPath } from "./utils.ts";
 
 const CONFIG_PATH = getWebSearchConfigPath();
-const UPLOAD_BASE = "https://generativelanguage.googleapis.com/upload/v1beta";
 
 const DEFAULT_VIDEO_PROMPT = `Extract the complete content of this video. Include:
 1. Video title (infer from content if not explicit), duration
@@ -311,7 +310,7 @@ async function uploadToFilesApi(
 ): Promise<{ name: string; uri: string }> {
 	const displayName = basename(info.absolutePath);
 
-	const initRes = await fetchGeminiApi(`${UPLOAD_BASE}/files`, {
+	const initRes = await fetchGeminiApi(`${getUploadBase()}/files`, {
 		method: "POST",
 		headers: {
 			"X-Goog-Upload-Protocol": "resumable",
@@ -364,7 +363,7 @@ async function pollFileState(
 	while (Date.now() < deadline) {
 		if (signal?.aborted) throw new Error("Aborted");
 
-		const res = await fetchGeminiApi(`${API_BASE}/${fileName}`, { signal }, apiKey);
+		const res = await fetchGeminiApi(`${getVersionedApiBase()}/${fileName}`, { signal }, apiKey);
 		if (!res.ok) throw new Error(`File state check failed: ${res.status}`);
 
 		const data = await res.json() as { state: string };
@@ -378,7 +377,7 @@ async function pollFileState(
 }
 
 function deleteGeminiFile(fileName: string, apiKey: string): void {
-	void fetchGeminiApi(`${API_BASE}/${fileName}`, { method: "DELETE" }, apiKey).catch((err) => {
+	void fetchGeminiApi(`${getVersionedApiBase()}/${fileName}`, { method: "DELETE" }, apiKey).catch((err) => {
 		const message = err instanceof Error ? err.message : String(err);
 		console.error(`Failed to delete Gemini file ${fileName}: ${message}`);
 	});


### PR DESCRIPTION
## Problem

Local video analysis (`fetch_content` on a local `.mp4`/`.webm`/...) sends its **Files API upload**, **file state polling**, and **file deletion** requests to the hardcoded `https://generativelanguage.googleapis.com` host (`UPLOAD_BASE` and the exported `API_BASE`), ignoring `geminiBaseUrl` / `GOOGLE_GEMINI_BASE_URL`.

Search, YouTube, URL-context, and PDF extraction all already respect the configured Gemini host, so users behind a Gemini-compatible gateway or relay (e.g. region-blocked users routing through a third-party `geminiBaseUrl`) can use every Gemini feature **except** local video analysis — which still tries Google directly and fails.

## Change

- Add `getUploadBase()` to `gemini-api.ts`, derived from `getApiHost()` (same pattern as `getVersionedApiBase()`).
- `video-extract.ts`: upload init now uses `getUploadBase()/files`; `pollFileState` and `deleteGeminiFile` now use `getVersionedApiBase()/${fileName}` instead of the hardcoded `API_BASE`.

All four local-video API calls now follow the configured Gemini base URL. When no `geminiBaseUrl` is set, `getApiHost()` returns the default host, so behavior is fully backward-compatible.

## Tests

- Existing `Gemini generate, upload, status, and delete use only shared header auth` still passes (default host path unchanged).
- Added `Gemini video upload, status, and delete respect a configured geminiBaseUrl relay`, asserting all upload/status/delete/generate requests go to the configured relay origin and never to `generativelanguage.googleapis.com`.

`npm run typecheck` passes; full suite: 365/366 pass (the one failure is the pre-existing, environment-dependent `firecrawl-extraction` test that also fails on clean `main`).

## Notes

- The resumable upload still PUTs to the `x-goog-upload-url` returned by the relay, so gateways that proxy the Files API control where the actual upload lands.
- `API_BASE` is now unused by `video-extract.ts`; it remains exported for any other consumers.