### PR TITLE
Kagi: Update to v1 of search API

### DIFF
--- a/kagi.ts
+++ b/kagi.ts
@@ -6,7 +6,7 @@ import { hasCredentialSource, redactCredential, resolveCredential } from "./cred
 import { fetchRemoteUrl, loadFetchContentDomainPolicy, loadSsrfConfig, validateRemoteUrl, type SsrfConfig } from "./ssrf-protection.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-const KAGI_SEARCH_URL = "https://kagi.com/api/v0/search";
+const KAGI_SEARCH_URL = "https://kagi.com/api/v1/search";
 const KAGI_EXTRACT_URL = "https://kagi.com/api/v1/extract";
 const CONFIG_PATH = getWebSearchConfigPath();
 const SEARCH_TIMEOUT_MS = 60_000;
@@ -95,8 +95,6 @@ function appendSearchItems(value: unknown, results: SearchResponse["results"], i
 	}
 	if (!value || typeof value !== "object") return;
 	const item = value as Record<string, unknown>;
-	const nested = item.results ?? item.items ?? item.list;
-	if (Array.isArray(nested)) appendSearchItems(nested, results, inlineContent);
 	const url = firstString(item.url, item.href, item.link);
 	if (!url) return;
 	const title = firstString(item.title, item.name) ?? url;
@@ -126,8 +124,11 @@ function parseSearchResponse(value: unknown): { results: SearchResponse["results
 	const envelope = value as Record<string, unknown>;
 	const results: SearchResponse["results"] = [];
 	const inlineContent: ExtractedContent[] = [];
-	appendSearchItems(envelope.data, results, inlineContent);
-	if (results.length === 0 && envelope.data !== null) appendSearchItems(envelope, results, inlineContent);
+	const data = envelope.data;
+	const items = (typeof data === "object" && data !== null && !Array.isArray(data))
+		? (data as Record<string, unknown>).search
+		: data;
+	appendSearchItems(items, results, inlineContent);
 	return { results, inlineContent };
 }
 
@@ -165,14 +166,13 @@ export function isKagiAvailable(): boolean {
 export async function searchWithKagi(query: string, options: KagiSearchOptions = {}): Promise<SearchResponse> {
 	const apiKey = await requireApiKey(options.signal);
 	const numResults = normalizeCount(options.numResults);
-	const url = new URL(KAGI_SEARCH_URL);
-	url.searchParams.set("q", query);
-	url.searchParams.set("limit", String(numResults));
 	const activityId = activityMonitor.logStart({ type: "api", query });
 	let response: Response;
 	try {
-		response = await fetch(url, {
-			headers: { Authorization: `Bot ${apiKey}`, Accept: "application/json" },
+		response = await fetch(KAGI_SEARCH_URL, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json", Accept: "application/json" },
+			body: JSON.stringify({ query, limit: numResults }),
 			signal: options.signal ? AbortSignal.any([AbortSignal.timeout(SEARCH_TIMEOUT_MS), options.signal]) : AbortSignal.timeout(SEARCH_TIMEOUT_MS),
 		});
 	} catch (err) {
@@ -228,8 +228,8 @@ export async function extractWithKagi(url: string, signal?: AbortSignal, options
 	try {
 		response = await fetchRemoteUrl(KAGI_EXTRACT_URL, {
 			method: "POST",
-			headers: { Authorization: `Bot ${apiKey}`, "Content-Type": "application/json", Accept: "application/json" },
-			body: JSON.stringify({ urls: [url] }),
+			headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json", Accept: "application/json" },
+			body: JSON.stringify({ pages: [{ url }] }),
 			signal: signal ? AbortSignal.any([AbortSignal.timeout(options.timeoutMs ?? SEARCH_TIMEOUT_MS), signal]) : AbortSignal.timeout(options.timeoutMs ?? SEARCH_TIMEOUT_MS),
 		}, {
 			allowRanges: ssrf.allowRanges,

--- a/test/new-search-providers.test.mjs
+++ b/test/new-search-providers.test.mjs
@@ -66,14 +66,14 @@ test("Ollama search and Web Fetch use the Cloud REST endpoints", async () => {
 	assert.equal(output.fetched.content, "Fetched markdown");
 });
 
-test("Kagi search maps v0 results and Extract maps markdown", async () => {
+test("Kagi search maps v1 results and Extract maps markdown", async () => {
 	const home = await createHome({ kagiApiKey: "kagi-test-key" });
 	const child = runChild(`
 		const calls = [];
 		globalThis.fetch = async (url, init = {}) => {
 			calls.push({ url: String(url), method: init.method || "GET", headers: Object.fromEntries(new Headers(init.headers)), body: init.body ? JSON.parse(init.body) : null });
-			if (String(url).startsWith("https://kagi.com/api/v0/search?")) {
-				return new Response(JSON.stringify({ data: [{ title: "Kagi result", url: "https://example.com/kagi", snippet: "Kagi snippet", content: "Kagi content" }] }), { status: 200 });
+			if (String(url) === "https://kagi.com/api/v1/search") {
+				return new Response(JSON.stringify({ data: { search: [{ title: "Kagi result", url: "https://example.com/kagi", snippet: "Kagi snippet" }] } }), { status: 200 });
 			}
 			if (String(url) === "https://kagi.com/api/v1/extract") {
 				return new Response(JSON.stringify({ data: [{ url: "https://example.com/kagi", title: "Kagi extract", markdown: "Kagi markdown" }] }), { status: 200 });
@@ -87,12 +87,13 @@ test("Kagi search maps v0 results and Extract maps markdown", async () => {
 	`, { PI_CODING_AGENT_DIR: home });
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
-	assert.match(output.calls[0].url, /^https:\/\/kagi\.com\/api\/v0\/search\?/);
-	assert.equal(output.calls[0].headers.authorization, "Bot kagi-test-key");
-	assert.equal(new URL(output.calls[0].url).searchParams.get("limit"), "3");
-	assert.deepEqual(output.search.inlineContent, [{ url: "https://example.com/kagi", title: "Kagi result", content: "Kagi content", error: null }]);
+	assert.equal(output.calls[0].url, "https://kagi.com/api/v1/search");
+	assert.equal(output.calls[0].method, "POST");
+	assert.equal(output.calls[0].headers.authorization, "Bearer kagi-test-key");
+	assert.deepEqual(output.calls[0].body, { query: "premium search", limit: 3 });
+	assert.deepEqual(output.search.results, [{ title: "Kagi result", url: "https://example.com/kagi", snippet: "Kagi snippet" }]);
 	assert.equal(output.calls[1].url, "https://kagi.com/api/v1/extract");
-	assert.deepEqual(output.calls[1].body, { urls: ["https://example.com/kagi"] });
+	assert.deepEqual(output.calls[1].body, { pages: [{ url: "https://example.com/kagi" }] });
 	assert.equal(output.fetched.content, "Kagi markdown");
 });
 


### PR DESCRIPTION
Thanks for this project and adding kagi :).

The docs no longer show a v0. I believe that was their invite only beta API.

V1 has been released and no more mention of v0 on their website.

https://kagi.com/api/docs/openapi/search