### PR TITLE
docs: document Reddit Jina fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Added Datalab hosted PDF-to-Markdown extraction as an optional PDF provider. Thanks José Antonio Galiano Sandoval (`@jagaliano`) for PR #226.
 
+### Changed
+- Documented the no-account Jina Reader fallback for Reddit URLs blocked by direct HTTP. Thanks `@talosu` for issue #225.
+
 ### Fixed
 - Preserve collapsed `web_search` result background padding. Thanks `@SheffeyG` for PR #224.
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,19 @@ Raw and direct-image HTTP requests use the same SSRF validation, hostname domain
 
 When Readability fails or returns only a cookie notice, the extension can retry configured Firecrawl extraction, Jina Reader (handles JS rendering server-side, no API key needed), TinyFish, Search1API, Querit, Kagi Extract, Ollama Web Fetch, Parallel, Bright Data Web Unlocker, Gemini URL Context API, and Gemini Web extraction when browser cookies are enabled. Configure `fetchRouting.providers` to change the order or set of `fetch_content` providers. Supported values are `http`, `firecrawl`, `jina`, `tinyfish`, `search1api`, `querit`, `kagi`, `ollama`, `parallel`, `brightdata`, and `gemini`; when absent, the default order is unchanged. For remote HTTP(S) targets, third-party hosted providers are disabled unless `fetchRouting.allowRemoteHostedProviders` is `true`, because hosted services perform their own fetch and can see a different redirect chain than the local safety gate. Firecrawl stays available as a configured extraction service. Firecrawl requests are cache-only by default and require an explicit fresh-scrape opt-in before the Firecrawl server can fetch target URLs. Bright Data Web Unlocker runs last of the remote scraping providers, ahead of only the Gemini fallbacks, because it is billed per request against a paid account; it is skipped unless both a key and an `unblocker` zone are configured. It applies no minimum-length check, so any non-empty body it returns — including a short consent or paywall stub — is the final answer for that URL and the Gemini fallbacks are not tried. Handles SPAs, JS-heavy pages, and anti-bot protections transparently. Also parses Next.js RSC flight data when present. HTML extraction also surfaces registered discovery relations (`service-desc`, `service-doc`, `service-meta`, `api-catalog`, `describedby`) from the HTTP `Link` header and matching `link`/`a[rel]` markup. Readable or rendered content remains primary; on an empty shell, the normal extraction fallbacks run before declared links are returned on their own.
 
+For Reddit URLs that return `403` through direct HTTP and where Reddit will not issue a classic app client ID, use the no-account Jina Reader fallback:
+
+```json
+{
+  "fetchRouting": {
+    "providers": ["http", "jina"],
+    "allowRemoteHostedProviders": true
+  }
+}
+```
+
+This lets local HTTP try first, then lets Jina Reader fetch the Reddit URL from its hosted service and return Markdown. The target URL is sent to Jina, so only enable it when that hosted fetch is acceptable.
+
 ## How It Works
 
 ```

--- a/extract.ts
+++ b/extract.ts
@@ -771,6 +771,7 @@ export async function extractContent(
 		...(brightdataError ? [`Bright Data fallback failed: ${brightdataError}`] : []),
 		"",
 		"Fallback options:",
+		`  • For Reddit without a working app, set fetchRouting.providers to ["http", "jina"] and fetchRouting.allowRemoteHostedProviders to true in ${WEB_SEARCH_CONFIG_PATH}`,
 		`  • Set firecrawlBaseUrl in ${WEB_SEARCH_CONFIG_PATH} to a self-hosted Firecrawl instance`,
 		`  • Set tinyfishApiKey in ${WEB_SEARCH_CONFIG_PATH} or TINYFISH_API_KEY`,
 		`  • Set search1apiApiKey in ${WEB_SEARCH_CONFIG_PATH} or SEARCH1API_KEY`,


### PR DESCRIPTION
Refs #225.

This drops the untested Reddit OAuth implementation from the draft. Reddit app registration now blocks both the reporter and maintainer before it issues a classic app client ID, so the OAuth path is not ship-safe.

This PR now does the small useful thing we can verify:
- documents the existing no-account Jina Reader fallback for Reddit URLs that return `403` through direct HTTP;
- adds the same fallback to `fetch_content` error guidance;
- credits @talosu for the issue and follow-up testing.

Recommended config:

```json
{
  "fetchRouting": {
    "providers": ["http", "jina"],
    "allowRemoteHostedProviders": true
  }
}
```

This keeps local HTTP first, then lets Jina Reader fetch the Reddit URL from its hosted service and return Markdown. The docs call out that the target URL is sent to Jina, so users only enable it when that hosted fetch is acceptable.

Validation on the current head:
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npm test` — 416 passed
- Fresh-context review: no blockers
