### PR TITLE
fix: replay curator search events after SSE reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Added Jina Search as a normal configured `web_search` provider with `jinaApiKey` / `JINA_API_KEY`, explicit/auto/routing/all-provider support, domain and recency constraints, optional inline page content, and Curator integration. Thanks Orbio Agent (`@Gabrielgvl`) for PR #214.
 
 ### Fixed
+- Keep manual `/websearch` curator pages in sync if the live SSE stream disconnects or misses events while searches are still running. Thanks `@Whisperfall` for issue #215.
 - Updated Kagi Search and Extract requests for the current v1 API contracts. Thanks `@mattgaff` for PR #217.
 - Recognize `:max` thinking suffixes when matching scoped summary models. Thanks `@justin8ty` for PR #219.
 - Route local video Gemini upload, polling, and deletion requests through configured `geminiBaseUrl` / `GOOGLE_GEMINI_BASE_URL` relays. Thanks Mr. (`@Liemo99`) for PR #213.

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -1481,6 +1481,9 @@ const SCRIPT = `(function() {
   var lastInteraction = Date.now();
   var completedCount = 0;
   var es = null;
+  var lastLiveEventAt = Date.now();
+  var stateSyncInFlight = false;
+  var liveUpdateWarning = false;
 
   var allQueries = queries.map(function(query, slotId) { return { slotId: slotId, query: query }; });
   var nextSlotId = queries.length;
@@ -1949,15 +1952,28 @@ const SCRIPT = `(function() {
   }
 
   function clearError() {
+    liveUpdateWarning = false;
     if (!errorBanner) return;
     errorBanner.hidden = true;
     errorBanner.textContent = "";
   }
 
   function setError(text) {
+    liveUpdateWarning = false;
     if (!errorBanner) return;
     errorBanner.textContent = text;
     errorBanner.hidden = false;
+  }
+
+  function setLiveUpdateWarning(text) {
+    liveUpdateWarning = true;
+    if (!errorBanner) return;
+    errorBanner.textContent = text;
+    errorBanner.hidden = false;
+  }
+
+  function clearLiveUpdateWarning() {
+    if (liveUpdateWarning) clearError();
   }
 
   function updateSummaryGeneratingIndicator() {
@@ -2756,9 +2772,10 @@ const SCRIPT = `(function() {
     }
   }
 
-  es.addEventListener("result", function(e) {
-    var data = parseSseEventData("result", e);
+  function applyResultEvent(data) {
     if (!data) return;
+    lastLiveEventAt = Date.now();
+    clearLiveUpdateWarning();
 
     var queryText = data.query || queries[data.queryIndex] || "";
     var slotId = typeof data.slotIndex === "number" ? data.slotIndex : queryIndexToSlot.get(data.queryIndex);
@@ -2768,13 +2785,16 @@ const SCRIPT = `(function() {
       card = createSearchingCard(queryText, data.provider);
       card.dataset.qi = data.queryIndex;
       insertResultCard(card, slotId, null);
+    } else if (card.dataset.completed === "true") {
+      return;
     }
     applyResponseToCard(card, data, queryText, data.provider, slotId);
-  });
+  }
 
-  es.addEventListener("search-error", function(e) {
-    var data = parseSseEventData("search-error", e);
+  function applySearchErrorEvent(data) {
     if (!data) return;
+    lastLiveEventAt = Date.now();
+    clearLiveUpdateWarning();
 
     var queryText = data.query || queries[data.queryIndex] || "";
     var slotId = typeof data.slotIndex === "number" ? data.slotIndex : queryIndexToSlot.get(data.queryIndex);
@@ -2784,6 +2804,8 @@ const SCRIPT = `(function() {
       card = createSearchingCard(queryText, data.provider);
       card.dataset.qi = data.queryIndex;
       insertResultCard(card, slotId, null);
+    } else if (card.dataset.completed === "true") {
+      return;
     }
     applyResponseToCard(card, {
       queryIndex: data.queryIndex,
@@ -2792,9 +2814,12 @@ const SCRIPT = `(function() {
       error: data.error || "Search failed",
       provider: data.provider,
     }, queryText, data.provider, slotId);
-  });
+  }
 
-  es.addEventListener("done", function() {
+  function applyDoneEvent() {
+    var wasSearchesDone = searchesDone;
+    lastLiveEventAt = Date.now();
+    clearLiveUpdateWarning();
     searchesDone = true;
     initialStreamDone = true;
     if (completedCount > 0) {
@@ -2804,12 +2829,77 @@ const SCRIPT = `(function() {
     recomputeProviderStates();
     updateStageUI();
     maybeAutoGenerateSummary();
-    resetTimer();
+    if (!wasSearchesDone) resetTimer();
+  }
+
+  function applyStoredLiveEvent(item) {
+    if (!item || typeof item !== "object") return;
+    if (item.event === "result") applyResultEvent(item.data);
+    if (item.event === "search-error") applySearchErrorEvent(item.data);
+  }
+
+  function syncStateFromServer(showWarning) {
+    if (stateSyncInFlight || submitted || timerExpired || searchesDone) return;
+    stateSyncInFlight = true;
+    fetch("/state?session=" + encodeURIComponent(token), { cache: "no-store" })
+      .then(function(res) {
+        return res.text().then(function(raw) {
+          var data = raw ? JSON.parse(raw) : null;
+          if (!res.ok || !data || data.ok === false) {
+            throw new Error(extractServerError(data) || ("HTTP " + res.status));
+          }
+          return data;
+        });
+      })
+      .then(function(data) {
+        if (Array.isArray(data.events)) {
+          data.events.forEach(applyStoredLiveEvent);
+        }
+        if (data.done) applyDoneEvent();
+        if (showWarning && !searchesDone) {
+          setLiveUpdateWarning("Live search updates disconnected. Reconnecting and polling for results.");
+        }
+      })
+      .catch(function(err) {
+        if (!showWarning || submitted || timerExpired) return;
+        var message = err instanceof Error ? err.message : String(err);
+        setLiveUpdateWarning("Live search updates disconnected. Retrying: " + (message || "unknown error"));
+      })
+      .finally(function() {
+        stateSyncInFlight = false;
+      });
+  }
+
+  es.addEventListener("open", function() {
+    lastLiveEventAt = Date.now();
+    clearLiveUpdateWarning();
+    syncStateFromServer(false);
+  });
+
+  es.addEventListener("result", function(e) {
+    var data = parseSseEventData("result", e);
+    applyResultEvent(data);
+  });
+
+  es.addEventListener("search-error", function(e) {
+    var data = parseSseEventData("search-error", e);
+    applySearchErrorEvent(data);
+  });
+
+  es.addEventListener("done", function() {
+    applyDoneEvent();
   });
 
   es.onerror = function() {
-    // EventSource reconnects automatically.
+    if (submitted || timerExpired || searchesDone) return;
+    syncStateFromServer(true);
   };
+
+  setInterval(function() {
+    if (submitted || timerExpired || searchesDone || initialStreamDone) return;
+    if (Date.now() - lastLiveEventAt <= 5000) return;
+    syncStateFromServer(false);
+  }, 5000);
 
   function setupCardInteraction(card) {
     var header = card.querySelector(".result-card-header");

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -8,6 +8,11 @@ const WATCHDOG_INTERVAL_MS = 1000;
 const MAX_BODY_SIZE = 64 * 1024;
 
 type ServerState = "SEARCHING" | "RESULT_SELECTION" | "COMPLETED";
+type CuratorResultEventData = IndexedCuratorSearchEntry & { slotIndex?: number };
+type CuratorSearchErrorEventData = { queryIndex: number; query: string; error: string; provider?: string; slotIndex?: number };
+type CuratorStoredEvent =
+	| { event: "result"; data: CuratorResultEventData }
+	| { event: "search-error"; data: CuratorSearchErrorEventData };
 
 export interface CuratorServerOptions {
 	queries: string[];
@@ -205,7 +210,8 @@ export function startCuratorServer(
 	let watchdog: NodeJS.Timeout | null = null;
 	let state: ServerState = "SEARCHING";
 	let sseResponse: ServerResponse | null = null;
-	const sseBuffer: string[] = [];
+	const streamedEventsByResultIndex = new Map<number, CuratorStoredEvent>();
+	let searchStreamDone = queries.length === 0;
 	let nextQueryIndex = queries.length;
 	let summarizeAbortController: AbortController | null = null;
 	let summarizeRequestSeq = 0;
@@ -289,13 +295,35 @@ export function startCuratorServer(
 		return false;
 	}
 
-	function sendSSE(event: string, data: unknown): void {
+	function writeSSE(res: ServerResponse, event: string, data: unknown): boolean {
 		const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-		const res = sseResponse;
-		if (res && !res.writableEnded && res.socket && !res.socket.destroyed) {
-			try { res.write(payload); return; } catch {}
+		try {
+			res.write(payload);
+			return true;
+		} catch {
+			return false;
 		}
-		sseBuffer.push(payload);
+	}
+
+	function sendSSE(event: string, data: unknown): void {
+		const res = sseResponse;
+		if (res && !res.writableEnded && res.socket && !res.socket.destroyed && writeSSE(res, event, data)) return;
+		if (sseResponse === res) sseResponse = null;
+	}
+
+	function retainStreamedEvent(event: CuratorStoredEvent): void {
+		streamedEventsByResultIndex.set(event.data.queryIndex, event);
+	}
+
+	function getStreamedEvents(): CuratorStoredEvent[] {
+		return [...streamedEventsByResultIndex.values()];
+	}
+
+	function replaySSE(res: ServerResponse): void {
+		for (const item of getStreamedEvents()) {
+			if (!writeSSE(res, item.event, item.data)) return;
+		}
+		if (searchStreamDone) writeSSE(res, "done", {});
 	}
 
 	const pageHtml = generateCuratorPage(
@@ -353,18 +381,7 @@ export function startCuratorServer(
 				res.flushHeaders();
 				if (res.socket) res.socket.setNoDelay(true);
 				sseResponse = res;
-				if (sseBuffer.length > 0) {
-					const pending = sseBuffer.splice(0, sseBuffer.length);
-					for (let i = 0; i < pending.length; i++) {
-						const msg = pending[i];
-						try {
-							res.write(msg);
-						} catch {
-							sseBuffer.unshift(...pending.slice(i));
-							break;
-						}
-					}
-				}
+				replaySSE(res);
 				if (sseKeepalive) clearInterval(sseKeepalive);
 				sseKeepalive = setInterval(() => {
 					if (sseResponse) {
@@ -374,6 +391,17 @@ export function startCuratorServer(
 				req.on("close", () => {
 					if (sseResponse === res) sseResponse = null;
 				});
+				return;
+			}
+
+			if (method === "GET" && url.pathname === "/state") {
+				const token = url.searchParams.get("session");
+				if (token !== sessionToken) {
+					sendJson(res, 403, { ok: false, error: "Invalid session" });
+					return;
+				}
+				touchHeartbeat();
+				sendJson(res, 200, { ok: true, events: getStreamedEvents(), done: searchStreamDone });
 				return;
 			}
 
@@ -685,15 +713,20 @@ export function startCuratorServer(
 				pushResult: (queryIndex, data) => {
 					if (completed) return;
 					nextQueryIndex = Math.max(nextQueryIndex, queryIndex + 1);
-					sendSSE("result", { queryIndex, query: data.query ?? queries[queryIndex] ?? "", ...data });
+					const eventData: CuratorResultEventData = { ...data, queryIndex, query: data.query ?? queries[queryIndex] ?? "" };
+					retainStreamedEvent({ event: "result", data: eventData });
+					sendSSE("result", eventData);
 				},
 				pushError: (queryIndex, error, provider, meta) => {
 					if (completed) return;
 					nextQueryIndex = Math.max(nextQueryIndex, queryIndex + 1);
-					sendSSE("search-error", { queryIndex, query: meta?.query ?? queries[queryIndex] ?? "", error, provider, slotIndex: meta?.slotIndex });
+					const eventData: CuratorSearchErrorEventData = { queryIndex, query: meta?.query ?? queries[queryIndex] ?? "", error, provider, slotIndex: meta?.slotIndex };
+					retainStreamedEvent({ event: "search-error", data: eventData });
+					sendSSE("search-error", eventData);
 				},
 				searchesDone: () => {
 					if (completed) return;
+					searchStreamDone = true;
 					sendSSE("done", {});
 					state = "RESULT_SELECTION";
 					stateChangedAt = Date.now();

--- a/test/curator-server-timeout.test.mjs
+++ b/test/curator-server-timeout.test.mjs
@@ -64,6 +64,25 @@ function withTimeout(promise, label) {
 	]);
 }
 
+async function readEventStreamUntil(response, marker, label) {
+	assert.equal(response.status, 200);
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let text = "";
+	try {
+		await withTimeout((async () => {
+			while (!text.includes(marker)) {
+				const chunk = await reader.read();
+				if (chunk.done) break;
+				text += decoder.decode(chunk.value, { stream: true });
+			}
+		})(), label);
+	} finally {
+		await reader.cancel().catch(() => {});
+	}
+	return text;
+}
+
 test("curator times out when searches finish but no browser connects", async () => {
 	const { startCuratorServer } = await loadServer();
 	let resolveCancel;
@@ -76,6 +95,28 @@ test("curator times out when searches finish but no browser connects", async () 
 
 		const reason = await withTimeout(cancelPromise, "no-browser timeout");
 		assert.equal(reason, "timeout");
+	} finally {
+		handle.close();
+	}
+});
+
+test("curator replays search events after SSE reconnect", async () => {
+	const { startCuratorServer } = await loadServer();
+	const handle = await startCuratorServer(baseOptions(20), baseCallbacks(() => {}));
+
+	try {
+		const eventsUrl = new URL("/events", handle.url);
+		eventsUrl.searchParams.set("session", "test-token");
+		const firstResponse = await fetch(eventsUrl);
+		assert.equal(firstResponse.status, 200);
+
+		handle.pushResult(0, { answer: "answer", results: [], provider: "exa" });
+		await firstResponse.body.cancel().catch(() => {});
+
+		const secondResponse = await fetch(eventsUrl);
+		const body = await readEventStreamUntil(secondResponse, "event: result", "sse replay");
+		assert.match(body, /event: result/);
+		assert.match(body, /"answer":"answer"/);
 	} finally {
 		handle.close();
 	}
@@ -174,6 +215,47 @@ test("curator heartbeat timeout finalizes connected idle browser sessions", asyn
 
 		const reason = await withTimeout(cancelPromise, "idle heartbeat timeout");
 		assert.equal(reason, "timeout");
+	} finally {
+		handle.close();
+	}
+});
+
+test("curator state replay keeps current results and compacts superseded history", async () => {
+	const { startCuratorServer } = await loadServer();
+	const handle = await startCuratorServer(baseOptions(20), baseCallbacks(() => {}));
+
+	try {
+		for (let i = 0; i < 205; i++) {
+			handle.pushResult(i, { answer: `answer ${i}`, results: [], provider: "exa", query: `query ${i}` });
+		}
+		handle.pushError(0, "updated", "exa", { query: "query 0" });
+
+		const response = await fetch(new URL("/state?session=test-token", handle.url));
+		assert.equal(response.status, 200);
+		const body = await response.json();
+		assert.equal(body.events.length, 205);
+		assert.equal(body.events[0].event, "search-error");
+		assert.equal(body.events[0].data.queryIndex, 0);
+		assert.equal(body.events[204].data.queryIndex, 204);
+	} finally {
+		handle.close();
+	}
+});
+
+test("curator state replay keeps all-provider entries that share one slot", async () => {
+	const { startCuratorServer } = await loadServer();
+	const handle = await startCuratorServer(baseOptions(20), baseCallbacks(() => {}));
+
+	try {
+		handle.pushResult(0, { answer: "exa answer", results: [], provider: "exa", query: "query", slotIndex: 0 });
+		handle.pushResult(1, { answer: "brave answer", results: [], provider: "brave", query: "query", slotIndex: 0 });
+
+		const response = await fetch(new URL("/state?session=test-token", handle.url));
+		assert.equal(response.status, 200);
+		const body = await response.json();
+		assert.deepEqual(body.events.map((event) => event.data.provider), ["exa", "brave"]);
+		assert.deepEqual(body.events.map((event) => event.data.queryIndex), [0, 1]);
+		assert.deepEqual(body.events.map((event) => event.data.slotIndex), [0, 0]);
 	} finally {
 		handle.close();
 	}


### PR DESCRIPTION
Keeps manual /websearch curator pages synchronized when the live SSE stream disconnects or misses events while searches are still running. The server now replays stored search events and exposes state for client polling fallback, and the client keeps duplicate done events from extending the result-selection idle timeout.

Closes #215.

Validation:
- node --test test/curator-server-timeout.test.mjs test/curator-fallback.test.mjs test/parallel-curator-state.test.mjs
- npm run typecheck
- git diff --check origin/main...HEAD

Fresh review: /tmp/pi-web-access-lanes/issue-215-wsl-curator/final-review.md.