### PR TITLE
fix: recognize :max think suffix for summary model

### DIFF
--- a/summary-model-scope.ts
+++ b/summary-model-scope.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh"]);
+const THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
 
 interface SummaryModelScopeContext {
 	cwd: string;


### PR DESCRIPTION
The thinking suffix `:max` is missing for summary model selection, which will cause scoped models (enabledModels) in Pi to be partially incompatible with the extension's search summary feature.

To fix, just add `:max` to the hardcoded THINKING_LEVELS.

Issue reproduced with the following scoped config:
  "enabledModels": [
    "deepseek/deepseek-v4-flash:max",
    "openai-codex/gpt-5.6-sol:high",
    "openai-codex/gpt-5.6-luna:max"
  ],