### PR TITLE
feat: add Datalab PDF extraction provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added Datalab hosted PDF-to-Markdown extraction as an optional PDF provider. Thanks José Antonio Galiano Sandoval (`@jagaliano`) for PR #226.
+
 ### Fixed
 - Preserve collapsed `web_search` result background padding. Thanks `@SheffeyG` for PR #224.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20Windows*-blue?style=for-the-badge)]()
 
-https://github.com/user-attachments/assets/cac6a17a-1eeb-4dde-9818-cdf85d8ea98f
+<https://github.com/user-attachments/assets/cac6a17a-1eeb-4dde-9818-cdf85d8ea98f>
 
 ## Why Pi Web Access
 
@@ -111,7 +111,7 @@ web_search({ queries: ["query 1", "query 2"], workflow: "auto-summary" })
 ```
 
 | Parameter | Description |
-|-----------|-------------|
+| ----------- | ------------- |
 | `query` / `queries` | Single query or batch of queries |
 | `numResults` | Results per query (default: 5, max: 20) |
 | `recencyFilter` | `day`, `week`, `month`, or `year` |
@@ -137,7 +137,7 @@ fetch_content({ url: "https://example.com/diagram.png" })
 ```
 
 | Parameter | Description |
-|-----------|-------------|
+| ----------- | ------------- |
 | `url` / `urls` | Single URL/path or multiple URLs |
 | `prompt` | Question for video analysis, or the page-local question required by `mode: "answer"` |
 | `mode` | `readable` (default), `raw` for exact textual HTTP bodies, or `answer` for a grounded answer from fetched content |
@@ -212,7 +212,35 @@ Requires `ffmpeg` (and `yt-dlp` for YouTube). Timestamps accept `H:MM:SS`, `MM:S
 
 ### PDFs
 
-PDF URLs are converted to Markdown with Gemini API when configured, with local `unpdf` text extraction as fallback. Markdown is saved under the temporary `pi-web-pdf` directory by default so the agent can `read` specific sections without loading the full document into context. Text-based extraction only — no OCR.
+PDF URLs are converted to Markdown and saved under the temporary `pi-web-pdf` directory by default so the agent can `read` specific sections without loading the full document into context. Three engines are available, selected with `pdf.provider` (`"auto"` is the default):
+
+| Provider | Engine | Trade-offs |
+| --- | --- | --- |
+| `datalab` | Datalab hosted conversion (Marker) | Deterministic layout-aware output — tables, multi-column reading order, headings, math; `accurate` mode handles scanned pages; may return a `parse_quality_score`; requires a Datalab key, billed per page with a free monthly credit |
+| `gemini` | Gemini API (vision LLM) | Best on scanned/complex pages; LLM transcription can occasionally drift or truncate; requires a Gemini key |
+| `unpdf` | Local pdf.js text extraction | Free, offline, no key; flattened text only — no layout, no tables, no OCR |
+
+`auto` order: Datalab (when a key is configured) → Gemini (when a key is configured) → local `unpdf`. Datalab runs first for layout-aware conversion. If its request fails — including after free-tier credit is exhausted — the chain continues to Gemini, then `unpdf`, automatically. Setting `pdf.provider` to `gemini`, `datalab`, or `unpdf` pins that engine and skips the other remote tiers (an explicit engine still falls back to `unpdf` when it errors, except for credential/config errors and caller cancellation). No Datalab key means the `datalab` tier is simply skipped — behavior is unchanged for existing users.
+
+**Why Datalab.** The hosted converter uses a dedicated extraction engine (Marker) intended to retain document structure such as tables, multi-column reading order, headings, links, and math, where local `unpdf` extraction only yields flattened text. It is deterministic rather than LLM-based. Completed responses may include a `parse_quality_score` (0–5) for optional quality gating. Pricing is per processed page: **fast / balanced** $4 / 1,000 pages; **accurate** $10 / 1,000 pages. The free tier gives a **$10 monthly credit** (personal email; $20 with a work email) at **25 requests/minute** — roughly **2,500 pages/month free in `fast` mode** or 1,000 in `accurate` mode. Processing defaults to the **US region**. EU data residency uses **1.25× usage**; opt in with `DATALAB_PROCESSING_LOCATION=eu`.
+
+Configure Datalab via the web-search config:
+
+```jsonc
+{
+  "datalabApiKey": "$DATALAB_API_KEY",
+  "pdf": {
+    "maxSizeMB": 20,
+    "provider": "auto",      // "auto" | "gemini" | "datalab" | "unpdf"
+    "datalabMode": "balanced", // "fast" | "balanced" | "accurate"
+    "datalabTimeoutMs": 120000
+  }
+}
+```
+
+Env vars: `DATALAB_API_KEY` (or `datalabApiKey` in config), `DATALAB_PROCESSING_LOCATION` (`us` default; `eu` enables EU data residency at 1.25× usage), `DATALAB_MODE` (`fast` / `balanced` / `accurate`), and `DATALAB_API_BASE` (custom gateway). `pdf.datalabMode` overrides `DATALAB_MODE`. The default `datalabTimeoutMs` is 120s and is capped at 300s.
+
+> Privacy note: like the Gemini tier, the PDF bytes are sent to the Datalab cloud for conversion. Files are uploaded to the selected region's storage and deleted best-effort after conversion.
 
 ### Blocked pages
 
@@ -230,7 +258,7 @@ fetch_content(url)
   → Video file?  Gemini API (Files API) → Gemini Web (if browser cookies enabled)
   → GitHub URL?  Clone repo, return file contents + local path
   → YouTube URL? Gemini Web (if browser cookies enabled) → Gemini API → Perplexity
-  → HTTP fetch → PDF? Gemini API → local text extraction, save to temp pi-web-pdf
+  → HTTP fetch → PDF? Datalab → Gemini API → local text extraction, save to temp pi-web-pdf
                → HTML? Readability (+ declared Link/rel discovery) → RSC parser → Firecrawl (if configured) → third-party hosted fallbacks only when fetchRouting.allowRemoteHostedProviders is enabled
                → Text/JSON/Markdown? Return directly
 ```
@@ -356,7 +384,8 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
     "maxSizeMB": 50
   },
   "pdf": {
-    "maxSizeMB": 20
+    "maxSizeMB": 20,
+    "provider": "auto"
   },
   "fetchContent": {
     "domainPolicy": {
@@ -375,7 +404,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
 }
 ```
 
-All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `tinyfishApiKey`, `search1apiApiKey`, `searchinfinityApiKey`, `queritApiKey`, `tavilyApiKey`, `jinaApiKey`, `serpdiveApiKey`, `kagiApiKey`, `ollamaApiKey`, `serpbaseApiKey`, `anysearchApiKey`, `xaiApiKey`, `brightdataApiKey`, `firecrawlApiKey`, `exaApiKey`, `perplexityApiKey`, `geminiApiKey`, and `cloudflareApiKey`) accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time. Escape `$$` as a literal leading `$` and `$!` as a literal leading `!`:
+All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `tinyfishApiKey`, `search1apiApiKey`, `searchinfinityApiKey`, `queritApiKey`, `tavilyApiKey`, `jinaApiKey`, `serpdiveApiKey`, `kagiApiKey`, `ollamaApiKey`, `serpbaseApiKey`, `anysearchApiKey`, `xaiApiKey`, `brightdataApiKey`, `firecrawlApiKey`, `exaApiKey`, `perplexityApiKey`, `geminiApiKey`, `datalabApiKey`, and `cloudflareApiKey`) accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time. Escape `$$` as a literal leading `$` and `$!` as a literal leading `!`:
 
 ```json
 {
@@ -408,8 +437,7 @@ Bright Data Web Unlocker is a paid `fetch_content` fallback after Parallel and b
 
 **SerpBase.** Set `serpbaseApiKey` or `SERPBASE_API_KEY` and select `provider: "serpbase"` to query SerpBase's Google Search Results API. SerpBase is explicit-only: it is never chosen by `auto` and never participates in `provider: "all"`, because each request can consume paid Google SERP credits. Domain filters are sent as Google `site:` clauses and reapplied locally; recency maps to Google's `tbs` time filter.
 
-
-Without an explicit `$` or `!` source, `OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TINYFISH_API_KEY`, `SEARCH1API_KEY`, `SEARCHINFINITY_API_KEY`, `QUERIT_API_KEY`, `TAVILY_API_KEY`, `JINA_API_KEY`, `SERPDIVE_API_KEY`, `KAGI_API_KEY`, `OLLAMA_API_KEY`, `SERPBASE_API_KEY`, `ANYSEARCH_API_KEY`, `XAI_API_KEY`, `BRIGHTDATA_API_KEY`, `FIRECRAWL_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars retain their existing precedence over literal config file values. `openaiResponsesUrl` can point OpenAI `web_search` and `source_check` at a third-party gateway that supports the OpenAI Responses API and web search tool; it is an explicit endpoint override, not derived from Pi model provider settings, and defaults to `https://api.openai.com/v1/responses`. `openaiSearchModel` pins the model id used for OpenAI `web_search`, bypassing automatic selection (newest terra-tier model); the id is sent verbatim with whichever OpenAI auth resolves, so gateway-only model ids work too. `xaiSearchModel` similarly pins the xAI search model. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` or `searchProvider` sets the default search provider and is used when a tool call omits `provider` or sends `"auto"`: `"all"`, `"openai"`, `"brave"`, `"parallel"`, `"tinyfish"`, `"search1api"`, `"searchinfinity"`, `"querit"`, `"tavily"`, `"jina"`, `"serpdive"`, `"kagi"`, `"ollama"`, `"anysearch"`, `"xai"`, `"brightdata"`, `"serpbase"`, `"searxng"`, `"exa"`, `"perplexity"`, or `"gemini"`. AnySearch, xAI, Bright Data, and SerpBase are never selected by `auto`; choose them explicitly or place them in `searchRouting`. If either single-provider field is configured, it takes precedence over `searchRouting`. Otherwise, `searchRouting` can opt into an ordered `providers` list and an explicit `fallbackOn` list containing `"transient"`, `"quota"`, and/or `"network"`; only those typed failures continue to the next available candidate. `"all"` is not valid inside `searchRouting.providers`, because that list defines sequential fallback rather than multi-provider aggregation. Named providers remain strict, and exhausted routes return per-provider diagnostics. `provider` can also be a non-empty array of named providers such as `["brave", "exa"]`; those providers run concurrently using the same aggregation path as `"all"`, while `"auto"` and `"all"` are invalid inside arrays. Random, weighted, sticky, and cooldown routing are not enabled. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the configured search and source-check tools while leaving fetch/content tools available. `toolNames` can opt into alternate public tool names for environments where another extension or model reserves the defaults, without changing behavior: `webSearch`, `sourceCheck`, `fetchContent`, and `getSearchContent` default to `web_search`, `source_check`, `fetch_content`, and `get_search_content`. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on the configured search tool, or toggled at runtime with `/curator`. `chromeProfile` pins Gemini Web cookie lookup to a specific Chromium profile. When omitted, detected Chromium profiles are scanned in stable order and the first profile containing the required Gemini cookies is used. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid browser data access and surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. Cookie databases are copied to a temporary read-only working copy; the reader uses `node:sqlite` when available and otherwise tries the `sqlite3` CLI or Python's standard-library SQLite module. `searchModel` overrides the Gemini API model used by the configured search tool without changing URL, YouTube, or video extraction defaults. Gemini API grounded search uses `gemini-3.6-flash` by default; set `searchModel` to choose another model. Gemini Web browser-cookie fallback uses its separate `gemini-3.1-pro` default because Gemini Web relies on private header values; explicitly configured unsupported Web models fail instead of silently falling back to 2.5 Flash. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). Preferred summary and query-rewrite models also resolve through routed provider registrations such as OpenRouter when the native provider is unavailable. When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected. `ssrf.trustEnvProxy` is a separate opt-in for sandboxed environments with valid HTTP(S) proxy env vars; it skips local DNS preflight only for proxied hostnames and still blocks localhost, literal private IPs, and `NO_PROXY` matches. It does not configure proxy transport.
+Without an explicit `$` or `!` source, `OPENAI_API_KEY`, `BRAVE_API_KEY`, `PARALLEL_API_KEY`, `TINYFISH_API_KEY`, `SEARCH1API_KEY`, `SEARCHINFINITY_API_KEY`, `QUERIT_API_KEY`, `TAVILY_API_KEY`, `JINA_API_KEY`, `SERPDIVE_API_KEY`, `KAGI_API_KEY`, `OLLAMA_API_KEY`, `SERPBASE_API_KEY`, `ANYSEARCH_API_KEY`, `XAI_API_KEY`, `BRIGHTDATA_API_KEY`, `FIRECRAWL_API_KEY`, `EXA_API_KEY`, `GEMINI_API_KEY`, `DATALAB_API_KEY`, `DATALAB_PROCESSING_LOCATION`, `DATALAB_MODE`, `DATALAB_API_BASE`, `PERPLEXITY_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, and `CLOUDFLARE_API_KEY` env vars retain their existing precedence over literal config file values. `openaiResponsesUrl` can point OpenAI `web_search` and `source_check` at a third-party gateway that supports the OpenAI Responses API and web search tool; it is an explicit endpoint override, not derived from Pi model provider settings, and defaults to `https://api.openai.com/v1/responses`. `openaiSearchModel` pins the model id used for OpenAI `web_search`, bypassing automatic selection (newest terra-tier model); the id is sent verbatim with whichever OpenAI auth resolves, so gateway-only model ids work too. `xaiSearchModel` similarly pins the xAI search model. Configured Exa API keys use Exa's own account limits directly; any legacy local `exa-usage.json` file is ignored. `GOOGLE_GEMINI_BASE_URL` overrides the Gemini API host for Gemini generate-content calls such as search, URL context, YouTube, and local video analysis. Set it to a bare host with no trailing slash and no version segment, for example `https://my-gateway.example.com/gemini`; `geminiBaseUrl` is the config-file equivalent. When the configured host contains `gateway.ai.cloudflare.com`, authentication uses `cf-aig-authorization: Bearer <token>` from `CLOUDFLARE_API_KEY` or `cloudflareApiKey`, and `GEMINI_API_KEY` is not required for generate-content calls. Local video file upload still uses Google's Files API directly, so gateway-only video extraction falls back to Gemini Web unless a `GEMINI_API_KEY` is also configured. `provider` or `searchProvider` sets the default search provider and is used when a tool call omits `provider` or sends `"auto"`: `"all"`, `"openai"`, `"brave"`, `"parallel"`, `"tinyfish"`, `"search1api"`, `"searchinfinity"`, `"querit"`, `"tavily"`, `"jina"`, `"serpdive"`, `"kagi"`, `"ollama"`, `"anysearch"`, `"xai"`, `"brightdata"`, `"serpbase"`, `"searxng"`, `"exa"`, `"perplexity"`, or `"gemini"`. AnySearch, xAI, Bright Data, and SerpBase are never selected by `auto`; choose them explicitly or place them in `searchRouting`. If either single-provider field is configured, it takes precedence over `searchRouting`. Otherwise, `searchRouting` can opt into an ordered `providers` list and an explicit `fallbackOn` list containing `"transient"`, `"quota"`, and/or `"network"`; only those typed failures continue to the next available candidate. `"all"` is not valid inside `searchRouting.providers`, because that list defines sequential fallback rather than multi-provider aggregation. Named providers remain strict, and exhausted routes return per-provider diagnostics. `provider` can also be a non-empty array of named providers such as `["brave", "exa"]`; those providers run concurrently using the same aggregation path as `"all"`, while `"auto"` and `"all"` are invalid inside arrays. Random, weighted, sticky, and cooldown routing are not enabled. This is also updated automatically when you change the provider in the curator UI. Set `webSearch.enabled` to `false` to unregister the configured search and source-check tools while leaving fetch/content tools available. `toolNames` can opt into alternate public tool names for environments where another extension or model reserves the defaults, without changing behavior: `webSearch`, `sourceCheck`, `fetchContent`, and `getSearchContent` default to `web_search`, `source_check`, `fetch_content`, and `get_search_content`. `workflow` sets the default search workflow: `"summary-review"` (default, opens curator with auto-generated summary draft), `"auto-summary"` (returns a model-generated summary without opening the curator), or `"none"` (raw results, no curator). Overridden per-call via the `workflow` parameter on the configured search tool, or toggled at runtime with `/curator`. `chromeProfile` pins Gemini Web cookie lookup to a specific Chromium profile. When omitted, detected Chromium profiles are scanned in stable order and the first profile containing the required Gemini cookies is used. `allowBrowserCookies` enables Chromium cookie extraction for Gemini Web; it defaults to `false` to avoid browser data access and surprise macOS Keychain prompts. You can also set `PI_ALLOW_BROWSER_COOKIES=1`. Cookie databases are copied to a temporary read-only working copy; the reader uses `node:sqlite` when available and otherwise tries the `sqlite3` CLI or Python's standard-library SQLite module. `searchModel` overrides the Gemini API model used by the configured search tool without changing URL, YouTube, or video extraction defaults. Gemini API grounded search uses `gemini-3.6-flash` by default; set `searchModel` to choose another model. Gemini Web browser-cookie fallback uses its separate `gemini-3.1-pro` default because Gemini Web relies on private header values; explicitly configured unsupported Web models fail instead of silently falling back to 2.5 Flash. `summaryModel` sets the default model used for generating summary drafts in the curator UI and `auto-summary` mode (e.g. `"anthropic/claude-haiku-4-5"`, `"openai-codex/gpt-5.3-codex-spark"`, or `"openrouter/nvidia/nemotron-3-super-120b-a12b:free"`). Preferred summary and query-rewrite models also resolve through routed provider registrations such as OpenRouter when the native provider is unavailable. When Pi `enabledModels` is configured, summaries are limited to that allowlist; if no enabled summary model is available, the tool returns a deterministic summary instead of calling an unrelated model. `curatorTimeoutSeconds` controls the initial curator idle timeout (default `20`, max `600`); users can still adjust the timer in the curator UI. `ssrf.allowRanges` lists CIDR ranges (e.g. `"198.18.0.0/15"`, `"fd00::/8"`) exempted from the SSRF guard that otherwise blocks private/reserved IP ranges. This unblocks `fetch_content`/`web_search` on hosts whose network proxy runs in TUN + fake-IP mode (Surge, Clash, Mihomo, Stash, ...), where public domains resolve into a synthetic reserved range. It is **off by default** — the guard stays fully enabled unless you list ranges here. Use the narrowest range that covers your proxy's fake-IP pool. All-address CIDRs such as `0.0.0.0/0` and `::/0` are rejected. `ssrf.trustEnvProxy` is a separate opt-in for sandboxed environments with valid HTTP(S) proxy env vars; it skips local DNS preflight only for proxied hostnames and still blocks localhost, literal private IPs, and `NO_PROXY` matches. It does not configure proxy transport.
 
 ### All providers
 
@@ -513,6 +541,7 @@ The model is chosen for you: the registry path walks a best-first candidate list
 Requests send only `{ model, input, tools }`, the shape verified against a live subscription account. `recencyFilter`, `domainFilter`, and `numResults` are folded into the prompt text rather than sent as tool parameters, so an unrecognized field can never turn a search into a 400. Sources are read from `url_citation` annotations on the answer and from each `web_search_call`'s own sources; there is no top-level `citations` array on this API.
 
 xAI's older Live Search (`search_parameters` on `/v1/chat/completions`) is deprecated and now answers HTTP 410.
+
 ### Bright Data
 
 Bright Data SERP is a **paid, third-party search proxy**: your query, its filters, and the result URLs
@@ -738,7 +767,7 @@ Values use the same format as pi keybindings (e.g. `ctrl+s`, `ctrl+shift+s`, `al
 
 Set `"enabled": false` under any feature to disable it. For GitHub specifically, `githubClone.enabled: false` only skips clone/API specialization; it does not unregister `fetch_content` or block generic URL extraction. Config changes require a Pi restart.
 
-Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Search, TinyFish, Search1API, and Searchinfinity apply the plan limits documented by their APIs. Querit Search and Contents subscriptions are independent. Content fetches run 3 concurrent with a 30s timeout for the direct HTTP fetch of each URL. Remote extraction fallbacks carry their own budgets and are not covered by that number: Jina Reader 30s, Firecrawl 60s, Kagi Extract 60s, Ollama Web Fetch 60s, Bright Data Web Unlocker 60s, TinyFish up to 150s, Gemini 120s. `pdf.maxSizeMB` defaults to 20 and is capped at 50.
+Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Search, TinyFish, Search1API, and Searchinfinity apply the plan limits documented by their APIs. Querit Search and Contents subscriptions are independent. Content fetches run 3 concurrent with a 30s timeout for the direct HTTP fetch of each URL. Remote extraction fallbacks carry their own budgets and are not covered by that number: Jina Reader 30s, Firecrawl 60s, Kagi Extract 60s, Ollama Web Fetch 60s, Bright Data Web Unlocker 60s, TinyFish up to 150s, Gemini 120s, Datalab 120s (capped at 300s, rate-limited to 25 requests/minute on the free tier). `pdf.maxSizeMB` defaults to 20 and is capped at 50.
 
 ## Limitations
 
@@ -754,7 +783,7 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Sear
 <summary>Files</summary>
 
 | File | Purpose |
-|------|---------|
+| ------ | --------- |
 | `index.ts` | Extension entry, tool definitions, commands, widget |
 | `curator-page.ts` | HTML/CSS/JS generation for the curator UI with markdown rendering |
 | `curator-server.ts` | Ephemeral HTTP server with SSE streaming and state machine |
@@ -792,6 +821,7 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Sear
 | `github-extract.ts` | GitHub URL parsing, clone cache, content generation |
 | `github-api.ts` | GitHub API fallback for large repos and commit SHAs |
 | `perplexity.ts` | Perplexity API client with rate limiting |
+| `datalab-pdf-extract.ts` | Datalab hosted PDF-to-Markdown conversion client (upload → convert → poll) |
 | `pdf-extract.ts` | PDF text extraction, saves to markdown |
 | `rsc-extract.ts` | RSC flight data parser for Next.js pages |
 | `utils.ts` | Shared formatting and error helpers |

--- a/datalab-pdf-extract.ts
+++ b/datalab-pdf-extract.ts
@@ -290,7 +290,11 @@ export async function extractPDFViaDatalab(
 
 		const checkUrl = normalizeCheckUrl(state.request_check_url);
 		while (Date.now() < deadline) {
-			await sleep(DEFAULT_POLL_INTERVAL_MS, options.signal);
+			await sleep(
+				Math.min(DEFAULT_POLL_INTERVAL_MS, remaining(deadline)),
+				options.signal,
+			);
+			if (Date.now() >= deadline) break;
 			const poll = await fetchDatalab(
 				checkUrl,
 				{
@@ -312,7 +316,9 @@ export async function extractPDFViaDatalab(
 		throw new Error("Datalab PDF conversion timed out");
 	} finally {
 		if (fileId !== undefined && fileId !== null) {
-			await deleteDatalabFile(apiKey, String(fileId));
+			// File deletion is best-effort. Do not extend a caller's timeout or
+			// cancellation while waiting for a remote cleanup request.
+			void deleteDatalabFile(apiKey, String(fileId));
 		}
 	}
 }

--- a/datalab-pdf-extract.ts
+++ b/datalab-pdf-extract.ts
@@ -1,0 +1,553 @@
+import { existsSync, readFileSync } from "node:fs";
+import {
+	hasCredentialSource,
+	resolveCredential,
+	redactCredential,
+} from "./credential-source.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const DEFAULT_API_HOST = "https://www.datalab.to";
+const API_PREFIX = "/api/v1";
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_POLL_INTERVAL_MS = 1_500;
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+const MAX_ERROR_BODY_BYTES = 300;
+const CLEANUP_TIMEOUT_MS = 5_000;
+const CONFIG_PATH = getWebSearchConfigPath();
+
+export type DatalabMode = "fast" | "balanced" | "accurate";
+export type DatalabProcessingLocation = "eu" | "us";
+
+export const DATALAB_MODE_VALUES = new Set<DatalabMode>([
+	"fast",
+	"balanced",
+	"accurate",
+]);
+export const DATALAB_LOCATION_VALUES = new Set<DatalabProcessingLocation>([
+	"eu",
+	"us",
+]);
+export const DEFAULT_DATALAB_MODE: DatalabMode = "balanced";
+export const DEFAULT_PROCESSING_LOCATION: DatalabProcessingLocation = "us";
+export const DEFAULT_DATALAB_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
+
+interface DatalabConfig {
+	datalabApiKey?: unknown;
+}
+
+let cachedConfig: DatalabConfig | null = null;
+
+function loadConfig(): DatalabConfig {
+	if (cachedConfig) return cachedConfig;
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = {};
+		return cachedConfig;
+	}
+
+	const rawText = readFileSync(CONFIG_PATH, "utf-8");
+	try {
+		cachedConfig = JSON.parse(rawText) as DatalabConfig;
+		return cachedConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+function normalizeString(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeFileId(value: unknown): string | null {
+	if (typeof value === "number" && Number.isFinite(value)) return String(value);
+	return normalizeString(value);
+}
+
+export function isDatalabApiAvailable(): boolean {
+	return hasCredentialSource({
+		provider: "Datalab",
+		configuredValue: loadConfig().datalabApiKey,
+		environmentValue: process.env.DATALAB_API_KEY,
+	});
+}
+
+export async function getDatalabApiKey(
+	signal?: AbortSignal,
+): Promise<string | null> {
+	return resolveCredential({
+		provider: "Datalab",
+		configuredValue: loadConfig().datalabApiKey,
+		environmentValue: process.env.DATALAB_API_KEY,
+		signal,
+	});
+}
+
+export function getDatalabApiBase(): string {
+	const normalized = normalizeString(process.env.DATALAB_API_BASE)?.replace(
+		/\/+$/,
+		"",
+	);
+	return normalized || `${DEFAULT_API_HOST}${API_PREFIX}`;
+}
+
+/**
+ * Resolve the processing region. US storage and processing is the default;
+ * set `DATALAB_PROCESSING_LOCATION=eu` to use EU data residency at Datalab's
+ * documented 1.25× usage rate. Only `eu` and `us` are supported by the API.
+ * Config errors are thrown with a `Failed to parse` prefix so the
+ * extraction fallback chain treats them as fatal, mirroring how malformed
+ * web-search config is handled elsewhere.
+ */
+export function getDatalabProcessingLocation(): DatalabProcessingLocation {
+	const value =
+		normalizeString(process.env.DATALAB_PROCESSING_LOCATION) ??
+		DEFAULT_PROCESSING_LOCATION;
+	const normalized = value.toLowerCase() as DatalabProcessingLocation;
+	if (!DATALAB_LOCATION_VALUES.has(normalized)) {
+		throw new Error(
+			`Failed to parse DATALAB_PROCESSING_LOCATION: expected "eu" or "us", got "${value}"`,
+		);
+	}
+	return normalized;
+}
+
+export function normalizeDatalabMode(value: unknown): DatalabMode {
+	const raw = normalizeString(value);
+	const normalized = raw ? (raw.toLowerCase() as DatalabMode) : null;
+	if (normalized && DATALAB_MODE_VALUES.has(normalized)) return normalized;
+	if (normalized === null) return DEFAULT_DATALAB_MODE;
+	throw new Error(
+		`Failed to parse datalab mode: expected "fast", "balanced", or "accurate", got "${value}"`,
+	);
+}
+
+export interface DatalabPDFExtractOptions {
+	maxPages: number;
+	title: string;
+	signal?: AbortSignal;
+	timeoutMs?: number;
+	mode?: DatalabMode;
+	processingLocation?: DatalabProcessingLocation;
+}
+
+export interface DatalabPDFExtractResult {
+	markdown: string;
+	pages: number;
+	parseQualityScore?: number;
+}
+
+interface DatalabUploadRequest {
+	file_id?: unknown;
+	upload_url?: unknown;
+	reference?: unknown;
+}
+
+interface DatalabConfirmResponse {
+	file_id?: unknown;
+	reference?: unknown;
+}
+
+interface DatalabConversionState {
+	status?: unknown;
+	success?: unknown;
+	request_check_url?: unknown;
+	markdown?: unknown;
+	page_count?: unknown;
+	parse_quality_score?: unknown;
+	error?: unknown;
+}
+
+/**
+ * Convert a PDF buffer to Markdown through the Datalab hosted API.
+ *
+ * Datalab converts documents with a dedicated extraction engine (Marker),
+ * which preserves tables, multi-column reading order, headings, and math
+ * where the local `unpdf` fallback only produces flattened text. Conversion
+ * is deterministic (no LLM transcription drift), and `accurate` mode handles
+ * scanned pages. Completed responses may include a `parse_quality_score` (0–5)
+ * for quality gating. Billing is per processed page; the free tier includes a
+ * monthly credit (see README) so light use costs nothing.
+ *
+ * The flow is:
+ *   1. request a presigned upload URL for the selected processing region,
+ *   2. PUT the PDF bytes directly to storage,
+ *   3. confirm the upload to obtain a `datalab://` reference,
+ *   4. submit the conversion with that reference, then
+ *   5. poll the returned `request_check_url` until `complete` or `failed`.
+ *
+ * The processing region is fixed at the upload step (US by default; set
+ * `DATALAB_PROCESSING_LOCATION=eu` for EU data residency). The convert step
+ * deliberately omits `processing_location` because the API rejects multipart form data that
+ * carries it; the server processes the file from the storage region it was
+ * uploaded to. The uploaded file is deleted best-effort after conversion.
+ * The caller's signal and a shared deadline bound the whole exchange.
+ */
+export async function extractPDFViaDatalab(
+	buffer: ArrayBuffer,
+	options: DatalabPDFExtractOptions,
+): Promise<DatalabPDFExtractResult> {
+	options.signal?.throwIfAborted();
+	const apiKey = await getDatalabApiKey(options.signal);
+	options.signal?.throwIfAborted();
+	if (!apiKey) {
+		throw new Error(
+			"Datalab PDF conversion requires a configured Datalab API key",
+		);
+	}
+
+	const mode = options.mode ?? normalizeDatalabMode(process.env.DATALAB_MODE);
+	const processingLocation =
+		options.processingLocation ?? getDatalabProcessingLocation();
+	const timeoutMs =
+		Number.isFinite(options.timeoutMs) && (options.timeoutMs ?? 0) > 0
+			? Math.floor(options.timeoutMs ?? 0)
+			: DEFAULT_TIMEOUT_MS;
+	const deadline = Date.now() + timeoutMs;
+
+	const upload = await requestUploadUrl({
+		apiKey,
+		title: options.title,
+		processingLocation,
+		signal: options.signal,
+		deadline,
+	});
+	if (typeof upload.upload_url !== "string" || !upload.upload_url) {
+		throw new Error("Datalab PDF conversion failed: missing upload_url");
+	}
+	const uploadFileId = normalizeFileId(upload.file_id);
+	if (!uploadFileId) {
+		throw new Error("Datalab PDF conversion failed: missing file_id");
+	}
+
+	let fileId = uploadFileId;
+	let reference = normalizeString(upload.reference);
+
+	try {
+		const put = await fetchDatalab(
+			upload.upload_url,
+			{
+				method: "PUT",
+				headers: { "content-type": "application/pdf" },
+				body: new Blob([buffer], { type: "application/pdf" }),
+				signal: withTimeout(options.signal, remaining(deadline)),
+			},
+			apiKey,
+		);
+		if (!put.ok) {
+			throw new Error(
+				`Datalab PDF upload failed: HTTP ${put.status} ${put.statusText}`,
+			);
+		}
+
+		const confirmed = await confirmUpload(
+			apiKey,
+			String(fileId),
+			options.signal,
+			deadline,
+		);
+		fileId = normalizeFileId(confirmed.file_id) ?? fileId;
+		reference = normalizeString(confirmed.reference) ?? reference;
+		if (!reference) {
+			throw new Error("Datalab PDF conversion failed: missing file reference");
+		}
+
+		const form = new FormData();
+		form.append("file_url", reference);
+		form.append("output_format", "markdown");
+		form.append("mode", mode);
+		form.append("max_pages", String(options.maxPages));
+		form.append("paginate", "true");
+
+		// The conversion itself must NOT repeat processing_location: the API
+		// rejects multipart form data carrying processing_location (HTTP 403).
+		// The region was already fixed when the presigned upload was issued for
+		// storage in the selected region, so the server processes the file
+		// wherever it was stored (US by default; use the env override for EU).
+
+		const submit = await fetchDatalab(
+			`${getDatalabApiBase()}/convert`,
+			{
+				method: "POST",
+				headers: { "x-api-key": apiKey },
+				body: form,
+				signal: withTimeout(options.signal, remaining(deadline)),
+			},
+			apiKey,
+		);
+		const state = await readJsonResponse(submit, apiKey);
+
+		// The submit response is an acceptance ack ({ success: true,
+		// request_check_url }) with no status field and no markdown; only the
+		// polled result carries a status. Key on status, never on success.
+		if (state.status === "complete") return toResult(state);
+		if (state.status === "failed") {
+			throw new Error(
+				`Datalab PDF conversion failed: ${state.error ?? "unknown error"}`,
+			);
+		}
+
+		const checkUrl = normalizeCheckUrl(state.request_check_url);
+		while (Date.now() < deadline) {
+			await sleep(DEFAULT_POLL_INTERVAL_MS, options.signal);
+			const poll = await fetchDatalab(
+				checkUrl,
+				{
+					method: "GET",
+					headers: { "x-api-key": apiKey },
+					signal: withTimeout(options.signal, remaining(deadline)),
+				},
+				apiKey,
+			);
+			const next = await readJsonResponse(poll, apiKey);
+			if (next.status === "complete") return toResult(next);
+			if (next.status === "failed") {
+				throw new Error(
+					`Datalab PDF conversion failed: ${next.error ?? "unknown error"}`,
+				);
+			}
+		}
+
+		throw new Error("Datalab PDF conversion timed out");
+	} finally {
+		if (fileId !== undefined && fileId !== null) {
+			await deleteDatalabFile(apiKey, String(fileId));
+		}
+	}
+}
+
+async function requestUploadUrl(options: {
+	apiKey: string;
+	title: string;
+	processingLocation: DatalabProcessingLocation;
+	signal: AbortSignal | undefined;
+	deadline: number;
+}): Promise<DatalabUploadRequest> {
+	const { apiKey, title, processingLocation, signal, deadline } = options;
+	const response = await fetchDatalab(
+		`${getDatalabApiBase()}/files/upload`,
+		{
+			method: "POST",
+			headers: {
+				"x-api-key": apiKey,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				filename: `${datalabFilename(title)}.pdf`,
+				content_type: "application/pdf",
+				processing_location: processingLocation,
+			}),
+			signal: withTimeout(signal, remaining(deadline)),
+		},
+		apiKey,
+	);
+	return readJsonResponse(response, apiKey) as Promise<DatalabUploadRequest>;
+}
+
+async function confirmUpload(
+	apiKey: string,
+	fileId: string,
+	signal: AbortSignal | undefined,
+	deadline: number,
+): Promise<DatalabConfirmResponse> {
+	const response = await fetchDatalab(
+		`${getDatalabApiBase()}/files/${encodeURIComponent(fileId)}/confirm`,
+		{
+			method: "GET",
+			headers: { "x-api-key": apiKey },
+			signal: withTimeout(signal, remaining(deadline)),
+		},
+		apiKey,
+	);
+	return readJsonResponse(response, apiKey) as Promise<DatalabConfirmResponse>;
+}
+
+async function deleteDatalabFile(
+	apiKey: string,
+	fileId: string,
+): Promise<void> {
+	try {
+		await fetchDatalab(
+			`${getDatalabApiBase()}/files/${encodeURIComponent(fileId)}`,
+			{
+				method: "DELETE",
+				headers: { "x-api-key": apiKey },
+				signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS),
+			},
+			apiKey,
+		);
+	} catch {
+		// Best-effort cleanup; a leftover file is not worth failing the conversion.
+	}
+}
+
+function toResult(state: DatalabConversionState): DatalabPDFExtractResult {
+	const markdown = normalizeString(state.markdown);
+	if (!markdown) {
+		throw new Error("Datalab PDF conversion returned empty markdown");
+	}
+	const quality = state.parse_quality_score;
+	return {
+		markdown,
+		pages: numericField(state.page_count) ?? countPageMarkers(markdown),
+		...(typeof quality === "number" && Number.isFinite(quality)
+			? { parseQualityScore: quality }
+			: {}),
+	};
+}
+
+function numericField(value: unknown): number | null {
+	return typeof value === "number" && Number.isFinite(value) && value > 0
+		? Math.floor(value)
+		: null;
+}
+
+function countPageMarkers(markdown: string): number {
+	return [...markdown.matchAll(/^<!-- Page (\d+) -->$/gm)].length;
+}
+
+function normalizeCheckUrl(value: unknown): string {
+	if (typeof value !== "string" || !value.trim()) {
+		throw new Error("Datalab PDF conversion failed: missing request_check_url");
+	}
+	const apiBase = getDatalabApiUrl();
+	let checkUrl: URL;
+	try {
+		checkUrl = new URL(value.trim(), apiBase);
+	} catch {
+		throw new Error("Datalab PDF conversion failed: invalid request_check_url");
+	}
+	if (checkUrl.origin !== apiBase.origin) {
+		throw new Error(
+			"Datalab PDF conversion failed: request_check_url has an unexpected origin",
+		);
+	}
+	return checkUrl.toString();
+}
+
+function getDatalabApiUrl(): URL {
+	try {
+		return new URL(getDatalabApiBase());
+	} catch {
+		throw new Error(
+			"Failed to parse DATALAB_API_BASE: expected an absolute URL",
+		);
+	}
+}
+
+function remaining(deadline: number): number {
+	return Math.max(1, deadline - Date.now());
+}
+
+function withTimeout(
+	signal: AbortSignal | undefined,
+	timeoutMs: number,
+): AbortSignal {
+	const timeout = AbortSignal.timeout(timeoutMs);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		let timer: ReturnType<typeof setTimeout>;
+		const cleanup = () => signal?.removeEventListener("abort", onAbort);
+		const onTimeout = () => {
+			cleanup();
+			resolve();
+		};
+		const onAbort = () => {
+			clearTimeout(timer);
+			cleanup();
+			reject(signal?.reason);
+		};
+
+		if (signal?.aborted) {
+			onAbort();
+			return;
+		}
+		timer = setTimeout(onTimeout, ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+async function fetchDatalab(
+	url: string,
+	init: RequestInit,
+	apiKey: string,
+): Promise<Response> {
+	try {
+		return await fetch(url, { ...init, redirect: init.redirect ?? "error" });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const redacted = redactCredential(message, apiKey);
+		if (redacted === message) throw error;
+		const redactedError = new Error(redacted);
+		if (error instanceof Error) redactedError.name = error.name;
+		throw redactedError;
+	}
+}
+
+async function readJsonResponse(
+	response: Response,
+	apiKey: string,
+): Promise<Record<string, unknown>> {
+	const text = await readResponseText(response);
+	if (!response.ok) {
+		const detail = text.trim().slice(0, MAX_ERROR_BODY_BYTES);
+		const message = detail
+			? `Datalab PDF conversion failed: HTTP ${response.status} ${response.statusText}: ${detail}`
+			: `Datalab PDF conversion failed: HTTP ${response.status} ${response.statusText}`;
+		throw new Error(redactCredential(message, apiKey));
+	}
+	try {
+		return JSON.parse(text) as Record<string, unknown>;
+	} catch {
+		throw new Error("Datalab PDF conversion returned invalid JSON");
+	}
+}
+
+async function readResponseText(response: Response): Promise<string> {
+	const contentLength = Number(response.headers.get("content-length"));
+	if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
+		throw new Error("Datalab PDF conversion response too large");
+	}
+	if (!response.body) return "";
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	const chunks: string[] = [];
+	let bytesRead = 0;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			bytesRead += value.byteLength;
+			if (bytesRead > MAX_RESPONSE_BYTES) {
+				try {
+					await reader.cancel();
+				} catch {
+					// The response is already too large; cancellation is best-effort.
+				}
+				throw new Error("Datalab PDF conversion response too large");
+			}
+			chunks.push(decoder.decode(value, { stream: true }));
+		}
+		chunks.push(decoder.decode());
+		return chunks.join("");
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+function datalabFilename(title: string): string {
+	return (
+		title
+			.toLowerCase()
+			.replace(/[^a-z0-9\s-]/g, "")
+			.replace(/\s+/g, "-")
+			.replace(/-+/g, "-")
+			.replace(/^-|-$/g, "")
+			.slice(0, 60) || "document"
+	);
+}

--- a/pdf-extract.ts
+++ b/pdf-extract.ts
@@ -1,8 +1,10 @@
 /**
  * PDF Content Extractor
  *
- * Uses Gemini for structured PDF-to-Markdown conversion when configured,
- * with unpdf as the deterministic local fallback.
+ * Converts PDFs to Markdown. The `auto` provider chain runs Datalab
+ * (deterministic, layout-aware) first, then Gemini API, with unpdf as the
+ * deterministic local fallback; the chain can also be pinned with
+ * `pdf.provider`.
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -10,31 +12,52 @@ import { writeFile, mkdir } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
 import { CredentialResolutionError } from "./credential-source.ts";
+import {
+	DATALAB_MODE_VALUES,
+	DEFAULT_DATALAB_TIMEOUT_MS,
+	isDatalabApiAvailable,
+	normalizeDatalabMode,
+	extractPDFViaDatalab,
+	type DatalabMode,
+} from "./datalab-pdf-extract.ts";
 import { isGeminiApiAvailable } from "./gemini-api.ts";
 import { extractPDFViaGemini } from "./gemini-pdf-extract.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
 export interface PDFExtractResult {
-  title: string;
-  pages: number;
-  chars: number;
-  outputPath: string;
+	title: string;
+	pages: number;
+	chars: number;
+	outputPath: string;
 }
 
 export interface PDFExtractOptions {
-  maxPages?: number;
-  outputDir?: string;
-  filename?: string;
-  signal?: AbortSignal;
-  geminiTimeoutMs?: number;
+	maxPages?: number;
+	outputDir?: string;
+	filename?: string;
+	signal?: AbortSignal;
+	geminiTimeoutMs?: number;
 }
 
+export type PDFProvider = "auto" | "gemini" | "datalab" | "unpdf";
+
+export const PDF_PROVIDER_VALUES = new Set<PDFProvider>([
+	"auto",
+	"gemini",
+	"datalab",
+	"unpdf",
+]);
+
 export interface PDFConfig {
-  maxSizeMB: number;
+	maxSizeMB: number;
+	provider: PDFProvider;
+	datalabMode: DatalabMode;
+	datalabTimeoutMs: number;
 }
 
 export const DEFAULT_PDF_MAX_SIZE_MB = 20;
 export const MAX_PDF_MAX_SIZE_MB = 50;
+export const MAX_DATALAB_TIMEOUT_MS = 300_000;
 const DEFAULT_MAX_PAGES = 100;
 const DEFAULT_OUTPUT_DIR = join(tmpdir(), "pi-web-pdf");
 const CONFIG_PATH = getWebSearchConfigPath();
@@ -43,255 +66,332 @@ const PAGE_MARKER_PATTERN = /^<!-- Page (\d+) -->$/gm;
 let cachedPDFConfig: PDFConfig | null = null;
 
 export function loadPDFConfig(): PDFConfig {
-  if (cachedPDFConfig) return { ...cachedPDFConfig };
-  if (!existsSync(CONFIG_PATH)) {
-    cachedPDFConfig = { maxSizeMB: DEFAULT_PDF_MAX_SIZE_MB };
-    return { ...cachedPDFConfig };
-  }
+	if (cachedPDFConfig) return { ...cachedPDFConfig };
+	if (!existsSync(CONFIG_PATH)) {
+		cachedPDFConfig = {
+			maxSizeMB: DEFAULT_PDF_MAX_SIZE_MB,
+			provider: "auto",
+			datalabMode: normalizeDatalabMode(process.env.DATALAB_MODE),
+			datalabTimeoutMs: DEFAULT_DATALAB_TIMEOUT_MS,
+		};
+		return { ...cachedPDFConfig };
+	}
 
-  const rawText = readFileSync(CONFIG_PATH, "utf-8");
-  let raw: unknown;
-  try {
-    raw = JSON.parse(rawText) as unknown;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
-  }
+	const rawText = readFileSync(CONFIG_PATH, "utf-8");
+	let raw: unknown;
+	try {
+		raw = JSON.parse(rawText) as unknown;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
 
-  const root = raw && typeof raw === "object" ? raw as Record<string, unknown> : {};
-  const pdf = root.pdf && typeof root.pdf === "object"
-    ? root.pdf as Record<string, unknown>
-    : {};
-  const configured = pdf.maxSizeMB;
-  const normalized = typeof configured === "number" && Number.isFinite(configured) && configured > 0
-    ? Math.min(configured, MAX_PDF_MAX_SIZE_MB)
-    : DEFAULT_PDF_MAX_SIZE_MB;
+	const root =
+		raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+	const pdf =
+		root.pdf && typeof root.pdf === "object"
+			? (root.pdf as Record<string, unknown>)
+			: {};
+	const configured = pdf.maxSizeMB;
+	const normalized =
+		typeof configured === "number" &&
+		Number.isFinite(configured) &&
+		configured > 0
+			? Math.min(configured, MAX_PDF_MAX_SIZE_MB)
+			: DEFAULT_PDF_MAX_SIZE_MB;
 
-  cachedPDFConfig = { maxSizeMB: normalized };
-  return { ...cachedPDFConfig };
+	const provider =
+		typeof pdf.provider === "string" &&
+		PDF_PROVIDER_VALUES.has(pdf.provider as PDFProvider)
+			? (pdf.provider as PDFProvider)
+			: "auto";
+	const datalabMode =
+		typeof pdf.datalabMode === "string" &&
+		DATALAB_MODE_VALUES.has(pdf.datalabMode as DatalabMode)
+			? (pdf.datalabMode as DatalabMode)
+			: normalizeDatalabMode(process.env.DATALAB_MODE);
+	const configuredTimeout = pdf.datalabTimeoutMs;
+	const datalabTimeoutMs =
+		typeof configuredTimeout === "number" &&
+		Number.isFinite(configuredTimeout) &&
+		configuredTimeout > 0
+			? Math.min(configuredTimeout, MAX_DATALAB_TIMEOUT_MS)
+			: DEFAULT_DATALAB_TIMEOUT_MS;
+
+	cachedPDFConfig = {
+		maxSizeMB: normalized,
+		provider,
+		datalabMode,
+		datalabTimeoutMs,
+	};
+	return { ...cachedPDFConfig };
 }
 
 async function getUnpdf() {
-  if (typeof (Promise as PromiseConstructor & { try?: unknown }).try !== "function") {
-    const { default: promiseTry } = await import("promise.try");
-    promiseTry.shim();
-  }
+	if (
+		typeof (Promise as PromiseConstructor & { try?: unknown }).try !==
+		"function"
+	) {
+		const { default: promiseTry } = await import("promise.try");
+		promiseTry.shim();
+	}
 
-  const [unpdf, pdfjs] = await Promise.all([
-    import("unpdf"),
-    import("unpdf/pdfjs"),
-  ]);
-  const { VerbosityLevel } = pdfjs as typeof pdfjs & { VerbosityLevel: { ERRORS: number } };
+	const [unpdf, pdfjs] = await Promise.all([
+		import("unpdf"),
+		import("unpdf/pdfjs"),
+	]);
+	const { VerbosityLevel } = pdfjs as typeof pdfjs & {
+		VerbosityLevel: { ERRORS: number };
+	};
 
-  return { getDocumentProxy: unpdf.getDocumentProxy, VerbosityLevel };
+	return { getDocumentProxy: unpdf.getDocumentProxy, VerbosityLevel };
 }
 
 /**
  * Extract text from a PDF buffer and save it to a Markdown file.
  */
 export async function extractPDFToMarkdown(
-  buffer: ArrayBuffer,
-  url: string,
-  options: PDFExtractOptions = {}
+	buffer: ArrayBuffer,
+	url: string,
+	options: PDFExtractOptions = {},
 ): Promise<PDFExtractResult> {
-  const {
-    maxPages = DEFAULT_MAX_PAGES,
-    outputDir = DEFAULT_OUTPUT_DIR,
-    filename,
-    signal,
-    geminiTimeoutMs,
-  } = options;
+	const {
+		maxPages = DEFAULT_MAX_PAGES,
+		outputDir = DEFAULT_OUTPUT_DIR,
+		filename,
+		signal,
+		geminiTimeoutMs,
+	} = options;
 
-  const safeMaxPages = Number.isFinite(maxPages)
-    ? Math.max(1, Math.floor(maxPages))
-    : DEFAULT_MAX_PAGES;
-  const urlTitle = extractTitleFromURL(url);
+	const safeMaxPages = Number.isFinite(maxPages)
+		? Math.max(1, Math.floor(maxPages))
+		: DEFAULT_MAX_PAGES;
+	const urlTitle = extractTitleFromURL(url);
+	const pdfConfig = loadPDFConfig();
+	const provider = pdfConfig.provider;
 
-  try {
-    if (isGeminiApiAvailable()) {
-      const markdownBody = await extractPDFViaGemini(buffer, {
-        maxPages: safeMaxPages,
-        title: urlTitle,
-        ...(signal ? { signal } : {}),
-        ...(geminiTimeoutMs !== undefined ? { timeoutMs: geminiTimeoutMs } : {}),
-      });
-      return writeMarkdownResult({
-        markdownBody,
-        title: urlTitle,
-        pages: countPageMarkers(markdownBody),
-        outputDir,
-        filename,
-        url,
-      });
-    }
-  } catch (err) {
-    if (shouldRethrowGeminiError(err, signal)) throw err;
-  }
+	if (provider === "auto" || provider === "datalab") {
+		try {
+			if (isDatalabApiAvailable()) {
+				const result = await extractPDFViaDatalab(buffer, {
+					maxPages: safeMaxPages,
+					title: urlTitle,
+					mode: pdfConfig.datalabMode,
+					timeoutMs: pdfConfig.datalabTimeoutMs,
+					...(signal ? { signal } : {}),
+				});
+				return writeMarkdownResult({
+					markdownBody: result.markdown,
+					title: urlTitle,
+					pages: result.pages,
+					outputDir,
+					filename,
+					url,
+				});
+			}
+		} catch (err) {
+			if (shouldRethrowExtractionError(err, signal)) throw err;
+		}
+	}
 
-  const { getDocumentProxy, VerbosityLevel } = await getUnpdf();
-  const pdf = await getDocumentProxy(new Uint8Array(buffer), {
-    verbosity: VerbosityLevel.ERRORS,
-  });
-  const metadata = await pdf.getMetadata();
-  const metadataInfo = metadata.info && typeof metadata.info === "object"
-    ? metadata.info as Record<string, unknown>
-    : null;
+	if (provider === "auto" || provider === "gemini") {
+		try {
+			if (isGeminiApiAvailable()) {
+				const markdownBody = await extractPDFViaGemini(buffer, {
+					maxPages: safeMaxPages,
+					title: urlTitle,
+					...(signal ? { signal } : {}),
+					...(geminiTimeoutMs !== undefined
+						? { timeoutMs: geminiTimeoutMs }
+						: {}),
+				});
+				return writeMarkdownResult({
+					markdownBody,
+					title: urlTitle,
+					pages: countPageMarkers(markdownBody),
+					outputDir,
+					filename,
+					url,
+				});
+			}
+		} catch (err) {
+			if (shouldRethrowExtractionError(err, signal)) throw err;
+		}
+	}
 
-  const metaTitle = typeof metadataInfo?.Title === "string" ? metadataInfo.Title : undefined;
-  const metaAuthor = typeof metadataInfo?.Author === "string" ? metadataInfo.Author : undefined;
-  const title = metaTitle?.trim() || urlTitle;
-  const pagesToExtract = Math.min(pdf.numPages, safeMaxPages);
-  const truncated = pdf.numPages > safeMaxPages;
-  const pages: { pageNum: number; text: string }[] = [];
+	const { getDocumentProxy, VerbosityLevel } = await getUnpdf();
+	const pdf = await getDocumentProxy(new Uint8Array(buffer), {
+		verbosity: VerbosityLevel.ERRORS,
+	});
+	const metadata = await pdf.getMetadata();
+	const metadataInfo =
+		metadata.info && typeof metadata.info === "object"
+			? (metadata.info as Record<string, unknown>)
+			: null;
 
-  for (let i = 1; i <= pagesToExtract; i++) {
-    const page = await pdf.getPage(i);
-    const textContent = await page.getTextContent();
-    const pageText = textContent.items
-      .map((item: unknown) => {
-        const textItem = item as { str?: string };
-        return textItem.str || "";
-      })
-      .join(" ")
-      .replace(/\s+/g, " ")
-      .trim();
+	const metaTitle =
+		typeof metadataInfo?.Title === "string" ? metadataInfo.Title : undefined;
+	const metaAuthor =
+		typeof metadataInfo?.Author === "string" ? metadataInfo.Author : undefined;
+	const title = metaTitle?.trim() || urlTitle;
+	const pagesToExtract = Math.min(pdf.numPages, safeMaxPages);
+	const truncated = pdf.numPages > safeMaxPages;
+	const pages: { pageNum: number; text: string }[] = [];
 
-    if (pageText) {
-      pages.push({ pageNum: i, text: pageText });
-    }
-  }
+	for (let i = 1; i <= pagesToExtract; i++) {
+		const page = await pdf.getPage(i);
+		const textContent = await page.getTextContent();
+		const pageText = textContent.items
+			.map((item: unknown) => {
+				const textItem = item as { str?: string };
+				return textItem.str || "";
+			})
+			.join(" ")
+			.replace(/\s+/g, " ")
+			.trim();
 
-  const bodyLines: string[] = [];
-  for (let i = 0; i < pages.length; i++) {
-    if (i > 0) {
-      bodyLines.push("");
-      bodyLines.push(`<!-- Page ${pages[i].pageNum} -->`);
-      bodyLines.push("");
-    }
-    bodyLines.push(pages[i].text);
-  }
+		if (pageText) {
+			pages.push({ pageNum: i, text: pageText });
+		}
+	}
 
-  return writeMarkdownResult({
-    markdownBody: bodyLines.join("\n"),
-    title,
-    pages: pdf.numPages,
-    outputDir,
-    filename,
-    url,
-    metaAuthor,
-    truncated,
-    pagesToExtract,
-  });
+	const bodyLines: string[] = [];
+	for (let i = 0; i < pages.length; i++) {
+		if (i > 0) {
+			bodyLines.push("");
+			bodyLines.push(`<!-- Page ${pages[i].pageNum} -->`);
+			bodyLines.push("");
+		}
+		bodyLines.push(pages[i].text);
+	}
+
+	return writeMarkdownResult({
+		markdownBody: bodyLines.join("\n"),
+		title,
+		pages: pdf.numPages,
+		outputDir,
+		filename,
+		url,
+		metaAuthor,
+		truncated,
+		pagesToExtract,
+	});
 }
 
 async function writeMarkdownResult(options: {
-  markdownBody: string;
-  title: string;
-  pages: number;
-  outputDir: string;
-  filename?: string;
-  url: string;
-  metaAuthor?: string;
-  truncated?: boolean;
-  pagesToExtract?: number;
+	markdownBody: string;
+	title: string;
+	pages: number;
+	outputDir: string;
+	filename?: string;
+	url: string;
+	metaAuthor?: string;
+	truncated?: boolean;
+	pagesToExtract?: number;
 }): Promise<PDFExtractResult> {
-  const lines: string[] = [];
-  lines.push(`# ${options.title}`);
-  lines.push("");
-  lines.push(`> Source: ${options.url}`);
-  lines.push(`> Pages: ${options.pages}${options.truncated ? ` (extracted first ${options.pagesToExtract})` : ""}`);
-  if (options.metaAuthor) lines.push(`> Author: ${options.metaAuthor}`);
-  lines.push("");
-  lines.push("---");
-  lines.push("");
-  if (options.markdownBody) lines.push(options.markdownBody);
+	const lines: string[] = [];
+	lines.push(`# ${options.title}`);
+	lines.push("");
+	lines.push(`> Source: ${options.url}`);
+	lines.push(
+		`> Pages: ${options.pages}${options.truncated ? ` (extracted first ${options.pagesToExtract})` : ""}`,
+	);
+	if (options.metaAuthor) lines.push(`> Author: ${options.metaAuthor}`);
+	lines.push("");
+	lines.push("---");
+	lines.push("");
+	if (options.markdownBody) lines.push(options.markdownBody);
 
-  if (options.truncated) {
-    lines.push("");
-    lines.push("---");
-    lines.push("");
-    lines.push(`*[Truncated: Only first ${options.pagesToExtract} of ${options.pages} pages extracted]*`);
-  }
+	if (options.truncated) {
+		lines.push("");
+		lines.push("---");
+		lines.push("");
+		lines.push(
+			`*[Truncated: Only first ${options.pagesToExtract} of ${options.pages} pages extracted]*`,
+		);
+	}
 
-  const content = lines.join("\n");
-  const outputFilename = options.filename || sanitizeFilename(options.title) + ".md";
-  const outputPath = join(options.outputDir, outputFilename);
+	const content = lines.join("\n");
+	const outputFilename =
+		options.filename || sanitizeFilename(options.title) + ".md";
+	const outputPath = join(options.outputDir, outputFilename);
 
-  await mkdir(options.outputDir, { recursive: true });
-  await writeFile(outputPath, content, "utf-8");
+	await mkdir(options.outputDir, { recursive: true });
+	await writeFile(outputPath, content, "utf-8");
 
-  return {
-    title: options.title,
-    pages: options.pages,
-    chars: content.length,
-    outputPath,
-  };
+	return {
+		title: options.title,
+		pages: options.pages,
+		chars: content.length,
+		outputPath,
+	};
 }
 
 function countPageMarkers(markdown: string): number {
-  return [...markdown.matchAll(PAGE_MARKER_PATTERN)].length;
+	return [...markdown.matchAll(PAGE_MARKER_PATTERN)].length;
 }
 
-function shouldRethrowGeminiError(err: unknown, signal?: AbortSignal): boolean {
-  if (signal?.aborted) return true;
-  if (err instanceof CredentialResolutionError) return true;
-  const message = err instanceof Error ? err.message : String(err);
-  return message.startsWith("Failed to parse ");
+function shouldRethrowExtractionError(
+	err: unknown,
+	signal?: AbortSignal,
+): boolean {
+	if (signal?.aborted) return true;
+	if (err instanceof CredentialResolutionError) return true;
+	const message = err instanceof Error ? err.message : String(err);
+	return message.startsWith("Failed to parse ");
 }
 
 /**
  * Extract a reasonable title from URL
  */
 function extractTitleFromURL(url: string): string {
-  try {
-    const urlObj = new URL(url);
-    const pathname = urlObj.pathname;
+	try {
+		const urlObj = new URL(url);
+		const pathname = urlObj.pathname;
 
-    let filename = basename(pathname, ".pdf");
+		let filename = basename(pathname, ".pdf");
 
-    if (urlObj.hostname.includes("arxiv.org")) {
-      const match = pathname.match(/\/(?:pdf|abs)\/(\d+\.\d+)/);
-      if (match) {
-        filename = `arxiv-${match[1]}`;
-      }
-    }
+		if (urlObj.hostname.includes("arxiv.org")) {
+			const match = pathname.match(/\/(?:pdf|abs)\/(\d+\.\d+)/);
+			if (match) {
+				filename = `arxiv-${match[1]}`;
+			}
+		}
 
-    filename = filename
-      .replace(/[_-]+/g, " ")
-      .replace(/\s+/g, " ")
-      .trim();
+		filename = filename.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
 
-    return filename || "document";
-  } catch {
-    return "document";
-  }
+		return filename || "document";
+	} catch {
+		return "document";
+	}
 }
 
 /**
  * Sanitize string for use as filename
  */
 function sanitizeFilename(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .slice(0, 100)
-    .replace(/^-|-$/g, "")
-    || "document";
+	return (
+		name
+			.toLowerCase()
+			.replace(/[^a-z0-9\s-]/g, "")
+			.replace(/\s+/g, "-")
+			.replace(/-+/g, "-")
+			.slice(0, 100)
+			.replace(/^-|-$/g, "") || "document"
+	);
 }
 
 /**
  * Check if URL or content-type indicates a PDF
  */
 export function isPDF(url: string, contentType?: string): boolean {
-  if (contentType?.includes("application/pdf")) {
-    return true;
-  }
-  try {
-    const urlObj = new URL(url);
-    return urlObj.pathname.toLowerCase().endsWith(".pdf");
-  } catch {
-    return false;
-  }
+	if (contentType?.includes("application/pdf")) {
+		return true;
+	}
+	try {
+		const urlObj = new URL(url);
+		return urlObj.pathname.toLowerCase().endsWith(".pdf");
+	} catch {
+		return false;
+	}
 }

--- a/test/brightdata-unlocker.test.mjs
+++ b/test/brightdata-unlocker.test.mjs
@@ -6,7 +6,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 
-const brightdataModuleUrl = new URL("../brightdata-unlocker.ts", import.meta.url).href;
+const brightdataModuleUrl = new URL(
+	"../brightdata-unlocker.ts",
+	import.meta.url,
+).href;
 const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
 
 // Scrubbing the env vars is not enough on its own: a `brightdataApiKey` written
@@ -15,15 +18,31 @@ const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
 // would resolve their own credential (and run their own resolver command)
 // inside these tests. Every child therefore starts from an empty home unless a
 // test hands it a purpose-built one.
-const EMPTY_HOME = mkdtempSync(join(tmpdir(), "pi-web-access-brightdata-empty-home-"));
+const EMPTY_HOME = mkdtempSync(
+	join(tmpdir(), "pi-web-access-brightdata-empty-home-"),
+);
 
 function runChild(script, env = {}) {
-	const childEnv = { ...process.env, HOME: EMPTY_HOME, USERPROFILE: EMPTY_HOME };
+	const childEnv = {
+		...process.env,
+		HOME: EMPTY_HOME,
+		USERPROFILE: EMPTY_HOME,
+	};
 	for (const key of [
-		"PI_CODING_AGENT_DIR", "XDG_CONFIG_HOME", "BRIGHTDATA_API_KEY", "KAGI_API_KEY", "OLLAMA_API_KEY", "BRIGHTDATA_UNLOCKER_ZONE",
-		"BRIGHTDATA_SERP_ZONE", "FIRECRAWL_BASE_URL", "FIRECRAWL_API_KEY", "PARALLEL_API_KEY",
-		"TINYFISH_API_KEY", "GEMINI_API_KEY",
-	]) delete childEnv[key];
+		"PI_CODING_AGENT_DIR",
+		"XDG_CONFIG_HOME",
+		"BRIGHTDATA_API_KEY",
+		"KAGI_API_KEY",
+		"OLLAMA_API_KEY",
+		"BRIGHTDATA_UNLOCKER_ZONE",
+		"BRIGHTDATA_SERP_ZONE",
+		"FIRECRAWL_BASE_URL",
+		"FIRECRAWL_API_KEY",
+		"PARALLEL_API_KEY",
+		"TINYFISH_API_KEY",
+		"GEMINI_API_KEY",
+	])
+		delete childEnv[key];
 	Object.assign(childEnv, env);
 	return spawnSync(process.execPath, ["--input-type=module"], {
 		input: script,
@@ -37,12 +56,17 @@ const PUBLIC_LOOKUP = `async () => [{ address: "93.184.216.34", family: 4 }]`;
 
 async function configHome(config) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-brightdata-"));
-	await writeFile(join(home, "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	await writeFile(
+		join(home, "web-search.json"),
+		JSON.stringify(config) + "\n",
+		"utf8",
+	);
 	return home;
 }
 
 test("Bright Data Web Unlocker maps markdown and sends the credential and Unlocker zone", async () => {
-	const child = runChild(`
+	const child = runChild(
+		`
 		let captured = null;
 		globalThis.fetch = async (url, init) => {
 			captured = { url: String(url), method: init.method, redirect: init.redirect, headers: Object.fromEntries(new Headers(init.headers)), body: JSON.parse(init.body) };
@@ -53,7 +77,12 @@ test("Bright Data Web Unlocker maps markdown and sends the credential and Unlock
 			lookup: ${PUBLIC_LOOKUP},
 		});
 		console.log(JSON.stringify({ captured, result }));
-	`, { BRIGHTDATA_API_KEY: "bd-test-key", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-test-key",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.equal(output.captured.url, "https://api.brightdata.com/request");
@@ -87,7 +116,8 @@ test("Bright Data Web Unlocker maps markdown and sends the credential and Unlock
 });
 
 test("Bright Data Web Unlocker rejects private targets without invoking the paid API", async () => {
-	const child = runChild(`
+	const child = runChild(
+		`
 		let fetchCalls = 0;
 		globalThis.fetch = async () => { fetchCalls++; return new Response("# Should never happen", { status: 200 }); };
 		const { extractWithBrightDataUnlocker } = await import(${JSON.stringify(brightdataModuleUrl)});
@@ -102,7 +132,12 @@ test("Bright Data Web Unlocker rejects private targets without invoking the paid
 		try { await extractWithBrightDataUnlocker("https://rebind.example.com/", undefined, { lookup: async () => [{ address: "93.184.216.34", family: 4 }, { address: "192.168.1.10", family: 4 }] }); }
 		catch (err) { errors.push(err.message); }
 		console.log(JSON.stringify({ errors, fetchCalls }));
-	`, { BRIGHTDATA_API_KEY: "bd-test-key", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-test-key",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	// The stub fetch succeeds, so a zero call count can only mean the guard ran first.
@@ -125,14 +160,20 @@ test("Bright Data Web Unlocker rejects private targets without invoking the paid
 // up-front guard or if "Blocked internal address" is made a recoverable error
 // the chain continues past.
 test("Bright Data Web Unlocker is not reached for a blocked target through fetch_content", async () => {
-	const home = await configHome({ brightdataApiKey: "bd-test-key", brightdataUnlockerZone: "pi_unlocker" });
-	const child = runChild(`
+	const home = await configHome({
+		brightdataApiKey: "bd-test-key",
+		brightdataUnlockerZone: "pi_unlocker",
+	});
+	const child = runChild(
+		`
 		let fetchCalls = [];
 		globalThis.fetch = async (url) => { fetchCalls.push(String(url)); return new Response("# Should never happen", { status: 200 }); };
 		const { extractContent } = await import(${JSON.stringify(extractModuleUrl)});
 		const result = await extractContent("http://169.254.169.254/latest/meta-data");
 		console.log(JSON.stringify({ fetchCalls, error: result.error, content: result.content }));
-	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home });
+	`,
+		{ HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.deepEqual(output.fetchCalls, []);
@@ -145,7 +186,8 @@ test("Bright Data Web Unlocker validates its own fixed API endpoint, not just th
 	// resolution that points api.brightdata.com at an internal address. The lookup
 	// is hostname-aware so the *target* still passes: that is what isolates the
 	// endpoint check from the target check, which every other test exercises.
-	const child = runChild(`
+	const child = runChild(
+		`
 		let fetchCalls = 0;
 		globalThis.fetch = async () => { fetchCalls++; return new Response("# Should never happen", { status: 200 }); };
 		const { extractWithBrightDataUnlocker } = await import(${JSON.stringify(brightdataModuleUrl)});
@@ -158,7 +200,12 @@ test("Bright Data Web Unlocker validates its own fixed API endpoint, not just th
 			});
 		} catch (err) { message = err.message; }
 		console.log(JSON.stringify({ message, fetchCalls }));
-	`, { BRIGHTDATA_API_KEY: "bd-test-key", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-test-key",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.equal(output.fetchCalls, 0);
@@ -166,7 +213,8 @@ test("Bright Data Web Unlocker validates its own fixed API endpoint, not just th
 });
 
 test("Bright Data Web Unlocker credentials are stripped on public cross-origin API redirects", async () => {
-	const child = runChild(`
+	const child = runChild(
+		`
 		let calls = [];
 		globalThis.fetch = async (url, init) => {
 			calls.push({ url: String(url), auth: Object.fromEntries(new Headers(init.headers)).authorization ?? null });
@@ -176,18 +224,29 @@ test("Bright Data Web Unlocker credentials are stripped on public cross-origin A
 		const { extractWithBrightDataUnlocker } = await import(${JSON.stringify(brightdataModuleUrl)});
 		const result = await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} });
 		console.log(JSON.stringify({ calls, result }));
-	`, { BRIGHTDATA_API_KEY: "bd-secret", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-secret",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.deepEqual(output.calls, [
 		{ url: "https://api.brightdata.com/request", auth: "Bearer bd-secret" },
 		{ url: "https://mirror.example.com/request", auth: null },
 	]);
-	assert.deepEqual(output.result, { url: "https://example.com/a", title: "Redirect body", content: "# Redirect body", error: null });
+	assert.deepEqual(output.result, {
+		url: "https://example.com/a",
+		title: "Redirect body",
+		content: "# Redirect body",
+		error: null,
+	});
 });
 
 test("Bright Data Web Unlocker blocks API redirects to private targets", async () => {
-	const child = runChild(`
+	const child = runChild(
+		`
 		let calls = [];
 		globalThis.fetch = async (url) => {
 			calls.push(String(url));
@@ -198,7 +257,12 @@ test("Bright Data Web Unlocker blocks API redirects to private targets", async (
 		try { await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} }); }
 		catch (err) { redirectError = err.message; }
 		console.log(JSON.stringify({ calls, redirectError }));
-	`, { BRIGHTDATA_API_KEY: "bd-test-key", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-test-key",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	// The hop was validated before it was followed, so only the first request happened.
@@ -207,7 +271,8 @@ test("Bright Data Web Unlocker blocks API redirects to private targets", async (
 });
 
 test("Bright Data Web Unlocker stops after five API redirects with an explicit message", async () => {
-	const child = runChild(`
+	const child = runChild(
+		`
 		let calls = [];
 		globalThis.fetch = async (url, init) => {
 			calls.push({ url: String(url), auth: Object.fromEntries(new Headers(init.headers)).authorization ?? null });
@@ -218,24 +283,38 @@ test("Bright Data Web Unlocker stops after five API redirects with an explicit m
 		try { await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} }); }
 		catch (err) { message = err.message; }
 		console.log(JSON.stringify({ calls, message }));
-	`, { BRIGHTDATA_API_KEY: "bd-secret", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-secret",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	// Six requests total: the initial POST plus exactly DEFAULT_MAX_REDIRECTS = 5
 	// followed hops. A seventh would mean the cap does not hold.
-	assert.deepEqual(output.calls.map(call => call.url), [
-		"https://api.brightdata.com/request",
-		"https://hop1.example.com/request",
-		"https://hop2.example.com/request",
-		"https://hop3.example.com/request",
-		"https://hop4.example.com/request",
-		"https://hop5.example.com/request",
-	]);
+	assert.deepEqual(
+		output.calls.map((call) => call.url),
+		[
+			"https://api.brightdata.com/request",
+			"https://hop1.example.com/request",
+			"https://hop2.example.com/request",
+			"https://hop3.example.com/request",
+			"https://hop4.example.com/request",
+			"https://hop5.example.com/request",
+		],
+	);
 	// The cap raises a named error rather than returning null or the last 302 body,
 	// and it names the hop it gave up on.
-	assert.equal(output.message, "Too many redirects fetching https://hop5.example.com/request");
+	assert.equal(
+		output.message,
+		"Too many redirects fetching https://hop5.example.com/request",
+	);
 	// The credential is dropped at the first origin change and never reinstated.
-	assert.deepEqual(output.calls.map(call => call.auth), ["Bearer bd-secret", null, null, null, null, null]);
+	assert.deepEqual(
+		output.calls.map((call) => call.auth),
+		["Bearer bd-secret", null, null, null, null, null],
+	);
 	assert.equal(output.message.includes("bd-secret"), false);
 });
 
@@ -243,12 +322,16 @@ test("BRIGHTDATA_UNLOCKER_ZONE takes precedence over brightdataUnlockerZone in t
 	// Both sources are populated at once, so the assertion can only pass if the
 	// precedence order is the documented one. Reversing it in getZone() still
 	// typechecks and still passes every other test in this file.
-	const home = await configHome({ brightdataApiKey: "bd-test-key", brightdataUnlockerZone: "config_zone1" });
+	const home = await configHome({
+		brightdataApiKey: "bd-test-key",
+		brightdataUnlockerZone: "config_zone1",
+	});
 	for (const { env, expected } of [
 		{ env: {}, expected: "config_zone1" },
 		{ env: { BRIGHTDATA_UNLOCKER_ZONE: "env_zone1" }, expected: "env_zone1" },
 	]) {
-		const child = runChild(`
+		const child = runChild(
+			`
 			let zone = null;
 			globalThis.fetch = async (_url, init) => {
 				zone = JSON.parse(init.body).zone;
@@ -257,15 +340,25 @@ test("BRIGHTDATA_UNLOCKER_ZONE takes precedence over brightdataUnlockerZone in t
 			const { extractWithBrightDataUnlocker } = await import(${JSON.stringify(brightdataModuleUrl)});
 			await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} });
 			console.log(JSON.stringify({ zone }));
-		`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home, ...env });
+		`,
+			{ HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home, ...env },
+		);
 		assert.equal(child.status, 0, child.stderr);
-		assert.equal(JSON.parse(child.stdout.trim()).zone, expected, JSON.stringify(env));
+		assert.equal(
+			JSON.parse(child.stdout.trim()).zone,
+			expected,
+			JSON.stringify(env),
+		);
 	}
 });
 
 test("Bright Data Web Unlocker requires its own zone and never borrows the SERP zone", async () => {
-	const home = await configHome({ brightdataApiKey: "bd-test-key", brightdataSerpZone: "serp_zone1" });
-	const child = runChild(`
+	const home = await configHome({
+		brightdataApiKey: "bd-test-key",
+		brightdataSerpZone: "serp_zone1",
+	});
+	const child = runChild(
+		`
 		let fetchCalls = 0;
 		globalThis.fetch = async () => { fetchCalls++; return new Response("# Should never happen", { status: 200 }); };
 		const { extractWithBrightDataUnlocker, isBrightDataUnlockerAvailable } = await import(${JSON.stringify(brightdataModuleUrl)});
@@ -274,13 +367,18 @@ test("Bright Data Web Unlocker requires its own zone and never borrows the SERP 
 		try { await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} }); }
 		catch (err) { zoneError = err.message; }
 		console.log(JSON.stringify({ available, zoneError, fetchCalls }));
-	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home });
+	`,
+		{ HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	// A SERP-only configuration must not opt the user into Web Unlocker spend.
 	assert.equal(output.available, false);
 	assert.equal(output.fetchCalls, 0);
-	assert.match(output.zoneError, /Bright Data Web Unlocker zone not configured/);
+	assert.match(
+		output.zoneError,
+		/Bright Data Web Unlocker zone not configured/,
+	);
 	assert.match(output.zoneError, /brightdataUnlockerZone/);
 	assert.match(output.zoneError, /BRIGHTDATA_UNLOCKER_ZONE/);
 });
@@ -290,16 +388,35 @@ test("Bright Data Web Unlocker availability needs both a zone and a credential s
 		{ env: {}, expected: false },
 		{ env: { BRIGHTDATA_API_KEY: "bd-test-key" }, expected: false },
 		{ env: { BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" }, expected: false },
-		{ env: { BRIGHTDATA_API_KEY: "bd-test-key", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" }, expected: true },
-		{ env: { BRIGHTDATA_API_KEY: "bd-test-key", BRIGHTDATA_UNLOCKER_ZONE: "https://zone.example.com" }, expected: false },
+		{
+			env: {
+				BRIGHTDATA_API_KEY: "bd-test-key",
+				BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+			},
+			expected: true,
+		},
+		{
+			env: {
+				BRIGHTDATA_API_KEY: "bd-test-key",
+				BRIGHTDATA_UNLOCKER_ZONE: "https://zone.example.com",
+			},
+			expected: false,
+		},
 	];
 	for (const { env, expected } of cases) {
-		const child = runChild(`
+		const child = runChild(
+			`
 			const { isBrightDataUnlockerAvailable } = await import(${JSON.stringify(brightdataModuleUrl)});
 			console.log(JSON.stringify({ available: isBrightDataUnlockerAvailable() }));
-		`, env);
+		`,
+			env,
+		);
 		assert.equal(child.status, 0, child.stderr);
-		assert.equal(JSON.parse(child.stdout.trim()).available, expected, JSON.stringify(env));
+		assert.equal(
+			JSON.parse(child.stdout.trim()).available,
+			expected,
+			JSON.stringify(env),
+		);
 	}
 });
 
@@ -314,7 +431,8 @@ test("Bright Data Web Unlocker resolves the credential at request time, after th
 		}) + "\n",
 		"utf8",
 	);
-	const child = runChild(`
+	const child = runChild(
+		`
 		import { existsSync } from "node:fs";
 		let auth = null;
 		globalThis.fetch = async (_url, init) => {
@@ -331,7 +449,9 @@ test("Bright Data Web Unlocker resolves the credential at request time, after th
 		await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} });
 		const ranAfter = existsSync(${JSON.stringify(marker)});
 		console.log(JSON.stringify({ availableBefore, ranBefore, blockedError, ranAfterBlocked, ranAfter, auth }));
-	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home });
+	`,
+		{ HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.equal(output.availableBefore, true);
@@ -343,7 +463,8 @@ test("Bright Data Web Unlocker resolves the credential at request time, after th
 });
 
 test("Bright Data Web Unlocker HTTP failures surface the status and redact the credential", async () => {
-	const child = runChild(`
+	const child = runChild(
+		`
 		globalThis.fetch = async () => new Response("payment required for token bd-secret", { status: 402 });
 		const { extractWithBrightDataUnlocker } = await import(${JSON.stringify(brightdataModuleUrl)});
 		let message = null;
@@ -351,7 +472,12 @@ test("Bright Data Web Unlocker HTTP failures surface the status and redact the c
 		try { result = await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} }); }
 		catch (err) { message = err.message; }
 		console.log(JSON.stringify({ message, result }));
-	`, { BRIGHTDATA_API_KEY: "bd-secret", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-secret",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	// A paid failure throws; it is never collapsed into a silent null.
@@ -368,7 +494,8 @@ test("Bright Data Web Unlocker redacts the credential before truncating a long e
 	// would be cut into a fragment that the later message-level redaction cannot
 	// match by exact string, and the fragment would reach the user. Both redactions
 	// individually pass the 402 test above, so only this one can tell them apart.
-	const child = runChild(`
+	const child = runChild(
+		`
 		const key = "bd-boundary-secret-0123456789";
 		globalThis.fetch = async () => new Response("e".repeat(280) + key + " trailing detail", { status: 500 });
 		const { extractWithBrightDataUnlocker } = await import(${JSON.stringify(brightdataModuleUrl)});
@@ -376,7 +503,12 @@ test("Bright Data Web Unlocker redacts the credential before truncating a long e
 		try { await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} }); }
 		catch (err) { message = err.message; }
 		console.log(JSON.stringify({ message }));
-	`, { BRIGHTDATA_API_KEY: "bd-boundary-secret-0123456789", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-boundary-secret-0123456789",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.match(output.message, /Bright Data Web Unlocker error 500/);
@@ -389,7 +521,8 @@ test("Bright Data Web Unlocker redacts transport errors and preserves the error 
 	// The catch-level redaction, pinned on its own: this path never touches the
 	// response-body redaction, and it must rebuild the error without losing
 	// `err.name`, which is what downstream abort detection reads.
-	const child = runChild(`
+	const child = runChild(
+		`
 		globalThis.fetch = async () => {
 			const err = new Error("socket hang up while sending token bd-secret");
 			err.name = "TypeError";
@@ -402,7 +535,12 @@ test("Bright Data Web Unlocker redacts transport errors and preserves the error 
 		try { result = await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} }); }
 		catch (err) { name = err.name; message = err.message; }
 		console.log(JSON.stringify({ name, message, result }));
-	`, { BRIGHTDATA_API_KEY: "bd-secret", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-secret",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.equal(output.result, "not-reached");
@@ -413,7 +551,8 @@ test("Bright Data Web Unlocker redacts transport errors and preserves the error 
 });
 
 test("Bright Data Web Unlocker returns null only for genuinely empty content", async () => {
-	const child = runChild(`
+	const child = runChild(
+		`
 		const bodies = ["", "   \\n\\t  ", "Paywalled: subscribe to continue reading."];
 		let index = 0;
 		globalThis.fetch = async () => new Response(bodies[index++], { status: 200 });
@@ -423,7 +562,12 @@ test("Bright Data Web Unlocker returns null only for genuinely empty content", a
 			results.push(await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} }));
 		}
 		console.log(JSON.stringify({ results }));
-	`, { BRIGHTDATA_API_KEY: "bd-test-key", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-test-key",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const results = JSON.parse(child.stdout.trim()).results;
 	assert.equal(results[0], null);
@@ -438,7 +582,8 @@ test("Bright Data Web Unlocker returns null only for genuinely empty content", a
 });
 
 test("Bright Data Web Unlocker propagates cancellation instead of returning null", async () => {
-	const child = runChild(`
+	const child = runChild(
+		`
 		let sawAbortedSignal = null;
 		globalThis.fetch = async (_url, init) => {
 			sawAbortedSignal = init.signal?.aborted ?? null;
@@ -451,7 +596,12 @@ test("Bright Data Web Unlocker propagates cancellation instead of returning null
 		try { await extractWithBrightDataUnlocker("https://example.com/a", AbortSignal.abort(), { lookup: ${PUBLIC_LOOKUP} }); }
 		catch (err) { name = err.name; message = err.message; }
 		console.log(JSON.stringify({ sawAbortedSignal, name, message }));
-	`, { BRIGHTDATA_API_KEY: "bd-test-key", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-test-key",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	// The caller signal reaches the request, and the abort is rethrown so
@@ -462,7 +612,8 @@ test("Bright Data Web Unlocker propagates cancellation instead of returning null
 });
 
 test("Bright Data Web Unlocker uses fetch_content's timeoutMs and its own 60s default otherwise", async () => {
-	const child = runChild(`
+	const child = runChild(
+		`
 		// AbortSignal.timeout is the only place the effective budget is observable,
 		// and the signal it returns is the one handed to fetch.
 		const realTimeout = AbortSignal.timeout;
@@ -496,7 +647,12 @@ test("Bright Data Web Unlocker uses fetch_content's timeoutMs and its own 60s de
 		try { timedOutResult = await extractWithBrightDataUnlocker("https://example.com/c", undefined, { lookup: ${PUBLIC_LOOKUP}, timeoutMs: 25 }); }
 		catch (err) { timedOutName = err.name; }
 		console.log(JSON.stringify({ explicit, fallback, tiny: requested, sawSignal, timedOutName, timedOutResult }));
-	`, { BRIGHTDATA_API_KEY: "bd-test-key", BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker" });
+	`,
+		{
+			BRIGHTDATA_API_KEY: "bd-test-key",
+			BRIGHTDATA_UNLOCKER_ZONE: "pi_unlocker",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.equal(output.sawSignal, true);
@@ -519,8 +675,13 @@ test("Bright Data Web Unlocker uses fetch_content's timeoutMs and its own 60s de
 // Bright Data hit returns before the Gemini fallbacks are consulted. The full
 // ordering is a source-order property of `extractContent`, not a tested one.
 test("fetch_content tries Bright Data after the direct fetch and Jina Reader, and returns before Gemini", async () => {
-	const home = await configHome({ brightdataApiKey: "bd-test-key", brightdataUnlockerZone: "pi_unlocker" });
-	const child = runChild(`
+	const home = await configHome({
+		brightdataApiKey: "bd-test-key",
+		brightdataUnlockerZone: "pi_unlocker",
+		fetchRouting: { allowRemoteHostedProviders: true },
+	});
+	const child = runChild(
+		`
 		let calls = [];
 		globalThis.fetch = async (url) => {
 			calls.push(String(url));
@@ -531,7 +692,9 @@ test("fetch_content tries Bright Data after the direct fetch and Jina Reader, an
 		const { extractContent } = await import(${JSON.stringify(extractModuleUrl)});
 		const result = await extractContent("https://example.com/protected", undefined, { lookup: ${PUBLIC_LOOKUP} });
 		console.log(JSON.stringify({ calls, result }));
-	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home });
+	`,
+		{ HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.deepEqual(output.calls, [
@@ -548,8 +711,13 @@ test("fetch_content tries Bright Data after the direct fetch and Jina Reader, an
 });
 
 test("Bright Data Web Unlocker failures stay visible in fetch_content guidance", async () => {
-	const home = await configHome({ brightdataApiKey: "bd-secret", brightdataUnlockerZone: "pi_unlocker" });
-	const child = runChild(`
+	const home = await configHome({
+		brightdataApiKey: "bd-secret",
+		brightdataUnlockerZone: "pi_unlocker",
+		fetchRouting: { allowRemoteHostedProviders: true },
+	});
+	const child = runChild(
+		`
 		let calls = [];
 		globalThis.fetch = async (url) => {
 			calls.push(String(url));
@@ -560,17 +728,29 @@ test("Bright Data Web Unlocker failures stay visible in fetch_content guidance",
 		const { extractContent } = await import(${JSON.stringify(extractModuleUrl)});
 		const result = await extractContent("https://example.com/paywalled", undefined, { lookup: ${PUBLIC_LOOKUP} });
 		console.log(JSON.stringify({ calls, error: result.error }));
-	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home });
+	`,
+		{ HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
-	assert.match(output.error, /Bright Data fallback failed: Bright Data Web Unlocker error 402/);
-	assert.match(output.error, /Set brightdataApiKey and brightdataUnlockerZone in .*web-search\.json or BRIGHTDATA_API_KEY and BRIGHTDATA_UNLOCKER_ZONE/);
+	assert.match(
+		output.error,
+		/Bright Data fallback failed: Bright Data Web Unlocker error 402/,
+	);
+	assert.match(
+		output.error,
+		/Set brightdataApiKey and brightdataUnlockerZone in .*web-search\.json or BRIGHTDATA_API_KEY and BRIGHTDATA_UNLOCKER_ZONE/,
+	);
 	assert.equal(output.error.includes("bd-secret"), false);
 });
 
 test("Bright Data Web Unlocker rejects a malformed zone and a malformed config root", async () => {
-	const badZone = await configHome({ brightdataApiKey: "bd-test-key", brightdataUnlockerZone: "https://zone.example.com" });
-	const badZoneChild = runChild(`
+	const badZone = await configHome({
+		brightdataApiKey: "bd-test-key",
+		brightdataUnlockerZone: "https://zone.example.com",
+	});
+	const badZoneChild = runChild(
+		`
 		let fetchCalls = 0;
 		globalThis.fetch = async () => { fetchCalls++; return new Response("# Should never happen", { status: 200 }); };
 		const { extractWithBrightDataUnlocker, isBrightDataUnlockerAvailable } = await import(${JSON.stringify(brightdataModuleUrl)});
@@ -579,24 +759,35 @@ test("Bright Data Web Unlocker rejects a malformed zone and a malformed config r
 		try { await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} }); }
 		catch (err) { message = err.message; }
 		console.log(JSON.stringify({ available, message, fetchCalls }));
-	`, { HOME: badZone, USERPROFILE: badZone, PI_CODING_AGENT_DIR: badZone });
+	`,
+		{ HOME: badZone, USERPROFILE: badZone, PI_CODING_AGENT_DIR: badZone },
+	);
 	assert.equal(badZoneChild.status, 0, badZoneChild.stderr);
 	const badZoneOutput = JSON.parse(badZoneChild.stdout.trim());
 	assert.equal(badZoneOutput.available, false);
 	assert.equal(badZoneOutput.fetchCalls, 0);
-	assert.match(badZoneOutput.message, /Invalid Bright Data Unlocker zone: brightdataUnlockerZone in .*web-search\.json/);
+	assert.match(
+		badZoneOutput.message,
+		/Invalid Bright Data Unlocker zone: brightdataUnlockerZone in .*web-search\.json/,
+	);
 
 	const badRoot = await mkdtemp(join(tmpdir(), "pi-web-access-brightdata-"));
 	await writeFile(join(badRoot, "web-search.json"), "[]\n", "utf8");
-	const badRootChild = runChild(`
+	const badRootChild = runChild(
+		`
 		const { extractWithBrightDataUnlocker } = await import(${JSON.stringify(brightdataModuleUrl)});
 		let message = null;
 		try { await extractWithBrightDataUnlocker("https://example.com/a", undefined, { lookup: ${PUBLIC_LOOKUP} }); }
 		catch (err) { message = err.message; }
 		console.log(JSON.stringify({ message }));
-	`, { HOME: badRoot, USERPROFILE: badRoot, PI_CODING_AGENT_DIR: badRoot });
+	`,
+		{ HOME: badRoot, USERPROFILE: badRoot, PI_CODING_AGENT_DIR: badRoot },
+	);
 	assert.equal(badRootChild.status, 0, badRootChild.stderr);
-	assert.match(JSON.parse(badRootChild.stdout.trim()).message, /Invalid config in .*web-search\.json: expected a JSON object/);
+	assert.match(
+		JSON.parse(badRootChild.stdout.trim()).message,
+		/Invalid config in .*web-search\.json: expected a JSON object/,
+	);
 });
 
 test("a private Bright Data endpoint mirror requires an explicit narrow SSRF range", async () => {
@@ -607,9 +798,11 @@ test("a private Bright Data endpoint mirror requires an explicit narrow SSRF ran
 		const home = await configHome({
 			brightdataApiKey: "bd-test-key",
 			brightdataUnlockerZone: "pi_unlocker",
+			fetchRouting: { allowRemoteHostedProviders: true },
 			...(allowRanges ? { ssrf: { allowRanges } } : {}),
 		});
-		const child = runChild(`
+		const child = runChild(
+			`
 			let calls = [];
 			globalThis.fetch = async (url) => {
 				calls.push(String(url));
@@ -623,15 +816,25 @@ test("a private Bright Data endpoint mirror requires an explicit narrow SSRF ran
 			const { extractContent } = await import(${JSON.stringify(extractModuleUrl)});
 			const result = await extractContent("https://example.com/protected", undefined, { lookup: ${PUBLIC_LOOKUP} });
 			console.log(JSON.stringify({ calls, result }));
-		`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home });
+		`,
+			{ HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home },
+		);
 		assert.equal(child.status, 0, child.stderr);
 		const output = JSON.parse(child.stdout.trim());
 		if (allowRanges) {
-			assert.deepEqual(output.calls.slice(2), ["https://api.brightdata.com/request", "http://127.0.0.1:3002/request"]);
+			assert.deepEqual(output.calls.slice(2), [
+				"https://api.brightdata.com/request",
+				"http://127.0.0.1:3002/request",
+			]);
 			assert.equal(output.result.content, "# Local mirror");
 		} else {
-			assert.deepEqual(output.calls.slice(2), ["https://api.brightdata.com/request"]);
-			assert.match(output.result.error, /Bright Data fallback failed: Blocked internal address/);
+			assert.deepEqual(output.calls.slice(2), [
+				"https://api.brightdata.com/request",
+			]);
+			assert.match(
+				output.result.error,
+				/Bright Data fallback failed: Blocked internal address/,
+			);
 		}
 	}
 });

--- a/test/datalab-pdf-extract.test.mjs
+++ b/test/datalab-pdf-extract.test.mjs
@@ -285,7 +285,7 @@ test("Datalab conversion rejects empty markdown", async () => {
 	);
 });
 
-test("Datalab conversion times out while polling", async () => {
+test("Datalab conversion times out while polling without waiting a full poll interval", async () => {
 	globalThis.fetch = async (url, init) => {
 		if (String(url).endsWith("/convert")) {
 			return jsonResponse({
@@ -299,6 +299,7 @@ test("Datalab conversion times out while polling", async () => {
 		return route(url, init);
 	};
 
+	const started = Date.now();
 	await assert.rejects(
 		extractPDFViaDatalab(new ArrayBuffer(1), {
 			maxPages: 1,
@@ -307,6 +308,49 @@ test("Datalab conversion times out while polling", async () => {
 		}),
 		/timed out/,
 	);
+	assert.ok(
+		Date.now() - started < 500,
+		"polling must not delay a 60ms timeout by its 1.5s interval",
+	);
+});
+
+test("Datalab cancellation returns without awaiting best-effort cleanup", async () => {
+	const controller = new AbortController();
+	let markConvertSubmitted;
+	const convertSubmitted = new Promise((resolve) => {
+		markConvertSubmitted = resolve;
+	});
+	let markCleanupStarted;
+	const cleanupStarted = new Promise((resolve) => {
+		markCleanupStarted = resolve;
+	});
+	let finishCleanup;
+	const cleanupBlocked = new Promise((resolve) => {
+		finishCleanup = resolve;
+	});
+
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/convert")) markConvertSubmitted();
+		if (String(url).endsWith("/files/7") && init.method === "DELETE") {
+			markCleanupStarted();
+			return cleanupBlocked;
+		}
+		return route(url, init);
+	};
+
+	const extraction = extractPDFViaDatalab(new ArrayBuffer(1), {
+		maxPages: 1,
+		title: "Doc",
+		signal: controller.signal,
+	});
+	await convertSubmitted;
+	controller.abort(new DOMException("cancelled", "AbortError"));
+	await cleanupStarted;
+
+	const outcome = await settlesWithin(extraction, 100);
+	assert.equal(outcome.status, "rejected");
+	assert.equal(outcome.error.name, "AbortError");
+	finishCleanup(new Response(null, { status: 200 }));
 });
 
 test("Datalab conversion rejects a cross-origin polling URL", async () => {
@@ -466,6 +510,22 @@ function jsonResponse(value) {
 	return new Response(JSON.stringify(value), {
 		status: 200,
 		headers: { "content-type": "application/json" },
+	});
+}
+
+function settlesWithin(promise, timeoutMs) {
+	return new Promise((resolve) => {
+		const timeout = setTimeout(() => resolve({ status: "pending" }), timeoutMs);
+		promise.then(
+			() => {
+				clearTimeout(timeout);
+				resolve({ status: "resolved" });
+			},
+			(error) => {
+				clearTimeout(timeout);
+				resolve({ status: "rejected", error });
+			},
+		);
 	});
 }
 

--- a/test/datalab-pdf-extract.test.mjs
+++ b/test/datalab-pdf-extract.test.mjs
@@ -1,0 +1,475 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+
+const originalFetch = globalThis.fetch;
+const originalKey = process.env.DATALAB_API_KEY;
+const originalMode = process.env.DATALAB_MODE;
+const originalLocation = process.env.DATALAB_PROCESSING_LOCATION;
+const originalBase = process.env.DATALAB_API_BASE;
+process.env.DATALAB_API_KEY = "synthetic-datalab-key";
+
+const { extractPDFViaDatalab, getDatalabApiBase } = await import(
+	"../datalab-pdf-extract.ts"
+);
+
+after(() => {
+	globalThis.fetch = originalFetch;
+	restoreEnv("DATALAB_API_KEY", originalKey);
+	restoreEnv("DATALAB_MODE", originalMode);
+	restoreEnv("DATALAB_PROCESSING_LOCATION", originalLocation);
+	restoreEnv("DATALAB_API_BASE", originalBase);
+});
+
+test("Datalab conversion uploads the PDF, converts with a datalab reference, and polls to completion", async () => {
+	const calls = [];
+	globalThis.fetch = async (url, init) => {
+		calls.push({ url: String(url), init });
+		return route(url, init);
+	};
+
+	const input = Uint8Array.from([1, 2, 3, 4]).buffer;
+	const result = await extractPDFViaDatalab(input, {
+		maxPages: 5,
+		title: "Sample Document",
+	});
+
+	const byUrl = calls.map((call) => call.url);
+	assert.equal(byUrl.filter((url) => url.endsWith("/files/upload")).length, 1);
+	assert.equal(byUrl.filter((url) => url.includes("/put/")).length, 1);
+	assert.equal(
+		byUrl.filter((url) => url.endsWith("/files/7/confirm")).length,
+		1,
+	);
+	assert.equal(byUrl.filter((url) => url.endsWith("/convert")).length, 1);
+	assert.equal(byUrl.filter((url) => url.endsWith("/check/abc123")).length, 1);
+
+	const upload = calls.find((call) => call.url.endsWith("/files/upload"));
+	assert.equal(
+		new Headers(upload.init.headers).get("x-api-key"),
+		"synthetic-datalab-key",
+	);
+	assert.equal(
+		new Headers(upload.init.headers).get("content-type"),
+		"application/json",
+	);
+	const uploadBody = parseJsonBody(upload.init.body);
+	assert.ok(uploadBody, "upload body did not parse");
+	assert.equal(uploadBody.filename, "sample-document.pdf");
+	assert.equal(uploadBody.content_type, "application/pdf");
+	assert.equal(uploadBody.processing_location, "us");
+
+	const put = calls.find((call) => call.url.includes("/put/"));
+	assert.equal(put.init.method, "PUT");
+	assert.equal(
+		new Headers(put.init.headers).get("content-type"),
+		"application/pdf",
+	);
+
+	const convert = calls.find((call) => call.url.endsWith("/convert"));
+	assert.equal(convert.init.method, "POST");
+	assert.equal(
+		new Headers(convert.init.headers).get("x-api-key"),
+		"synthetic-datalab-key",
+	);
+	const body = convert.init.body;
+	assert.ok(body instanceof FormData);
+	assert.equal(body.get("file_url"), "datalab://file-7");
+	assert.equal(body.get("output_format"), "markdown");
+	assert.equal(body.get("paginate"), "true");
+	assert.equal(body.get("max_pages"), "5");
+	assert.equal(body.get("mode"), "balanced");
+	assert.equal(body.get("processing_location"), null);
+
+	const cleanup = calls.find(
+		(call) => call.url.endsWith("/files/7") && call.init.method === "DELETE",
+	);
+	assert.ok(cleanup, "expected best-effort file cleanup after conversion");
+
+	assert.match(result.markdown, /^<!-- Page 1 -->/);
+	assert.equal(result.pages, 2);
+	assert.equal(result.parseQualityScore, 4.5);
+});
+
+test("Datalab conversion still succeeds when cleanup fails", async () => {
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/files/7") && init.method === "DELETE") {
+			throw new Error("cleanup transport failure");
+		}
+		return route(url, init);
+	};
+
+	const result = await extractPDFViaDatalab(new ArrayBuffer(1), {
+		maxPages: 1,
+		title: "Doc",
+	});
+	assert.match(result.markdown, /Sample Document/);
+});
+
+test("Datalab conversion honors processing location and mode selection", async () => {
+	let capturedLocation = null;
+	let capturedMode = null;
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/files/upload")) {
+			capturedLocation = parseJsonBody(init.body)?.processing_location ?? null;
+			return jsonResponse({
+				file_id: 7,
+				upload_url: "https://storage.test/put/abc",
+				reference: "datalab://file-7",
+			});
+		}
+		if (String(url).endsWith("/convert")) {
+			const body = init.body;
+			capturedMode = body.get("mode");
+			return jsonResponse({
+				status: "complete",
+				success: true,
+				markdown: "<!-- Page 1 -->\nDone",
+				page_count: 1,
+			});
+		}
+		return route(url, init);
+	};
+
+	process.env.DATALAB_PROCESSING_LOCATION = "eu";
+	process.env.DATALAB_MODE = "accurate";
+	await extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 2, title: "Doc" });
+
+	assert.equal(capturedLocation, "eu");
+	assert.equal(capturedMode, "accurate");
+	delete process.env.DATALAB_PROCESSING_LOCATION;
+	delete process.env.DATALAB_MODE;
+});
+
+test("Datalab conversion rejects a missing file_id before uploading", async () => {
+	const calls = [];
+	globalThis.fetch = async (url, init) => {
+		calls.push(String(url));
+		if (String(url).endsWith("/files/upload")) {
+			return jsonResponse({
+				upload_url: "https://storage.test/put/abc",
+				reference: "datalab://file-7",
+			});
+		}
+		return route(url, init);
+	};
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 1, title: "Doc" }),
+		/missing file_id/,
+	);
+	assert.equal(
+		calls.some((url) => url.includes("/put/")),
+		false,
+		"must not upload without a file ID for confirmation and cleanup",
+	);
+});
+
+test("Datalab conversion returns immediately when the convert response is complete", async () => {
+	let convertCalls = 0;
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/convert")) {
+			convertCalls += 1;
+			return jsonResponse({
+				status: "complete",
+				success: true,
+				markdown: "<!-- Page 1 -->\nFast",
+				page_count: 1,
+			});
+		}
+		return route(url, init);
+	};
+
+	const result = await extractPDFViaDatalab(new ArrayBuffer(1), {
+		maxPages: 1,
+		title: "Doc",
+	});
+	assert.equal(convertCalls, 1);
+	assert.match(result.markdown, /Fast/);
+});
+
+test("Datalab conversion rejects HTTP errors with the status and redacted body", async () => {
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/files/upload")) {
+			return new Response(JSON.stringify({ detail: "invalid api key" }), {
+				status: 401,
+				statusText: "Unauthorized",
+				headers: { "content-type": "application/json" },
+			});
+		}
+		return route(url, init);
+	};
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 1, title: "Doc" }),
+		/HTTP 401 Unauthorized: .*invalid api key/,
+	);
+});
+
+test("Datalab conversion redacts API keys from transport errors", async () => {
+	globalThis.fetch = async () => {
+		throw new Error("network failure for synthetic-datalab-key");
+	};
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 1, title: "Doc" }),
+		(error) => {
+			assert.equal(error.name, "Error");
+			assert.doesNotMatch(error.message, /synthetic-datalab-key/);
+			return true;
+		},
+	);
+});
+
+test("Datalab conversion rejects a streamed response above its byte limit", async () => {
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/files/upload")) {
+			return new Response(
+				new ReadableStream({
+					start(controller) {
+						controller.enqueue(new Uint8Array(4 * 1024 * 1024 + 1));
+						controller.close();
+					},
+				}),
+				{ status: 200 },
+			);
+		}
+		return route(url, init);
+	};
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 1, title: "Doc" }),
+		/response too large/,
+	);
+});
+
+test("Datalab conversion rejects failed conversion status", async () => {
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/convert")) {
+			return jsonResponse({
+				status: "processing",
+				request_check_url: "/check/abc",
+			});
+		}
+		if (String(url).endsWith("/check/abc")) {
+			return jsonResponse({
+				status: "failed",
+				success: false,
+				error: "document is corrupt",
+			});
+		}
+		return route(url, init);
+	};
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 1, title: "Doc" }),
+		/document is corrupt/,
+	);
+});
+
+test("Datalab conversion rejects empty markdown", async () => {
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/convert")) {
+			return jsonResponse({
+				status: "complete",
+				success: true,
+				markdown: "   ",
+				page_count: 1,
+			});
+		}
+		return route(url, init);
+	};
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 1, title: "Doc" }),
+		/empty markdown/,
+	);
+});
+
+test("Datalab conversion times out while polling", async () => {
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/convert")) {
+			return jsonResponse({
+				status: "processing",
+				request_check_url: "/check/abc",
+			});
+		}
+		if (String(url).endsWith("/check/abc")) {
+			return jsonResponse({ status: "processing" });
+		}
+		return route(url, init);
+	};
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), {
+			maxPages: 1,
+			title: "Doc",
+			timeoutMs: 60,
+		}),
+		/timed out/,
+	);
+});
+
+test("Datalab conversion rejects a cross-origin polling URL", async () => {
+	const calls = [];
+	globalThis.fetch = async (url, init) => {
+		calls.push(String(url));
+		if (String(url).endsWith("/convert")) {
+			return jsonResponse({
+				status: "processing",
+				request_check_url: "https://untrusted.example.test/check/abc",
+			});
+		}
+		return route(url, init);
+	};
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 1, title: "Doc" }),
+		/unexpected origin/,
+	);
+	assert.equal(
+		calls.some((url) => url.includes("untrusted.example.test")),
+		false,
+		"must not send the API key to a polling URL returned by another origin",
+	);
+});
+
+test("Datalab conversion surfaces missing request_check_url", async () => {
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/convert")) {
+			return jsonResponse({ status: "processing" });
+		}
+		return route(url, init);
+	};
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 1, title: "Doc" }),
+		/missing request_check_url/,
+	);
+});
+
+test("Datalab conversion honors a custom API base", async () => {
+	process.env.DATALAB_API_BASE = "https://datalab.example.test/api/v1";
+	const seen = [];
+	globalThis.fetch = async (url, init) => {
+		seen.push(String(url));
+		if (String(url).endsWith("/check/abc123")) {
+			return jsonResponse({
+				status: "complete",
+				success: true,
+				markdown: "<!-- Page 1 -->\nCustom",
+				page_count: 1,
+			});
+		}
+		return route(url, init);
+	};
+
+	assert.equal(getDatalabApiBase(), "https://datalab.example.test/api/v1");
+	const result = await extractPDFViaDatalab(new ArrayBuffer(1), {
+		maxPages: 1,
+		title: "Doc",
+	});
+	assert.match(result.markdown, /Custom/);
+	assert.ok(
+		seen.some((url) =>
+			url.startsWith("https://datalab.example.test/api/v1/files/upload"),
+		),
+	);
+	assert.ok(
+		seen.some((url) =>
+			url.startsWith("https://datalab.example.test/api/v1/convert"),
+		),
+	);
+	delete process.env.DATALAB_API_BASE;
+});
+
+test("Datalab conversion preserves caller cancellation", async () => {
+	const controller = new AbortController();
+	controller.abort(new DOMException("cancelled", "AbortError"));
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), {
+			maxPages: 1,
+			title: "Doc",
+			signal: controller.signal,
+		}),
+		(error) => error instanceof DOMException && error.name === "AbortError",
+	);
+});
+
+test("Datalab conversion rejects invalid processing location env", async () => {
+	process.env.DATALAB_PROCESSING_LOCATION = "mars";
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 1, title: "Doc" }),
+		/Failed to parse DATALAB_PROCESSING_LOCATION/,
+	);
+	delete process.env.DATALAB_PROCESSING_LOCATION;
+});
+
+function route(url) {
+	const urlString = String(url);
+	if (urlString.endsWith("/files/upload")) {
+		return jsonResponse({
+			file_id: 7,
+			upload_url: "https://storage.test/put/abc",
+			reference: "datalab://file-7",
+			expires_in: 3600,
+		});
+	}
+	if (urlString.includes("/put/")) {
+		return new Response(null, { status: 200 });
+	}
+	if (urlString.endsWith("/files/7/confirm")) {
+		return jsonResponse({
+			file_id: 7,
+			reference: "datalab://file-7",
+			message: "confirmed",
+		});
+	}
+	if (urlString.endsWith("/files/7")) {
+		return new Response(null, { status: 200 });
+	}
+	if (urlString.endsWith("/convert")) {
+		return jsonResponse({
+			status: "processing",
+			request_check_url: "/check/abc123",
+		});
+	}
+	if (urlString.endsWith("/check/abc123")) {
+		return jsonResponse({
+			status: "complete",
+			success: true,
+			markdown:
+				"<!-- Page 1 -->\n# Sample Document\n\nFirst page.\n\n<!-- Page 2 -->\n\nSecond page.",
+			page_count: 2,
+			parse_quality_score: 4.5,
+			cost_breakdown: { total_cost_cents: 1 },
+		});
+	}
+	return new Response(
+		JSON.stringify({ detail: "unexpected fetch: " + urlString }),
+		{
+			status: 418,
+			headers: { "content-type": "application/json" },
+		},
+	);
+}
+
+function parseJsonBody(value) {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return null;
+	}
+}
+
+function jsonResponse(value) {
+	return new Response(JSON.stringify(value), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function restoreEnv(name, value) {
+	if (value === undefined) delete process.env[name];
+	else process.env[name] = value;
+}

--- a/test/declared-web-links.test.mjs
+++ b/test/declared-web-links.test.mjs
@@ -5,19 +5,40 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { parseHTML } from "linkedom";
-import { appendDeclaredWebLinks, discoverDeclaredWebLinks } from "../declared-web-links.ts";
+import {
+	appendDeclaredWebLinks,
+	discoverDeclaredWebLinks,
+} from "../declared-web-links.ts";
 
 const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
 
 function runChild(script) {
 	const home = mkdtempSync(join(tmpdir(), "pi-web-access-declared-links-"));
-	writeFileSync(join(home, "web-search.json"), "{}\n", "utf8");
-	const childEnv = { ...process.env, HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: home };
+	writeFileSync(
+		join(home, "web-search.json"),
+		JSON.stringify({ fetchRouting: { allowRemoteHostedProviders: true } }) +
+			"\n",
+		"utf8",
+	);
+	const childEnv = {
+		...process.env,
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: home,
+	};
 	for (const key of [
-		"GEMINI_API_KEY", "GOOGLE_GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GEMINI_BASE_URL",
-		"CLOUDFLARE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY", "FIRECRAWL_BASE_URL",
-		"FIRECRAWL_API_KEY", "PI_ALLOW_BROWSER_COOKIES",
-	]) delete childEnv[key];
+		"GEMINI_API_KEY",
+		"GOOGLE_GEMINI_API_KEY",
+		"GOOGLE_API_KEY",
+		"GOOGLE_GEMINI_BASE_URL",
+		"CLOUDFLARE_API_KEY",
+		"PARALLEL_API_KEY",
+		"TINYFISH_API_KEY",
+		"FIRECRAWL_BASE_URL",
+		"FIRECRAWL_API_KEY",
+		"PI_ALLOW_BROWSER_COOKIES",
+	])
+		delete childEnv[key];
 	try {
 		return spawnSync(process.execPath, ["--input-type=module"], {
 			input: script,
@@ -43,11 +64,11 @@ test("discovers registered relations from Link headers and HTML declarations", (
 	const links = discoverDeclaredWebLinks(
 		document,
 		'</catalog>; title="API, <catalog>"; rel="API-CATALOG"; type="application/linkset+json", ' +
-		'</schema>; rel="service-desc"; type="application/schema+json", ' +
-		'</metadata>; rel="service-meta"; optional, ' +
-		'</quoted>; title="x; rel=service-doc"; rel="alternate", ' +
-		'</anchored>; rel="service-doc"; anchor="/other", ' +
-		'</ignored>; rel="alternate"',
+			'</schema>; rel="service-desc"; type="application/schema+json", ' +
+			'</metadata>; rel="service-meta"; optional, ' +
+			'</quoted>; title="x; rel=service-doc"; rel="alternate", ' +
+			'</anchored>; rel="service-doc"; anchor="/other", ' +
+			'</ignored>; rel="alternate"',
 		"https://example.com/root/start",
 	);
 
@@ -75,11 +96,16 @@ test("discovers registered relations from Link headers and HTML declarations", (
 });
 
 test("bounds declarations while preserving their relation annotations", () => {
-	const declarations = Array.from({ length: 25 }, (_, index) =>
-		`<link rel="service-doc" href="/docs/${index}">`
+	const declarations = Array.from(
+		{ length: 25 },
+		(_, index) => `<link rel="service-doc" href="/docs/${index}">`,
 	).join("");
 	const { document } = parseHTML(`<html><head>${declarations}</head></html>`);
-	const links = discoverDeclaredWebLinks(document, null, "https://example.com/");
+	const links = discoverDeclaredWebLinks(
+		document,
+		null,
+		"https://example.com/",
+	);
 	assert.equal(links.length, 20);
 
 	const oversized = discoverDeclaredWebLinks(
@@ -89,7 +115,10 @@ test("bounds declarations while preserving their relation annotations", () => {
 	);
 	assert.deepEqual(oversized, []);
 
-	const content = appendDeclaredWebLinks("Existing: https://example.com/docs/0-extra", links.slice(0, 2));
+	const content = appendDeclaredWebLinks(
+		"Existing: https://example.com/docs/0-extra",
+		links.slice(0, 2),
+	);
 	assert.match(content, /<https:\/\/example\.com\/docs\/0>/);
 	assert.match(content, /<https:\/\/example\.com\/docs\/1>/);
 });
@@ -149,7 +178,10 @@ test("HTML extraction surfaces declared documentation links without broad URL he
 	assert.match(output.readable.content, /Readable article content/);
 	assert.match(output.readable.content, /## Declared links/);
 	assert.match(output.readable.content, /service-desc/);
-	assert.match(output.readable.content, /https:\/\/example\.com\/openapi\.json/);
+	assert.match(
+		output.readable.content,
+		/https:\/\/example\.com\/openapi\.json/,
+	);
 	assert.deepEqual(output.readableCalls, ["https://example.com/readable"]);
 
 	assert.equal(output.shell.error, null);
@@ -163,12 +195,18 @@ test("HTML extraction surfaces declared documentation links without broad URL he
 	assert.equal(output.fallback.error, null);
 	assert.match(output.fallback.content, /Rendered API/);
 	assert.match(output.fallback.content, /service-desc/);
-	assert.match(output.fallback.content, /https:\/\/example\.com\/openapi\.json/);
+	assert.match(
+		output.fallback.content,
+		/https:\/\/example\.com\/openapi\.json/,
+	);
 	assert.deepEqual(output.fallbackCalls, [
 		"https://example.com/fallback",
 		"https://r.jina.ai/https://example.com/fallback",
 	]);
 
-	assert.doesNotMatch(output.generic.content, /https:\/\/example\.com\/developers/);
+	assert.doesNotMatch(
+		output.generic.content,
+		/https:\/\/example\.com\/developers/,
+	);
 	assert.ok(output.generic.error);
 });

--- a/test/parallel.test.mjs
+++ b/test/parallel.test.mjs
@@ -12,7 +12,11 @@ const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
 async function createHome(config = {}) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-parallel-"));
 	await mkdir(join(home, ".pi"), { recursive: true });
-	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	await writeFile(
+		join(home, ".pi", "web-search.json"),
+		JSON.stringify(config) + "\n",
+		"utf8",
+	);
 	return home;
 }
 
@@ -32,32 +36,48 @@ function runChild(script, env = {}) {
 
 test("Parallel availability reads env and config keys while rejecting placeholders", async () => {
 	const home = await createHome({ parallelApiKey: "your-key" });
-	let child = runChild(`
+	let child = runChild(
+		`
 		const { isParallelAvailable } = await import(${JSON.stringify(parallelModuleUrl)});
 		console.log(String(isParallelAvailable()));
-	`, { HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "" });
+	`,
+		{ HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "" },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "false");
 
-	child = runChild(`
+	child = runChild(
+		`
 		const { isParallelAvailable } = await import(${JSON.stringify(parallelModuleUrl)});
 		console.log(String(isParallelAvailable()));
-	`, { HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "pk_live_parallel_test_key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			PARALLEL_API_KEY: "pk_live_parallel_test_key",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "true");
 
-	const configHome = await createHome({ parallelApiKey: "pk_live_parallel_config_key" });
-	child = runChild(`
+	const configHome = await createHome({
+		parallelApiKey: "pk_live_parallel_config_key",
+	});
+	child = runChild(
+		`
 		const { isParallelAvailable } = await import(${JSON.stringify(parallelModuleUrl)});
 		console.log(String(isParallelAvailable()));
-	`, { HOME: configHome, USERPROFILE: configHome, PARALLEL_API_KEY: "" });
+	`,
+		{ HOME: configHome, USERPROFILE: configHome, PARALLEL_API_KEY: "" },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "true");
 });
 
 test("explicit Parallel search routes through Parallel API and maps results", async () => {
 	const home = await createHome({ provider: "parallel" });
-	const child = runChild(`
+	const child = runChild(
+		`
 		let captured = null;
 		globalThis.fetch = async (url, init) => {
 			captured = { url: String(url), headers: init.headers, body: JSON.parse(init.body) };
@@ -68,24 +88,50 @@ test("explicit Parallel search routes through Parallel API and maps results", as
 		const { search } = await import(${JSON.stringify(searchModuleUrl)});
 		const result = await search("parallel search docs", { provider: "parallel", includeContent: true, numResults: 3, domainFilter: ["docs.parallel.ai", "-example.com"] });
 		console.log(JSON.stringify({ captured, result }));
-	`, { HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "pk_live_parallel_test_key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			PARALLEL_API_KEY: "pk_live_parallel_test_key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.equal(output.captured.url, "https://api.parallel.ai/v1/search");
-	assert.equal(output.captured.headers["x-api-key"], "pk_live_parallel_test_key");
+	assert.equal(
+		output.captured.headers["x-api-key"],
+		"pk_live_parallel_test_key",
+	);
 	assert.deepEqual(output.captured.body.advanced_settings, {
 		max_results: 3,
-		source_policy: { include_domains: ["docs.parallel.ai"], exclude_domains: ["example.com"] },
+		source_policy: {
+			include_domains: ["docs.parallel.ai"],
+			exclude_domains: ["example.com"],
+		},
 	});
 	assert.equal(output.result.provider, "parallel");
-	assert.deepEqual(output.result.results, [{ title: "Parallel Docs", url: "https://docs.parallel.ai/search", snippet: "Parallel search excerpt" }]);
-	assert.deepEqual(output.result.inlineContent, [{ url: "https://docs.parallel.ai/search", title: "Parallel Docs", content: "Parallel search excerpt", error: null }]);
+	assert.deepEqual(output.result.results, [
+		{
+			title: "Parallel Docs",
+			url: "https://docs.parallel.ai/search",
+			snippet: "Parallel search excerpt",
+		},
+	]);
+	assert.deepEqual(output.result.inlineContent, [
+		{
+			url: "https://docs.parallel.ai/search",
+			title: "Parallel Docs",
+			content: "Parallel search excerpt",
+			error: null,
+		},
+	]);
 });
 
 test("Parallel extract retries full content when excerpts are too short", async () => {
 	const home = await createHome();
-	const child = runChild(`
+	const child = runChild(
+		`
 		const calls = [];
 		globalThis.fetch = async (url, init) => {
 			calls.push({ url: String(url), body: JSON.parse(init.body) });
@@ -97,20 +143,32 @@ test("Parallel extract retries full content when excerpts are too short", async 
 		const { extractWithParallel } = await import(${JSON.stringify(parallelModuleUrl)});
 		const result = await extractWithParallel("https://example.com");
 		console.log(JSON.stringify({ calls, result }));
-	`, { HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "pk_live_parallel_test_key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			PARALLEL_API_KEY: "pk_live_parallel_test_key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.equal(output.calls.length, 2);
-	assert.deepEqual(output.calls[1].body.advanced_settings, { full_content: true });
+	assert.deepEqual(output.calls[1].body.advanced_settings, {
+		full_content: true,
+	});
 	assert.equal(output.result.title, "Full");
 	assert.equal(output.result.error, null);
 	assert.match(output.result.content, /^# Full/);
 });
 
 test("fetch_content continues to Gemini when Parallel extract fails", async () => {
-	const home = await createHome({ geminiApiKey: "gemini-test-key" });
-	const child = runChild(`
+	const home = await createHome({
+		geminiApiKey: "gemini-test-key",
+		fetchRouting: { allowRemoteHostedProviders: true },
+	});
+	const child = runChild(
+		`
 		const calls = [];
 		globalThis.fetch = async (url, init = {}) => {
 			const urlText = String(url);
@@ -135,12 +193,22 @@ test("fetch_content continues to Gemini when Parallel extract fails", async () =
 		const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
 		const result = await extractContent("https://example.com/app", undefined, { lookup });
 		console.log(JSON.stringify({ calls, result }));
-	`, { HOME: home, USERPROFILE: home, PARALLEL_API_KEY: "pk_live_parallel_test_key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			PARALLEL_API_KEY: "pk_live_parallel_test_key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.ok(output.calls.includes("https://api.parallel.ai/v1/extract"));
-	assert.ok(output.calls.some((url) => url.includes("generativelanguage.googleapis.com")));
+	assert.ok(
+		output.calls.some((url) =>
+			url.includes("generativelanguage.googleapis.com"),
+		),
+	);
 	assert.equal(output.result.error, null);
 	assert.match(output.result.content, /Gemini fallback/);
 });

--- a/test/pdf-config.test.mjs
+++ b/test/pdf-config.test.mjs
@@ -9,22 +9,67 @@ import { readPDFResponseBuffer } from "../extract.ts";
 const pdfModuleUrl = new URL("../pdf-extract.ts", import.meta.url).href;
 
 test("pdf.maxSizeMB defaults to 20 and accepts values through 50", () => {
-	assert.equal(readConfig(undefined), 20);
-	assert.equal(readConfig({ pdf: { maxSizeMB: 30 } }), 30);
-	assert.equal(readConfig({ pdf: { maxSizeMB: 50 } }), 50);
+	assert.equal(readConfig(undefined).maxSizeMB, 20);
+	assert.equal(readConfig({ pdf: { maxSizeMB: 30 } }).maxSizeMB, 30);
+	assert.equal(readConfig({ pdf: { maxSizeMB: 50 } }).maxSizeMB, 50);
 });
 
 test("pdf.maxSizeMB caps values above 50 and rejects invalid values", () => {
-	assert.equal(readConfig({ pdf: { maxSizeMB: 80 } }), 50);
-	assert.equal(readConfig({ pdf: { maxSizeMB: 0 } }), 20);
-	assert.equal(readConfig({ pdf: { maxSizeMB: -1 } }), 20);
-	assert.equal(readConfig({ pdf: { maxSizeMB: "50" } }), 20);
+	assert.equal(readConfig({ pdf: { maxSizeMB: 80 } }).maxSizeMB, 50);
+	assert.equal(readConfig({ pdf: { maxSizeMB: 0 } }).maxSizeMB, 20);
+	assert.equal(readConfig({ pdf: { maxSizeMB: -1 } }).maxSizeMB, 20);
+	assert.equal(readConfig({ pdf: { maxSizeMB: "50" } }).maxSizeMB, 20);
+});
+
+test("pdf.provider defaults to auto and validates explicit providers", () => {
+	assert.equal(readConfig(undefined).provider, "auto");
+	assert.equal(readConfig({ pdf: { provider: "gemini" } }).provider, "gemini");
+	assert.equal(
+		readConfig({ pdf: { provider: "datalab" } }).provider,
+		"datalab",
+	);
+	assert.equal(readConfig({ pdf: { provider: "unpdf" } }).provider, "unpdf");
+	assert.equal(readConfig({ pdf: { provider: "gemini2" } }).provider, "auto");
+});
+
+test("pdf.datalabMode defaults to balanced and validates modes", () => {
+	assert.equal(readConfig(undefined).datalabMode, "balanced");
+	assert.equal(
+		readConfig({ pdf: { datalabMode: "fast" } }).datalabMode,
+		"fast",
+	);
+	assert.equal(
+		readConfig({ pdf: { datalabMode: "accurate" } }).datalabMode,
+		"accurate",
+	);
+	assert.equal(
+		readConfig({ pdf: { datalabMode: "ultra" } }).datalabMode,
+		"balanced",
+	);
+});
+
+test("pdf.datalabTimeoutMs defaults to 120000 and caps at 300000", () => {
+	assert.equal(readConfig(undefined).datalabTimeoutMs, 120000);
+	assert.equal(
+		readConfig({ pdf: { datalabTimeoutMs: 5000 } }).datalabTimeoutMs,
+		5000,
+	);
+	assert.equal(
+		readConfig({ pdf: { datalabTimeoutMs: 999999 } }).datalabTimeoutMs,
+		300000,
+	);
+	assert.equal(
+		readConfig({ pdf: { datalabTimeoutMs: -1 } }).datalabTimeoutMs,
+		120000,
+	);
 });
 
 test("PDF streamed byte enforcement allows the exact limit", async () => {
 	const bytes = Uint8Array.from([1, 2]);
 	const maxSizeMB = bytes.byteLength / 1024 / 1024;
-	const response = new Response(bytes, { headers: { "content-type": "application/pdf" } });
+	const response = new Response(bytes, {
+		headers: { "content-type": "application/pdf" },
+	});
 
 	const buffer = await readPDFResponseBuffer(response, maxSizeMB);
 	assert.deepEqual(new Uint8Array(buffer), bytes);
@@ -51,14 +96,15 @@ function readConfig(config) {
 		const child = spawnSync(process.execPath, ["--input-type=module"], {
 			input: `
 				process.env.PI_CODING_AGENT_DIR = ${JSON.stringify(configDir)};
+				delete process.env.DATALAB_MODE;
 				const { loadPDFConfig } = await import(${JSON.stringify(pdfModuleUrl)});
-				console.log(loadPDFConfig().maxSizeMB);
+				console.log(JSON.stringify(loadPDFConfig()));
 			`,
 			encoding: "utf8",
 			env: { ...process.env, PI_CODING_AGENT_DIR: configDir },
 		});
 		assert.equal(child.status, 0, child.stderr);
-		return Number(child.stdout.trim());
+		return JSON.parse(child.stdout.trim());
 	} finally {
 		rmSync(configDir, { recursive: true, force: true });
 	}

--- a/test/pdf-extract.test.mjs
+++ b/test/pdf-extract.test.mjs
@@ -12,110 +12,117 @@ const require = createRequire(import.meta.url);
 const extractorUrl = new URL("../pdf-extract.ts", import.meta.url).href;
 
 test("extractPDFToMarkdown works on Node 22 without native Promise.try", () => {
-  const child = spawnSync(process.execPath, ["--input-type=module"], {
-    input: buildChildScript(extractorUrl),
-    encoding: "utf8",
-    maxBuffer: 2 * 1024 * 1024,
-  });
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
 
-  assert.equal(
-    child.status,
-    0,
-    "PDF extraction failed in a child process. stderr summary:\n" + errorSummary(child.stderr),
-  );
+	assert.equal(
+		child.status,
+		0,
+		"PDF extraction failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
 
-  assert.match(child.stdout, /Hello PDF/);
+	assert.match(child.stdout, /Hello PDF/);
 });
 
 test("extractPDFToMarkdown uses Gemini before loading unpdf", () => {
-  const loaderDir = mkdtempSync(join(tmpdir(), "pi-web-access-pdf-gemini-first-"));
-  const loaderPath = join(loaderDir, "block-unpdf-loader.mjs");
-  writeFileSync(loaderPath, buildBlockUnpdfLoader());
+	const loaderDir = mkdtempSync(
+		join(tmpdir(), "pi-web-access-pdf-gemini-first-"),
+	);
+	const loaderPath = join(loaderDir, "block-unpdf-loader.mjs");
+	writeFileSync(loaderPath, buildBlockUnpdfLoader());
 
-  try {
-    const child = spawnSync(
-      process.execPath,
-      ["--experimental-loader", loaderPath, "--input-type=module"],
-      {
-        input: buildChildScript(extractorUrl, false, "success"),
-        encoding: "utf8",
-        maxBuffer: 2 * 1024 * 1024,
-      },
-    );
+	try {
+		const child = spawnSync(
+			process.execPath,
+			["--experimental-loader", loaderPath, "--input-type=module"],
+			{
+				input: buildChildScript(extractorUrl, false, "success"),
+				encoding: "utf8",
+				maxBuffer: 2 * 1024 * 1024,
+			},
+		);
 
-    assert.equal(
-      child.status,
-      0,
-      "PDF Gemini-first assertion failed in a child process. stderr summary:\n" + errorSummary(child.stderr),
-    );
-    assert.match(child.stdout, /Gemini PDF/);
-  } finally {
-    rmSync(loaderDir, { recursive: true, force: true });
-  }
+		assert.equal(
+			child.status,
+			0,
+			"PDF Gemini-first assertion failed in a child process. stderr summary:\n" +
+				errorSummary(child.stderr),
+		);
+		assert.match(child.stdout, /Gemini PDF/);
+	} finally {
+		rmSync(loaderDir, { recursive: true, force: true });
+	}
 });
 
 test("extractPDFToMarkdown falls back to unpdf when Gemini output is truncated", () => {
-  const child = spawnSync(process.execPath, ["--input-type=module"], {
-    input: buildChildScript(extractorUrl, false, "truncate"),
-    encoding: "utf8",
-    maxBuffer: 2 * 1024 * 1024,
-  });
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl, false, "truncate"),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
 
-  assert.equal(
-    child.status,
-    0,
-    "PDF Gemini fallback failed in a child process. stderr summary:\n" + errorSummary(child.stderr),
-  );
-  assert.match(child.stdout, /Hello PDF/);
+	assert.equal(
+		child.status,
+		0,
+		"PDF Gemini fallback failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
+	assert.match(child.stdout, /Hello PDF/);
 });
 
 test("extractPDFToMarkdown preserves caller cancellation without local fallback", () => {
-  const child = spawnSync(process.execPath, ["--input-type=module"], {
-    input: buildChildScript(extractorUrl, false, "abort"),
-    encoding: "utf8",
-    maxBuffer: 2 * 1024 * 1024,
-  });
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl, false, "abort"),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
 
-  assert.equal(
-    child.status,
-    0,
-    "PDF cancellation assertion failed in a child process. stderr summary:\n" + errorSummary(child.stderr),
-  );
-  assert.match(child.stdout, /Aborted/);
-  assert.doesNotMatch(child.stdout, /Hello PDF/);
+	assert.equal(
+		child.status,
+		0,
+		"PDF cancellation assertion failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
+	assert.match(child.stdout, /Aborted/);
+	assert.doesNotMatch(child.stdout, /Hello PDF/);
 });
 
 test("extractPDFToMarkdown passes PDF.js errors-only verbosity", () => {
-  const loaderDir = mkdtempSync(join(tmpdir(), "pi-web-access-pdf-loader-"));
-  const loaderPath = join(loaderDir, "unpdf-loader.mjs");
-  writeFileSync(loaderPath, buildUnpdfLoader());
+	const loaderDir = mkdtempSync(join(tmpdir(), "pi-web-access-pdf-loader-"));
+	const loaderPath = join(loaderDir, "unpdf-loader.mjs");
+	writeFileSync(loaderPath, buildUnpdfLoader());
 
-  try {
-    const child = spawnSync(
-      process.execPath,
-      ["--experimental-loader", loaderPath, "--input-type=module"],
-      {
-        input: buildChildScript(extractorUrl, true),
-        encoding: "utf8",
-        maxBuffer: 2 * 1024 * 1024,
-      },
-    );
+	try {
+		const child = spawnSync(
+			process.execPath,
+			["--experimental-loader", loaderPath, "--input-type=module"],
+			{
+				input: buildChildScript(extractorUrl, true),
+				encoding: "utf8",
+				maxBuffer: 2 * 1024 * 1024,
+			},
+		);
 
-    assert.equal(
-      child.status,
-      0,
-      "PDF verbosity assertion failed in a child process. stderr summary:\n" + errorSummary(child.stderr),
-    );
+		assert.equal(
+			child.status,
+			0,
+			"PDF verbosity assertion failed in a child process. stderr summary:\n" +
+				errorSummary(child.stderr),
+		);
 
-    const options = JSON.parse(child.stdout.trim().split("\n").at(-1));
-    assert.equal(options.verbosity, 0);
-  } finally {
-    rmSync(loaderDir, { recursive: true, force: true });
-  }
+		const options = JSON.parse(child.stdout.trim().split("\n").at(-1));
+		assert.equal(options.verbosity, 0);
+	} finally {
+		rmSync(loaderDir, { recursive: true, force: true });
+	}
 });
 
 function buildBlockUnpdfLoader() {
-  return `
+	return `
     export function resolve(specifier, context, nextResolve) {
       if (specifier === "unpdf" || specifier === "unpdf/pdfjs") {
         throw new Error("unpdf should not load before successful Gemini PDF extraction");
@@ -126,8 +133,8 @@ function buildBlockUnpdfLoader() {
 }
 
 function buildUnpdfLoader() {
-  const unpdfUrl = pathToFileURL(require.resolve("unpdf")).href;
-  return `
+	const unpdfUrl = pathToFileURL(require.resolve("unpdf")).href;
+	return `
     const unpdfUrl = ${JSON.stringify(unpdfUrl)};
 
     export function resolve(specifier, context, nextResolve) {
@@ -155,50 +162,126 @@ function buildUnpdfLoader() {
   `;
 }
 
-function buildChildScript(moduleUrl, printOptions = false, geminiMode = "none") {
-  return `
-    import { mkdtemp, readFile } from "node:fs/promises";
-    import { tmpdir } from "node:os";
-    import { join } from "node:path";
-
-    process.on("uncaughtException", (error) => {
-      console.error(error?.stack || error);
-      process.exit(1);
-    });
-    process.on("unhandledRejection", (error) => {
-      console.error(error?.stack || error);
-      process.exit(1);
-    });
-
-    Reflect.deleteProperty(Promise, "try");
-    if (typeof Promise.try !== "undefined") {
-      throw new Error("Expected Promise.try to be unavailable before PDF extraction");
-    }
-
-    const geminiMode = ${JSON.stringify(geminiMode)};
-    const configDir = await mkdtemp(join(tmpdir(), "pi-web-access-pdf-config-"));
-    process.env.PI_CODING_AGENT_DIR = configDir;
-
-    if (geminiMode !== "none") {
-      process.env.GEMINI_API_KEY = "synthetic-gemini-key";
-      globalThis.fetch = async (_url, init) => {
-        if (init?.signal?.aborted) throw new DOMException("Aborted", "AbortError");
-        const success = geminiMode === "success";
-        return new Response(JSON.stringify({
-          candidates: [{
-            finishReason: success ? "STOP" : "MAX_TOKENS",
-            content: { parts: [{ text: success ? "<!-- Page 1 -->\\nGemini PDF" : "<!-- Page 1 -->\\nPartial" }] },
-          }],
-        }), { status: 200, headers: { "content-type": "application/json" } });
-      };
-    } else {
-      delete process.env.GEMINI_API_KEY;
-      delete process.env.GOOGLE_GEMINI_BASE_URL;
-      delete process.env.CLOUDFLARE_API_KEY;
-    }
-
-    const { extractPDFToMarkdown } = await import(${JSON.stringify(moduleUrl)});
-    const outputDir = await mkdtemp(join(tmpdir(), "pi-web-access-pdf-"));
+function buildChildScript(
+	moduleUrl,
+	printOptions = false,
+	geminiMode = "none",
+	datalabMode = "none",
+	provider = null,
+) {
+	return `
+        import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+        import { tmpdir } from "node:os";
+        import { join } from "node:path";
+    
+        process.on("uncaughtException", (error) => {
+          console.error(error?.stack || error);
+          process.exit(1);
+        });
+        process.on("unhandledRejection", (error) => {
+          console.error(error?.stack || error);
+          process.exit(1);
+        });
+    
+        Reflect.deleteProperty(Promise, "try");
+        if (typeof Promise.try !== "undefined") {
+          throw new Error("Expected Promise.try to be unavailable before PDF extraction");
+        }
+    
+        const geminiMode = ${JSON.stringify(geminiMode)};
+        const datalabMode = ${JSON.stringify(datalabMode)};
+        const provider = ${JSON.stringify(provider)};
+        const configDir = await mkdtemp(join(tmpdir(), "pi-web-access-pdf-config-"));
+        process.env.PI_CODING_AGENT_DIR = configDir;
+    
+        if (provider) {
+          await writeFile(
+            join(configDir, "web-search.json"),
+            JSON.stringify({ pdf: { provider } }),
+          );
+        }
+    
+        if (geminiMode !== "none") {
+          process.env.GEMINI_API_KEY = "synthetic-gemini-key";
+        } else {
+          delete process.env.GEMINI_API_KEY;
+          delete process.env.GOOGLE_GEMINI_BASE_URL;
+          delete process.env.CLOUDFLARE_API_KEY;
+        }
+    
+        if (datalabMode !== "none") {
+          process.env.DATALAB_API_KEY = "synthetic-datalab-key";
+        } else {
+          delete process.env.DATALAB_API_KEY;
+        }
+    
+        if (geminiMode !== "none" || datalabMode !== "none") {
+          globalThis.fetch = async (url, init) => {
+            if (init?.signal?.aborted) throw new DOMException("Aborted", "AbortError");
+            const urlString = String(url);
+            if (urlString.includes("generateContent")) {
+              if (provider === "datalab" || provider === "unpdf") {
+                throw new Error("Gemini called but provider=" + provider);
+              }
+              if (geminiMode === "success" || geminiMode === "truncate") {
+                const success = geminiMode === "success";
+                return new Response(JSON.stringify({
+                  candidates: [{
+                    finishReason: success ? "STOP" : "MAX_TOKENS",
+                    content: { parts: [{ text: success ? "<!-- Page 1 -->\\nGemini PDF" : "<!-- Page 1 -->\\nPartial" }] },
+                  }],
+                }), { status: 200, headers: { "content-type": "application/json" } });
+              }
+            }
+            if (datalabMode !== "none") {
+              if (urlString.includes("/files/upload")) {
+                return new Response(JSON.stringify({
+                  file_id: 7,
+                  upload_url: "https://storage.test/put/abc",
+                  reference: "datalab://file-7",
+                }), { status: 200, headers: { "content-type": "application/json" } });
+              }
+              if (urlString.includes("/put/")) {
+                return new Response(null, { status: 200 });
+              }
+              if (urlString.includes("/files/7/confirm")) {
+                return new Response(JSON.stringify({
+                  file_id: 7,
+                  reference: "datalab://file-7",
+                  message: "confirmed",
+                }), { status: 200, headers: { "content-type": "application/json" } });
+              }
+              if (urlString.endsWith("/files/7")) {
+                return new Response(null, { status: 200 });
+              }
+            }
+            if (urlString.includes("/convert") || urlString.includes("/check")) {
+              if (datalabMode === "fail") {
+                return new Response(JSON.stringify({ detail: "boom" }), {
+                  status: 500,
+                  statusText: "Internal Server Error",
+                  headers: { "content-type": "application/json" },
+                });
+              }
+              if (urlString.includes("/convert")) {
+                return new Response(JSON.stringify({
+                  status: "processing",
+                  request_check_url: "/check/1",
+                }), { status: 200, headers: { "content-type": "application/json" } });
+              }
+              return new Response(JSON.stringify({
+                status: "complete",
+                success: true,
+                markdown: "<!-- Page 1 -->\\nDatalab PDF",
+                page_count: 1,
+              }), { status: 200, headers: { "content-type": "application/json" } });
+            }
+            throw new Error("unexpected fetch: " + urlString);
+          };
+        }
+    
+        const { extractPDFToMarkdown } = await import(${JSON.stringify(moduleUrl)});
+        const outputDir = await mkdtemp(join(tmpdir(), "pi-web-access-pdf-"));
 
     if (geminiMode === "abort") {
       const controller = new AbortController();
@@ -260,12 +343,158 @@ function buildChildScript(moduleUrl, printOptions = false, geminiMode = "none") 
   `;
 }
 
-function errorSummary(value, size = 1200) {
-  const marker = "TypeError: Promise.try is not a function";
-  const index = value.indexOf(marker);
-  if (index >= 0) {
-    return value.slice(index, index + size);
-  }
+test("extractPDFToMarkdown uses Datalab before unpdf when configured", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl, false, "none", "success"),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
 
-  return value.length > size ? value.slice(-size) : value;
+	assert.equal(
+		child.status,
+		0,
+		"PDF Datalab-first assertion failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
+	assert.match(child.stdout, /Datalab PDF/);
+});
+
+test("extractPDFToMarkdown falls back to unpdf when Datalab conversion fails", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl, false, "none", "fail"),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
+
+	assert.equal(
+		child.status,
+		0,
+		"PDF Datalab fallback failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
+	assert.match(child.stdout, /Hello PDF/);
+});
+
+test("extractPDFToMarkdown auto order runs Datalab before Gemini", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl, false, "success", "success"),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
+
+	assert.equal(
+		child.status,
+		0,
+		"PDF Datalab-before-Gemini assertion failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
+	assert.match(child.stdout, /Datalab PDF/);
+	assert.doesNotMatch(child.stdout, /Gemini PDF/);
+});
+
+test("extractPDFToMarkdown auto order falls back from Datalab to Gemini", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl, false, "success", "fail"),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
+
+	assert.equal(
+		child.status,
+		0,
+		"PDF Datalab-to-Gemini fallback assertion failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
+	assert.match(child.stdout, /Gemini PDF/);
+	assert.doesNotMatch(child.stdout, /Datalab PDF/);
+});
+
+test("extractPDFToMarkdown provider=datalab skips Gemini even with a Gemini key", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(
+			extractorUrl,
+			false,
+			"success",
+			"success",
+			"datalab",
+		),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
+
+	assert.equal(
+		child.status,
+		0,
+		"PDF provider=datalab assertion failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
+	assert.match(child.stdout, /Datalab PDF/);
+	assert.doesNotMatch(child.stdout, /Gemini PDF/);
+});
+
+test("extractPDFToMarkdown provider=datalab without a key skips Gemini", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl, false, "success", "none", "datalab"),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
+
+	assert.equal(
+		child.status,
+		0,
+		"PDF provider=datalab without key assertion failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
+	assert.match(child.stdout, /Hello PDF/);
+	assert.doesNotMatch(child.stdout, /Gemini PDF/);
+});
+
+test("extractPDFToMarkdown provider=gemini skips Datalab even with a Datalab key", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(
+			extractorUrl,
+			false,
+			"success",
+			"success",
+			"gemini",
+		),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
+
+	assert.equal(
+		child.status,
+		0,
+		"PDF provider=gemini assertion failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
+	assert.match(child.stdout, /Gemini PDF/);
+	assert.doesNotMatch(child.stdout, /Datalab PDF/);
+});
+
+test("extractPDFToMarkdown provider=unpdf skips Gemini even with a Gemini key", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(extractorUrl, false, "success", "none", "unpdf"),
+		encoding: "utf8",
+		maxBuffer: 2 * 1024 * 1024,
+	});
+
+	assert.equal(
+		child.status,
+		0,
+		"PDF provider=unpdf assertion failed in a child process. stderr summary:\n" +
+			errorSummary(child.stderr),
+	);
+	assert.match(child.stdout, /Hello PDF/);
+	assert.doesNotMatch(child.stdout, /Gemini PDF/);
+});
+
+function errorSummary(value, size = 1200) {
+	const marker = "TypeError: Promise.try is not a function";
+	const index = value.indexOf(marker);
+	if (index >= 0) {
+		return value.slice(index, index + size);
+	}
+
+	return value.length > size ? value.slice(-size) : value;
 }

--- a/test/pdf-extract.test.mjs
+++ b/test/pdf-extract.test.mjs
@@ -173,7 +173,7 @@ function buildChildScript(
         import { mkdtemp, readFile, writeFile } from "node:fs/promises";
         import { tmpdir } from "node:os";
         import { join } from "node:path";
-    
+
         process.on("uncaughtException", (error) => {
           console.error(error?.stack || error);
           process.exit(1);
@@ -182,25 +182,25 @@ function buildChildScript(
           console.error(error?.stack || error);
           process.exit(1);
         });
-    
+
         Reflect.deleteProperty(Promise, "try");
         if (typeof Promise.try !== "undefined") {
           throw new Error("Expected Promise.try to be unavailable before PDF extraction");
         }
-    
+
         const geminiMode = ${JSON.stringify(geminiMode)};
         const datalabMode = ${JSON.stringify(datalabMode)};
         const provider = ${JSON.stringify(provider)};
         const configDir = await mkdtemp(join(tmpdir(), "pi-web-access-pdf-config-"));
         process.env.PI_CODING_AGENT_DIR = configDir;
-    
+
         if (provider) {
           await writeFile(
             join(configDir, "web-search.json"),
             JSON.stringify({ pdf: { provider } }),
           );
         }
-    
+
         if (geminiMode !== "none") {
           process.env.GEMINI_API_KEY = "synthetic-gemini-key";
         } else {
@@ -208,13 +208,13 @@ function buildChildScript(
           delete process.env.GOOGLE_GEMINI_BASE_URL;
           delete process.env.CLOUDFLARE_API_KEY;
         }
-    
+
         if (datalabMode !== "none") {
           process.env.DATALAB_API_KEY = "synthetic-datalab-key";
         } else {
           delete process.env.DATALAB_API_KEY;
         }
-    
+
         if (geminiMode !== "none" || datalabMode !== "none") {
           globalThis.fetch = async (url, init) => {
             if (init?.signal?.aborted) throw new DOMException("Aborted", "AbortError");
@@ -279,7 +279,7 @@ function buildChildScript(
             throw new Error("unexpected fetch: " + urlString);
           };
         }
-    
+
         const { extractPDFToMarkdown } = await import(${JSON.stringify(moduleUrl)});
         const outputDir = await mkdtemp(join(tmpdir(), "pi-web-access-pdf-"));
 

--- a/test/querit-provider.test.mjs
+++ b/test/querit-provider.test.mjs
@@ -9,7 +9,8 @@ import { test } from "node:test";
 const queritModuleUrl = new URL("../querit.ts", import.meta.url).href;
 const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
 const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
-const curatorPageModuleUrl = new URL("../curator-page.ts", import.meta.url).href;
+const curatorPageModuleUrl = new URL("../curator-page.ts", import.meta.url)
+	.href;
 
 const PROVIDER_ENV_KEYS = [
 	"OPENAI_API_KEY",
@@ -20,7 +21,10 @@ const PROVIDER_ENV_KEYS = [
 	"QUERIT_API_KEY",
 	"TAVILY_API_KEY",
 	"JINA_API_KEY",
-	"SERPDIVE_API_KEY", "KAGI_API_KEY", "OLLAMA_API_KEY", "SERPBASE_API_KEY",
+	"SERPDIVE_API_KEY",
+	"KAGI_API_KEY",
+	"OLLAMA_API_KEY",
+	"SERPBASE_API_KEY",
 	"ANYSEARCH_API_KEY",
 	"SEARXNG_BASE_URL",
 	"EXA_API_KEY",
@@ -34,7 +38,11 @@ const PROVIDER_ENV_KEYS = [
 async function createHome(config = {}) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-querit-"));
 	await mkdir(join(home, ".pi"), { recursive: true });
-	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	await writeFile(
+		join(home, ".pi", "web-search.json"),
+		JSON.stringify(config) + "\n",
+		"utf8",
+	);
 	return home;
 }
 
@@ -54,36 +62,54 @@ function runChild(script, env = {}) {
 
 test("Querit availability reads environment and config credentials", async () => {
 	const emptyHome = await createHome();
-	let child = runChild(`
+	let child = runChild(
+		`
 		const { isQueritAvailable } = await import(${JSON.stringify(queritModuleUrl)});
 		console.log(String(isQueritAvailable()));
-	`, { HOME: emptyHome, USERPROFILE: emptyHome });
+	`,
+		{ HOME: emptyHome, USERPROFILE: emptyHome },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "false");
 
-	child = runChild(`
+	child = runChild(
+		`
 		const { isQueritAvailable } = await import(${JSON.stringify(queritModuleUrl)});
 		console.log(String(isQueritAvailable()));
-	`, { HOME: emptyHome, USERPROFILE: emptyHome, QUERIT_API_KEY: "synthetic-querit-env-key" });
+	`,
+		{
+			HOME: emptyHome,
+			USERPROFILE: emptyHome,
+			QUERIT_API_KEY: "synthetic-querit-env-key",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "true");
 
-	const configHome = await createHome({ queritApiKey: "synthetic-querit-config-key" });
-	child = runChild(`
+	const configHome = await createHome({
+		queritApiKey: "synthetic-querit-config-key",
+	});
+	child = runChild(
+		`
 		const { isQueritAvailable } = await import(${JSON.stringify(queritModuleUrl)});
 		console.log(String(isQueritAvailable()));
-	`, { HOME: configHome, USERPROFILE: configHome });
+	`,
+		{ HOME: configHome, USERPROFILE: configHome },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "true");
 });
 
 test("Querit resolves command credentials only when a request starts", async () => {
-	const markerDir = await mkdtemp(join(tmpdir(), "pi-web-access-querit-marker-"));
+	const markerDir = await mkdtemp(
+		join(tmpdir(), "pi-web-access-querit-marker-"),
+	);
 	const marker = join(markerDir, "ran");
 	const home = await createHome({
 		queritApiKey: `!touch ${marker} && printf synthetic-querit-command-key`,
 	});
-	const child = runChild(`
+	const child = runChild(
+		`
 		import { existsSync } from "node:fs";
 		const { isQueritAvailable, searchWithQuerit } = await import(${JSON.stringify(queritModuleUrl)});
 		const availableBefore = isQueritAvailable();
@@ -95,7 +121,9 @@ test("Querit resolves command credentials only when a request starts", async () 
 		};
 		await searchWithQuerit("credential timing");
 		console.log(JSON.stringify({ availableBefore, ranBefore, ranAfter: existsSync(${JSON.stringify(marker)}), authorization }));
-	`, { HOME: home, USERPROFILE: home });
+	`,
+		{ HOME: home, USERPROFILE: home },
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	assert.deepEqual(JSON.parse(child.stdout.trim()), {
@@ -109,7 +137,8 @@ test("Querit resolves command credentials only when a request starts", async () 
 
 test("Querit search maps SDK filters and retrieves inline contents", async () => {
 	const home = await createHome();
-	const child = runChild(`
+	const child = runChild(
+		`
 		const calls = [];
 		globalThis.fetch = async (url, init = {}) => {
 			calls.push({
@@ -152,7 +181,13 @@ test("Querit search maps SDK filters and retrieves inline contents", async () =>
 			domainFilter: ["https://www.querit.ai/docs", "-example.com"],
 		});
 		console.log(JSON.stringify({ calls, result }));
-	`, { HOME: home, USERPROFILE: home, QUERIT_API_KEY: "synthetic-querit-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			QUERIT_API_KEY: "synthetic-querit-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
@@ -188,22 +223,27 @@ test("Querit search maps SDK filters and retrieves inline contents", async () =>
 			},
 		},
 	]);
-	assert.deepEqual(output.result.results, [{
-		title: "Querit docs",
-		url: "https://www.querit.ai/en/docs",
-		snippet: "Real-time search for LLMs.",
-	}]);
-	assert.deepEqual(output.result.inlineContent, [{
-		url: "https://www.querit.ai/en/docs",
-		title: "Querit Documentation",
-		content: "# Full Querit documentation",
-		error: null,
-	}]);
+	assert.deepEqual(output.result.results, [
+		{
+			title: "Querit docs",
+			url: "https://www.querit.ai/en/docs",
+			snippet: "Real-time search for LLMs.",
+		},
+	]);
+	assert.deepEqual(output.result.inlineContent, [
+		{
+			url: "https://www.querit.ai/en/docs",
+			title: "Querit Documentation",
+			content: "# Full Querit documentation",
+			error: null,
+		},
+	]);
 });
 
 test("Querit contents requests are batched at ten URLs", async () => {
 	const home = await createHome();
-	const child = runChild(`
+	const child = runChild(
+		`
 		const contentBatches = [];
 		globalThis.fetch = async (url, init = {}) => {
 			const body = JSON.parse(init.body);
@@ -232,17 +272,27 @@ test("Querit contents requests are batched at ten URLs", async () => {
 		const { searchWithQuerit } = await import(${JSON.stringify(queritModuleUrl)});
 		const result = await searchWithQuerit("batch", { includeContent: true, numResults: 11 });
 		console.log(JSON.stringify({ contentBatches, inlineCount: result.inlineContent?.length }));
-	`, { HOME: home, USERPROFILE: home, QUERIT_API_KEY: "synthetic-querit-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			QUERIT_API_KEY: "synthetic-querit-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
-	assert.deepEqual(output.contentBatches.map((batch) => batch.length), [10, 1]);
+	assert.deepEqual(
+		output.contentBatches.map((batch) => batch.length),
+		[10, 1],
+	);
 	assert.equal(output.inlineCount, 11);
 });
 
 test("Querit extraction maps contents metadata and timeout", async () => {
 	const home = await createHome();
-	const child = runChild(`
+	const child = runChild(
+		`
 		let call = null;
 		globalThis.fetch = async (url, init = {}) => {
 			call = { url: String(url), body: JSON.parse(init.body) };
@@ -263,7 +313,13 @@ test("Querit extraction maps contents metadata and timeout", async () => {
 		const { extractWithQuerit } = await import(${JSON.stringify(queritModuleUrl)});
 		const result = await extractWithQuerit("https://example.com/article", undefined, { timeoutMs: 45_000 });
 		console.log(JSON.stringify({ call, result }));
-	`, { HOME: home, USERPROFILE: home, QUERIT_API_KEY: "synthetic-querit-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			QUERIT_API_KEY: "synthetic-querit-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
@@ -286,14 +342,21 @@ test("Querit extraction maps contents metadata and timeout", async () => {
 
 test("Querit errors redact credentials and surface API-level failures", async () => {
 	const home = await createHome();
-	let child = runChild(`
+	let child = runChild(
+		`
 		globalThis.fetch = async () => new Response("rejected synthetic-querit-secret", { status: 401 });
 		const { searchWithQuerit } = await import(${JSON.stringify(queritModuleUrl)});
 		let error = "";
 		try { await searchWithQuerit("redact me"); }
 		catch (err) { error = err.message; }
 		console.log(JSON.stringify({ error }));
-	`, { HOME: home, USERPROFILE: home, QUERIT_API_KEY: "synthetic-querit-secret" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			QUERIT_API_KEY: "synthetic-querit-secret",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	let output = JSON.parse(child.stdout.trim());
@@ -301,25 +364,36 @@ test("Querit errors redact credentials and surface API-level failures", async ()
 	assert.equal(output.error.includes("synthetic-querit-secret"), false);
 	assert.match(output.error, /\[redacted\]/i);
 
-	child = runChild(`
+	child = runChild(
+		`
 		globalThis.fetch = async () => new Response(JSON.stringify({ error_code: 429, error_msg: "quota exceeded", search_id: 301 }), { status: 200 });
 		const { searchWithQuerit } = await import(${JSON.stringify(queritModuleUrl)});
 		let error = "";
 		try { await searchWithQuerit("quota"); }
 		catch (err) { error = err.message; }
 		console.log(JSON.stringify({ error }));
-	`, { HOME: home, USERPROFILE: home, QUERIT_API_KEY: "synthetic-querit-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			QUERIT_API_KEY: "synthetic-querit-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	output = JSON.parse(child.stdout.trim());
-	assert.equal(output.error, "Querit Search API returned error 429: quota exceeded");
+	assert.equal(
+		output.error,
+		"Querit Search API returned error 429: quota exceeded",
+	);
 });
 
 test("configured search routing can select Querit", async () => {
 	const home = await createHome({
 		searchRouting: { providers: ["querit"], fallbackOn: ["network"] },
 	});
-	const child = runChild(`
+	const child = runChild(
+		`
 		globalThis.fetch = async () => new Response(JSON.stringify({
 			error_code: 200,
 			error_msg: "",
@@ -329,12 +403,14 @@ test("configured search routing can select Querit", async () => {
 		const { search } = await import(${JSON.stringify(searchModuleUrl)});
 		const result = await search("route", { provider: "auto" });
 		console.log(JSON.stringify({ provider: result.provider, results: result.results }));
-	`, {
-		HOME: home,
-		USERPROFILE: home,
-		PI_CODING_AGENT_DIR: join(home, ".pi"),
-		QUERIT_API_KEY: "synthetic-querit-test-key",
-	});
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			PI_CODING_AGENT_DIR: join(home, ".pi"),
+			QUERIT_API_KEY: "synthetic-querit-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
@@ -343,8 +419,11 @@ test("configured search routing can select Querit", async () => {
 });
 
 test("fetch_content uses Querit after local and earlier hosted extraction fail", async () => {
-	const home = await createHome();
-	const child = runChild(`
+	const home = await createHome({
+		fetchRouting: { allowRemoteHostedProviders: true },
+	});
+	const child = runChild(
+		`
 		const calls = [];
 		globalThis.fetch = async (url, init = {}) => {
 			const target = String(url);
@@ -369,7 +448,13 @@ test("fetch_content uses Querit after local and earlier hosted extraction fail",
 		const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
 		const result = await extractContent("https://example.com/app", undefined, { lookup });
 		console.log(JSON.stringify({ calls, result }));
-	`, { HOME: home, USERPROFILE: home, QUERIT_API_KEY: "synthetic-querit-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			QUERIT_API_KEY: "synthetic-querit-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
@@ -419,8 +504,11 @@ test("curator page exposes Querit as a manual provider", async () => {
 });
 
 test("Querit provider timeout continues to the next fetch_content fallback", async () => {
-	const home = await createHome();
-	const child = runChild(`
+	const home = await createHome({
+		fetchRouting: { allowRemoteHostedProviders: true },
+	});
+	const child = runChild(
+		`
 		const calls = [];
 		globalThis.fetch = async (url, init = {}) => {
 			const target = String(url);
@@ -455,12 +543,14 @@ test("Querit provider timeout continues to the next fetch_content fallback", asy
 		const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
 		const result = await extractContent("https://example.com/timeout", undefined, { lookup, timeoutMs: 1 });
 		console.log(JSON.stringify({ calls, result }));
-	`, {
-		HOME: home,
-		USERPROFILE: home,
-		QUERIT_API_KEY: "synthetic-querit-test-key",
-		PARALLEL_API_KEY: "synthetic-parallel-test-key",
-	});
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			QUERIT_API_KEY: "synthetic-querit-test-key",
+			PARALLEL_API_KEY: "synthetic-parallel-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());

--- a/test/search1api.test.mjs
+++ b/test/search1api.test.mjs
@@ -9,7 +9,8 @@ import { test } from "node:test";
 const search1apiModuleUrl = new URL("../search1api.ts", import.meta.url).href;
 const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
 const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
-const curatorPageModuleUrl = new URL("../curator-page.ts", import.meta.url).href;
+const curatorPageModuleUrl = new URL("../curator-page.ts", import.meta.url)
+	.href;
 
 const PROVIDER_ENV_KEYS = [
 	"OPENAI_API_KEY",
@@ -20,7 +21,10 @@ const PROVIDER_ENV_KEYS = [
 	"QUERIT_API_KEY",
 	"TAVILY_API_KEY",
 	"JINA_API_KEY",
-	"SERPDIVE_API_KEY", "KAGI_API_KEY", "OLLAMA_API_KEY", "SERPBASE_API_KEY",
+	"SERPDIVE_API_KEY",
+	"KAGI_API_KEY",
+	"OLLAMA_API_KEY",
+	"SERPBASE_API_KEY",
 	"ANYSEARCH_API_KEY",
 	"SEARXNG_BASE_URL",
 	"EXA_API_KEY",
@@ -36,7 +40,11 @@ const PROVIDER_ENV_KEYS = [
 async function createHome(config = {}) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-search1api-"));
 	await mkdir(join(home, ".pi"), { recursive: true });
-	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	await writeFile(
+		join(home, ".pi", "web-search.json"),
+		JSON.stringify(config) + "\n",
+		"utf8",
+	);
 	return home;
 }
 
@@ -56,36 +64,54 @@ function runChild(script, env = {}) {
 
 test("Search1API availability reads environment and config credentials", async () => {
 	const emptyHome = await createHome();
-	let child = runChild(`
+	let child = runChild(
+		`
 		const { isSearch1APIAvailable } = await import(${JSON.stringify(search1apiModuleUrl)});
 		console.log(String(isSearch1APIAvailable()));
-	`, { HOME: emptyHome, USERPROFILE: emptyHome });
+	`,
+		{ HOME: emptyHome, USERPROFILE: emptyHome },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "false");
 
-	child = runChild(`
+	child = runChild(
+		`
 		const { isSearch1APIAvailable } = await import(${JSON.stringify(search1apiModuleUrl)});
 		console.log(String(isSearch1APIAvailable()));
-	`, { HOME: emptyHome, USERPROFILE: emptyHome, SEARCH1API_KEY: "synthetic-search1api-env-key" });
+	`,
+		{
+			HOME: emptyHome,
+			USERPROFILE: emptyHome,
+			SEARCH1API_KEY: "synthetic-search1api-env-key",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "true");
 
-	const configHome = await createHome({ search1apiApiKey: "synthetic-search1api-config-key" });
-	child = runChild(`
+	const configHome = await createHome({
+		search1apiApiKey: "synthetic-search1api-config-key",
+	});
+	child = runChild(
+		`
 		const { isSearch1APIAvailable } = await import(${JSON.stringify(search1apiModuleUrl)});
 		console.log(String(isSearch1APIAvailable()));
-	`, { HOME: configHome, USERPROFILE: configHome });
+	`,
+		{ HOME: configHome, USERPROFILE: configHome },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "true");
 });
 
 test("Search1API resolves command credentials only when a request starts", async () => {
-	const markerDir = await mkdtemp(join(tmpdir(), "pi-web-access-search1api-marker-"));
+	const markerDir = await mkdtemp(
+		join(tmpdir(), "pi-web-access-search1api-marker-"),
+	);
 	const marker = join(markerDir, "ran");
 	const home = await createHome({
 		search1apiApiKey: `!touch ${marker} && printf synthetic-search1api-command-key`,
 	});
-	const child = runChild(`
+	const child = runChild(
+		`
 		import { existsSync } from "node:fs";
 		const { isSearch1APIAvailable, searchWithSearch1API } = await import(${JSON.stringify(search1apiModuleUrl)});
 		const availableBefore = isSearch1APIAvailable();
@@ -97,7 +123,9 @@ test("Search1API resolves command credentials only when a request starts", async
 		};
 		await searchWithSearch1API("credential timing");
 		console.log(JSON.stringify({ availableBefore, ranBefore, ranAfter: existsSync(${JSON.stringify(marker)}), authorization }));
-	`, { HOME: home, USERPROFILE: home });
+	`,
+		{ HOME: home, USERPROFILE: home },
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	assert.deepEqual(JSON.parse(child.stdout.trim()), {
@@ -111,7 +139,8 @@ test("Search1API resolves command credentials only when a request starts", async
 
 test("explicit Search1API search maps filters, deep content, and results", async () => {
 	const home = await createHome({ provider: "search1api" });
-	const child = runChild(`
+	const child = runChild(
+		`
 		const calls = [];
 		globalThis.fetch = async (url, init = {}) => {
 			calls.push({
@@ -138,42 +167,55 @@ test("explicit Search1API search maps filters, deep content, and results", async
 			domainFilter: ["https://www.search1api.com/docs", "-example.com"],
 		});
 		console.log(JSON.stringify({ calls, result }));
-	`, { HOME: home, USERPROFILE: home, SEARCH1API_KEY: "synthetic-search1api-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			SEARCH1API_KEY: "synthetic-search1api-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
-	assert.deepEqual(output.calls, [{
-		url: "https://api.search1api.com/search",
-		headers: {
-			authorization: "Bearer synthetic-search1api-test-key",
-			"content-type": "application/json",
+	assert.deepEqual(output.calls, [
+		{
+			url: "https://api.search1api.com/search",
+			headers: {
+				authorization: "Bearer synthetic-search1api-test-key",
+				"content-type": "application/json",
+			},
+			body: {
+				query: "search1api docs",
+				max_results: 1,
+				crawl_results: 1,
+				include_sites: ["www.search1api.com"],
+				exclude_sites: ["example.com"],
+				time_range: "week",
+			},
 		},
-		body: {
-			query: "search1api docs",
-			max_results: 1,
-			crawl_results: 1,
-			include_sites: ["www.search1api.com"],
-			exclude_sites: ["example.com"],
-			time_range: "week",
-		},
-	}]);
+	]);
 	assert.equal(output.result.provider, "search1api");
-	assert.deepEqual(output.result.results, [{
-		title: "Search1API Docs",
-		url: "https://www.search1api.com/docs",
-		snippet: "Search, crawl, and extract.",
-	}]);
-	assert.deepEqual(output.result.inlineContent, [{
-		url: "https://www.search1api.com/docs",
-		title: "Search1API Docs",
-		content: "# Full Search1API documentation",
-		error: null,
-	}]);
+	assert.deepEqual(output.result.results, [
+		{
+			title: "Search1API Docs",
+			url: "https://www.search1api.com/docs",
+			snippet: "Search, crawl, and extract.",
+		},
+	]);
+	assert.deepEqual(output.result.inlineContent, [
+		{
+			url: "https://www.search1api.com/docs",
+			title: "Search1API Docs",
+			content: "# Full Search1API documentation",
+			error: null,
+		},
+	]);
 });
 
 test("Search1API search does not request paid page crawling unless includeContent is true", async () => {
 	const home = await createHome();
-	const child = runChild(`
+	const child = runChild(
+		`
 		let body = null;
 		globalThis.fetch = async (_url, init) => {
 			body = JSON.parse(init.body);
@@ -182,7 +224,13 @@ test("Search1API search does not request paid page crawling unless includeConten
 		const { searchWithSearch1API } = await import(${JSON.stringify(search1apiModuleUrl)});
 		await searchWithSearch1API("basic search", { numResults: 20 });
 		console.log(JSON.stringify(body));
-	`, { HOME: home, USERPROFILE: home, SEARCH1API_KEY: "synthetic-search1api-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			SEARCH1API_KEY: "synthetic-search1api-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	assert.deepEqual(JSON.parse(child.stdout.trim()), {
@@ -194,7 +242,8 @@ test("Search1API search does not request paid page crawling unless includeConten
 
 test("Search1API Crawl maps extracted content", async () => {
 	const home = await createHome();
-	const child = runChild(`
+	const child = runChild(
+		`
 		const calls = [];
 		globalThis.fetch = async (url, init) => {
 			calls.push({
@@ -215,18 +264,26 @@ test("Search1API Crawl maps extracted content", async () => {
 		const { extractWithSearch1API } = await import(${JSON.stringify(search1apiModuleUrl)});
 		const result = await extractWithSearch1API("https://example.com/article", undefined, { timeoutMs: 45000 });
 		console.log(JSON.stringify({ calls, result }));
-	`, { HOME: home, USERPROFILE: home, SEARCH1API_KEY: "synthetic-search1api-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			SEARCH1API_KEY: "synthetic-search1api-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
-	assert.deepEqual(output.calls, [{
-		url: "https://api.search1api.com/crawl",
-		headers: {
-			authorization: "Bearer synthetic-search1api-test-key",
-			"content-type": "application/json",
+	assert.deepEqual(output.calls, [
+		{
+			url: "https://api.search1api.com/crawl",
+			headers: {
+				authorization: "Bearer synthetic-search1api-test-key",
+				"content-type": "application/json",
+			},
+			body: { url: "https://example.com/article" },
 		},
-		body: { url: "https://example.com/article" },
-	}]);
+	]);
 	assert.deepEqual(output.result, {
 		url: "https://example.com/article",
 		title: "Example article",
@@ -237,14 +294,21 @@ test("Search1API Crawl maps extracted content", async () => {
 
 test("Search1API errors redact credentials", async () => {
 	const home = await createHome();
-	const child = runChild(`
+	const child = runChild(
+		`
 		globalThis.fetch = async () => new Response("rejected synthetic-search1api-secret", { status: 401 });
 		const { searchWithSearch1API } = await import(${JSON.stringify(search1apiModuleUrl)});
 		let error = "";
 		try { await searchWithSearch1API("redact me"); }
 		catch (err) { error = err.message; }
 		console.log(JSON.stringify({ error }));
-	`, { HOME: home, USERPROFILE: home, SEARCH1API_KEY: "synthetic-search1api-secret" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			SEARCH1API_KEY: "synthetic-search1api-secret",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
@@ -254,8 +318,11 @@ test("Search1API errors redact credentials", async () => {
 });
 
 test("fetch_content uses Search1API after local and Jina extraction fail", async () => {
-	const home = await createHome();
-	const child = runChild(`
+	const home = await createHome({
+		fetchRouting: { allowRemoteHostedProviders: true },
+	});
+	const child = runChild(
+		`
 		const calls = [];
 		globalThis.fetch = async (url, init = {}) => {
 			const urlText = String(url);
@@ -277,12 +344,14 @@ test("fetch_content uses Search1API after local and Jina extraction fail", async
 		const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
 		const result = await extractContent("https://example.com/app", undefined, { lookup });
 		console.log(JSON.stringify({ calls, result }));
-	`, {
-		HOME: home,
-		USERPROFILE: home,
-		SEARCH1API_KEY: "synthetic-search1api-test-key",
-		PARALLEL_API_KEY: "synthetic-parallel-test-key",
-	});
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			SEARCH1API_KEY: "synthetic-search1api-test-key",
+			PARALLEL_API_KEY: "synthetic-parallel-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
@@ -303,7 +372,8 @@ test("configured searchRouting can select Search1API", async () => {
 	const home = await createHome({
 		searchRouting: { providers: ["search1api"], fallbackOn: ["network"] },
 	});
-	const child = runChild(`
+	const child = runChild(
+		`
 		globalThis.fetch = async () => new Response(JSON.stringify({
 			searchParameters: { query: "route" },
 			results: [{ title: "Routed", snippet: "Search1API route", link: "https://example.com/routed" }],
@@ -311,7 +381,14 @@ test("configured searchRouting can select Search1API", async () => {
 		const { search } = await import(${JSON.stringify(searchModuleUrl)});
 		const result = await search("route", { provider: "auto" });
 		console.log(JSON.stringify({ provider: result.provider, results: result.results }));
-	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: join(home, ".pi"), SEARCH1API_KEY: "synthetic-search1api-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			PI_CODING_AGENT_DIR: join(home, ".pi"),
+			SEARCH1API_KEY: "synthetic-search1api-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());

--- a/test/tinyfish.test.mjs
+++ b/test/tinyfish.test.mjs
@@ -8,7 +8,8 @@ import { test } from "node:test";
 const tinyfishModuleUrl = new URL("../tinyfish.ts", import.meta.url).href;
 const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
 const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
-const curatorPageModuleUrl = new URL("../curator-page.ts", import.meta.url).href;
+const curatorPageModuleUrl = new URL("../curator-page.ts", import.meta.url)
+	.href;
 
 const PROVIDER_ENV_KEYS = [
 	"OPENAI_API_KEY",
@@ -17,7 +18,10 @@ const PROVIDER_ENV_KEYS = [
 	"TINYFISH_API_KEY",
 	"TAVILY_API_KEY",
 	"JINA_API_KEY",
-	"SERPDIVE_API_KEY", "KAGI_API_KEY", "OLLAMA_API_KEY", "SERPBASE_API_KEY",
+	"SERPDIVE_API_KEY",
+	"KAGI_API_KEY",
+	"OLLAMA_API_KEY",
+	"SERPBASE_API_KEY",
 	"ANYSEARCH_API_KEY",
 	"BRIGHTDATA_API_KEY",
 	"BRIGHTDATA_SERP_ZONE",
@@ -35,7 +39,11 @@ const PROVIDER_ENV_KEYS = [
 async function createHome(config = {}) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-tinyfish-"));
 	await mkdir(join(home, ".pi"), { recursive: true });
-	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	await writeFile(
+		join(home, ".pi", "web-search.json"),
+		JSON.stringify(config) + "\n",
+		"utf8",
+	);
 	return home;
 }
 
@@ -55,32 +63,48 @@ function runChild(script, env = {}) {
 
 test("TinyFish availability reads environment and config credentials", async () => {
 	const emptyHome = await createHome();
-	let child = runChild(`
+	let child = runChild(
+		`
 		const { isTinyFishAvailable } = await import(${JSON.stringify(tinyfishModuleUrl)});
 		console.log(String(isTinyFishAvailable()));
-	`, { HOME: emptyHome, USERPROFILE: emptyHome });
+	`,
+		{ HOME: emptyHome, USERPROFILE: emptyHome },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "false");
 
-	child = runChild(`
+	child = runChild(
+		`
 		const { isTinyFishAvailable } = await import(${JSON.stringify(tinyfishModuleUrl)});
 		console.log(String(isTinyFishAvailable()));
-	`, { HOME: emptyHome, USERPROFILE: emptyHome, TINYFISH_API_KEY: "synthetic-tinyfish-env-key" });
+	`,
+		{
+			HOME: emptyHome,
+			USERPROFILE: emptyHome,
+			TINYFISH_API_KEY: "synthetic-tinyfish-env-key",
+		},
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "true");
 
-	const configHome = await createHome({ tinyfishApiKey: "synthetic-tinyfish-config-key" });
-	child = runChild(`
+	const configHome = await createHome({
+		tinyfishApiKey: "synthetic-tinyfish-config-key",
+	});
+	child = runChild(
+		`
 		const { isTinyFishAvailable } = await import(${JSON.stringify(tinyfishModuleUrl)});
 		console.log(String(isTinyFishAvailable()));
-	`, { HOME: configHome, USERPROFILE: configHome });
+	`,
+		{ HOME: configHome, USERPROFILE: configHome },
+	);
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "true");
 });
 
 test("explicit TinyFish search maps filters, results, and full inline content", async () => {
 	const home = await createHome({ provider: "tinyfish" });
-	const child = runChild(`
+	const child = runChild(
+		`
 		const calls = [];
 		globalThis.fetch = async (url, init = {}) => {
 			const urlText = String(url);
@@ -114,40 +138,60 @@ test("explicit TinyFish search maps filters, results, and full inline content", 
 			domainFilter: ["docs.tinyfish.ai", "-example.com"],
 		});
 		console.log(JSON.stringify({ calls, result }));
-	`, { HOME: home, USERPROFILE: home, TINYFISH_API_KEY: "synthetic-tinyfish-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			TINYFISH_API_KEY: "synthetic-tinyfish-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
 	assert.equal(output.calls.length, 2);
 	const searchUrl = new URL(output.calls[0].url);
-	assert.equal(searchUrl.origin + searchUrl.pathname, "https://api.search.tinyfish.ai/");
+	assert.equal(
+		searchUrl.origin + searchUrl.pathname,
+		"https://api.search.tinyfish.ai/",
+	);
 	assert.equal(searchUrl.searchParams.get("query"), "tinyfish docs");
-	assert.equal(searchUrl.searchParams.get("include_domains"), "docs.tinyfish.ai");
+	assert.equal(
+		searchUrl.searchParams.get("include_domains"),
+		"docs.tinyfish.ai",
+	);
 	assert.equal(searchUrl.searchParams.get("exclude_domains"), "example.com");
 	assert.equal(searchUrl.searchParams.get("recency_minutes"), "10080");
-	assert.equal(output.calls[0].headers["x-api-key"], "synthetic-tinyfish-test-key");
+	assert.equal(
+		output.calls[0].headers["x-api-key"],
+		"synthetic-tinyfish-test-key",
+	);
 	assert.deepEqual(output.calls[1].body, {
 		urls: ["https://docs.tinyfish.ai/"],
 		format: "markdown",
 		per_url_timeout_ms: 110000,
 	});
 	assert.equal(output.result.provider, "tinyfish");
-	assert.deepEqual(output.result.results, [{
-		title: "TinyFish Docs",
-		url: "https://docs.tinyfish.ai/",
-		snippet: "Search and fetch",
-	}]);
-	assert.deepEqual(output.result.inlineContent, [{
-		url: "https://docs.tinyfish.ai/",
-		title: "TinyFish Docs",
-		content: "# Full TinyFish documentation",
-		error: null,
-	}]);
+	assert.deepEqual(output.result.results, [
+		{
+			title: "TinyFish Docs",
+			url: "https://docs.tinyfish.ai/",
+			snippet: "Search and fetch",
+		},
+	]);
+	assert.deepEqual(output.result.inlineContent, [
+		{
+			url: "https://docs.tinyfish.ai/",
+			title: "TinyFish Docs",
+			content: "# Full TinyFish documentation",
+			error: null,
+		},
+	]);
 });
 
 test("TinyFish search paginates when more than ten results are requested", async () => {
 	const home = await createHome();
-	const child = runChild(`
+	const child = runChild(
+		`
 		const urls = [];
 		globalThis.fetch = async (url) => {
 			const parsed = new URL(String(url));
@@ -164,7 +208,13 @@ test("TinyFish search paginates when more than ten results are requested", async
 		const { searchWithTinyFish } = await import(${JSON.stringify(tinyfishModuleUrl)});
 		const result = await searchWithTinyFish("many", { numResults: 15 });
 		console.log(JSON.stringify({ urls, count: result.results.length, last: result.results.at(-1)?.url }));
-	`, { HOME: home, USERPROFILE: home, TINYFISH_API_KEY: "synthetic-tinyfish-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			TINYFISH_API_KEY: "synthetic-tinyfish-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
@@ -176,7 +226,8 @@ test("TinyFish search paginates when more than ten results are requested", async
 
 test("TinyFish extraction maps successful content and reports per-URL errors", async () => {
 	const home = await createHome();
-	const child = runChild(`
+	const child = runChild(
+		`
 		let attempt = 0;
 		const bodies = [];
 		globalThis.fetch = async (_url, init) => {
@@ -199,7 +250,13 @@ test("TinyFish extraction maps successful content and reports per-URL errors", a
 		try { await extractWithTinyFish("https://example.com/blocked"); }
 		catch (err) { error = err.message; }
 		console.log(JSON.stringify({ bodies, good, error }));
-	`, { HOME: home, USERPROFILE: home, TINYFISH_API_KEY: "synthetic-tinyfish-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			TINYFISH_API_KEY: "synthetic-tinyfish-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
@@ -215,19 +272,29 @@ test("TinyFish extraction maps successful content and reports per-URL errors", a
 		content: "# Rendered body",
 		error: null,
 	});
-	assert.match(output.error, /TinyFish Fetch failed .*bot_blocked \(HTTP 403\)/);
+	assert.match(
+		output.error,
+		/TinyFish Fetch failed .*bot_blocked \(HTTP 403\)/,
+	);
 });
 
 test("TinyFish API errors redact credentials", async () => {
 	const home = await createHome();
-	const child = runChild(`
+	const child = runChild(
+		`
 		globalThis.fetch = async () => new Response("rejected synthetic-tinyfish-secret", { status: 401 });
 		const { searchWithTinyFish } = await import(${JSON.stringify(tinyfishModuleUrl)});
 		let error = "";
 		try { await searchWithTinyFish("redact me"); }
 		catch (err) { error = err.message; }
 		console.log(JSON.stringify({ error }));
-	`, { HOME: home, USERPROFILE: home, TINYFISH_API_KEY: "synthetic-tinyfish-secret" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			TINYFISH_API_KEY: "synthetic-tinyfish-secret",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
@@ -237,8 +304,11 @@ test("TinyFish API errors redact credentials", async () => {
 });
 
 test("fetch_content uses TinyFish before Parallel after local and Jina extraction fail", async () => {
-	const home = await createHome();
-	const child = runChild(`
+	const home = await createHome({
+		fetchRouting: { allowRemoteHostedProviders: true },
+	});
+	const child = runChild(
+		`
 		const calls = [];
 		globalThis.fetch = async (url, init = {}) => {
 			const urlText = String(url);
@@ -260,12 +330,14 @@ test("fetch_content uses TinyFish before Parallel after local and Jina extractio
 		const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
 		const result = await extractContent("https://example.com/app", undefined, { lookup });
 		console.log(JSON.stringify({ calls, result }));
-	`, {
-		HOME: home,
-		USERPROFILE: home,
-		TINYFISH_API_KEY: "synthetic-tinyfish-test-key",
-		PARALLEL_API_KEY: "synthetic-parallel-test-key",
-	});
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			TINYFISH_API_KEY: "synthetic-tinyfish-test-key",
+			PARALLEL_API_KEY: "synthetic-parallel-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
@@ -286,7 +358,8 @@ test("configured searchRouting can select TinyFish", async () => {
 	const home = await createHome({
 		searchRouting: { providers: ["tinyfish"], fallbackOn: ["network"] },
 	});
-	const child = runChild(`
+	const child = runChild(
+		`
 		globalThis.fetch = async () => new Response(JSON.stringify({
 			query: "route",
 			results: [{ title: "Routed", snippet: "TinyFish route", url: "https://example.com/routed" }],
@@ -296,7 +369,14 @@ test("configured searchRouting can select TinyFish", async () => {
 		const { search } = await import(${JSON.stringify(searchModuleUrl)});
 		const result = await search("route", { provider: "auto" });
 		console.log(JSON.stringify({ provider: result.provider, results: result.results }));
-	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: join(home, ".pi"), TINYFISH_API_KEY: "synthetic-tinyfish-test-key" });
+	`,
+		{
+			HOME: home,
+			USERPROFILE: home,
+			PI_CODING_AGENT_DIR: join(home, ".pi"),
+			TINYFISH_API_KEY: "synthetic-tinyfish-test-key",
+		},
+	);
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());


### PR DESCRIPTION
# feat: add Datalab as a selectable PDF-to-Markdown provider

## Summary

Adds Datalab's hosted PDF-to-Markdown conversion as a third extraction engine alongside the existing Gemini API and local `unpdf` paths. The PDF tier is now user-selectable via `pdf.provider` (`auto` | `gemini` | `datalab` | `unpdf`). In `auto` mode the chain runs **Datalab → Gemini → `unpdf`**: Datalab runs first for layout-aware conversion, falling through to Gemini when it errors (for example when free-tier credit is exhausted), then to local `unpdf`. A pinned provider skips the other remote tiers; behavior for existing users without a Datalab key is unchanged (Gemini → `unpdf`).

## Why Datalab

- **Dedicated, layout-aware extraction.** The hosted converter runs a dedicated document-intelligence model (open weights: [Chandra OCR 2](https://github.com/datalab-to/chandra)) that retains tables, multi-column reading order, headings, links, and math, where local `unpdf` extraction only yields flattened text.
- **Optional quality signal.** Completed responses may include `parse_quality_score` (0–5), suitable for gating or alerting when present.
- **Scanned documents.** `accurate` mode is intended for complex layouts and scanned pages.
- **Generous free tier.** $10/month credit with a personal email ($20 with a work email) at 25 requests/minute — roughly 2,500 pages/month in `fast` / `balanced` mode or 1,000 in `accurate` mode. Paid pricing is per page: `fast` / `balanced` $4 / 1,000 pages; `accurate` $10 / 1,000 pages. EU data residency consumes 1.25× usage.

## Configuration

```jsonc
{
  "datalabApiKey": "$DATALAB_API_KEY",
  "pdf": {
    "maxSizeMB": 20,
    "provider": "auto",        // "auto" | "gemini" | "datalab" | "unpdf"
    "datalabMode": "balanced", // "fast" | "balanced" | "accurate"
    "datalabTimeoutMs": 120000
  }
}
```

Env vars: `DATALAB_API_KEY` (or `datalabApiKey`), `DATALAB_PROCESSING_LOCATION` (`us` default; `eu` enables EU data residency at 1.25× usage), `DATALAB_MODE`, `DATALAB_API_BASE` (custom gateway). `pdf.datalabMode` overrides `DATALAB_MODE`; `datalabTimeoutMs` defaults to 120s, capped at 300s.

## Benchmarks

Datalab publishes its extraction quality on the widely used [olmOCR benchmark](https://github.com/datalab-to/chandra); the hosted Datalab API is the top overall scorer, well ahead of the Gemini tier it replaces in `auto` order:

| Model | Overall (olmOCR) |
| :--- | :---: |
| **Datalab API** | **86.7 ± 0.8** |
| Chandra 2 (open weights) | 85.8 ± 0.8 |
| olmOCR 2 | 82.4 |
| Mistral OCR API | 72.0 |
| GPT-4o (Anchored) | 69.9 |
| Gemini Flash 2 (Anchored) | 63.8 ± 1.2 |

That is a ~23-point overall gap over Gemini Flash 2, and Datalab leads even more on the categories this feature targets — ArXiv 90.4 vs 54.5, old-scan math 90.2 vs 56.1, tables 90.7 vs 72.1, long tiny text 92.3 vs 71.5.

Multilingual results follow the same pattern: across 43 common languages the Datalab API averages 80.4% vs Gemini 2.5 Flash's 67.6%, and across a full 90-language run Chandra 2 averages 72.7% vs Gemini 2.5 Flash's 60.8%.

*Source: [datalab-to/chandra](https://github.com/datalab-to/chandra) (Datalab-published; Gemini/GPT-4o rows sourced from the olmOCR repo).*

## Future: local model option (no API cost)

The model behind the Datalab API is published as open weights ([Chandra OCR 2](https://github.com/datalab-to/chandra)) with local inference modes (HuggingFace and vLLM). The PDF provider chain is separated by design, so a future local tier — a `local` provider or a configurable self-hosted endpoint — can slot in ahead of or instead of the cloud tiers and run extraction with **zero per-page API cost**: the same quality model, no request-rate limit, and no document bytes leaving the machine. This PR intentionally does not implement that tier; it keeps the routing seam open for it.

## Implementation notes

- **No new dependency.** The client uses native `fetch` / `FormData` / `Blob`.
- **Regional upload flow.** Datalab rejects multipart uploads combined with `processing_location` (HTTP 403), so the provider requests a presigned upload URL for the selected region, PUTs the PDF bytes directly to storage, confirms the upload, submits the conversion by `file_url` reference, and polls `request_check_url` until `complete` / `failed`. The region is fixed at the upload step; the convert step intentionally omits `processing_location`.
- **Status-keyed polling.** The convert submit response is an acceptance ack (`success: true`, no status), so completion is keyed on the `status` field (`complete` / `failed`) rather than `success`.
- **Credentials** resolve through the existing repo credential-source rules (`datalabApiKey` config value or `DATALAB_API_KEY`); API keys are redacted from all errors, and the upload key never appears in URLs.
- **Error semantics match the Gemini tier.** Caller cancellation/abort is rethrown, credential and config-parse errors are fatal, and other failures fall through to the next eligible tier (Gemini, then local `unpdf` in `auto`; local `unpdf` for a pinned provider).
- **Request boundaries.** JSON responses are capped while streaming; authenticated requests reject redirects, and polling URLs must share the configured Datalab API origin so an API key cannot be sent to an arbitrary host.
- **Cleanup.** Uploaded files are deleted best-effort after conversion.
- **Privacy note.** Like the Gemini tier, PDF bytes are sent to the Datalab cloud for conversion, stored in the selected region, and deleted best-effort afterward.

## Tests

- 29 new regression tests: 18 Datalab-client tests (regional upload/convert/poll flow, non-blocking cleanup, caller cancellation, region + mode selection, missing file ID, cross-origin polling URL rejection, streamed response cap, HTTP and transport-error redaction, failed-status errors, empty markdown, deadline-bounded polling, timeout, missing check URL, custom API base, invalid region), 8 provider-chain tests (Datalab-before-`unpdf`, Datalab→Gemini fallback, all pinned-provider skip cases), and 3 config-parsing tests.
- **Fallback-fixture repair.** Nine existing hosted-fallback tests now explicitly enable `fetchRouting.allowRemoteHostedProviders`, matching the secure default and restoring their intended provider-chain coverage.
- Full suite: 416/416 pass. Datalab/PDF coverage is green.
- Live end-to-end verified against a real one-page PDF: Markdown output and `page_count` confirmed. `parse_quality_score` is consumed when the API supplies it and may be absent.

## Docs

README PDF section rewritten with the provider matrix, Datalab quality/pricing rationale, config reference, env vars, timeouts/limits, and a privacy note.
