### PR TITLE
fix: preserve web search result background padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Preserve collapsed `web_search` result background padding. Thanks `@SheffeyG` for PR #224.
+
 ## [0.19.0] - 2026-08-08
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -2086,7 +2086,7 @@ export default function (pi: ExtensionAPI) {
 			const totalLines = lines.length;
 
 			if (!expanded) {
-				const box = new Box(1, 0, (t) => theme.bg("toolSuccessBg", t));
+				const box = new Box(2, 0);
 				box.addChild(new Text(statusLine, 0, 0));
 
 				let collapsedLines = 1; // statusLine

--- a/index.ts
+++ b/index.ts
@@ -2086,7 +2086,7 @@ export default function (pi: ExtensionAPI) {
 			const totalLines = lines.length;
 
 			if (!expanded) {
-				const box = new Box(2, 0);
+				const box = new Box(1, 0);
 				box.addChild(new Text(statusLine, 0, 0));
 
 				let collapsedLines = 1; // statusLine


### PR DESCRIPTION
 The collapsed search result creates its own background-colored `Box` inside Pi's existing tool result box:

 ```ts
 new Box(1, 0, (t) => theme.bg("toolSuccessBg", t))
 ```

 The inner background emits an ANSI background reset before Pi renders the outer box's final right-padding column. As a result, that last column does not inherit toolSuccessBg, producing a visible one-character gap.

 This only affects the collapsed web_search renderer. Successful fetch_content results return plain Text and do not exhibit the issue.

 Remove the redundant inner background and let Pi's outer tool box provide the success background:

 ```ts
 new Box(2, 0)
 ```

 The box still provides horizontal spacing for the collapsed search summary, while the background is now applied once by the host across the complete result width.
 
Before
<img width="954" height="260" alt="image" src="https://github.com/user-attachments/assets/030213c0-bfe4-4f7f-ba7c-2bae4c9e3bb9" />
After
<img width="956" height="261" alt="Snipaste_2026-08-08_18-14-00" src="https://github.com/user-attachments/assets/4626af96-7cd4-4359-b98a-5ca652a01c53" />
