### PR TITLE
fix: route Gemini Web requests through a dedicated undici agent with a larger header budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - Added Datalab hosted PDF-to-Markdown extraction as an optional PDF provider. Thanks José Antonio Galiano Sandoval (`@jagaliano`) for PR #226.
 
 ### Fixed
-- Fix Gemini Web "fetch failed" (`UND_ERR_HEADERS_OVERFLOW`) when running inside a host agent whose global undici dispatcher uses HTTP/1.1 with the default 16 KiB `maxHeaderSize`: Google's `/app` page exceeds that budget. Gemini Web requests now use a dedicated undici agent with a 4 MiB header budget.
+- Fix Gemini Web "fetch failed" (`UND_ERR_HEADERS_OVERFLOW`) when running inside a host agent whose global undici dispatcher uses HTTP/1.1 with the default 16 KiB `maxHeaderSize`: Google's `/app` page exceeds that budget. Gemini Web requests now use a dedicated undici agent with a 4 MiB header budget. Thanks José Antonio Galiano Sandoval (`@jagaliano`) for PR #230.
 - Preserve collapsed `web_search` result background padding. Thanks `@SheffeyG` for PR #224.
 
 ## [0.19.0] - 2026-08-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Added Datalab hosted PDF-to-Markdown extraction as an optional PDF provider. Thanks José Antonio Galiano Sandoval (`@jagaliano`) for PR #226.
 
 ### Fixed
+- Fix Gemini Web "fetch failed" (`UND_ERR_HEADERS_OVERFLOW`) when running inside a host agent whose global undici dispatcher uses HTTP/1.1 with the default 16 KiB `maxHeaderSize`: Google's `/app` page exceeds that budget. Gemini Web requests now use a dedicated undici agent with a 4 MiB header budget.
 - Preserve collapsed `web_search` result background padding. Thanks `@SheffeyG` for PR #224.
 
 ## [0.19.0] - 2026-08-08

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -667,7 +667,7 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 
 async function searchWithGeminiApi(query: string, options: SearchOptions = {}): Promise<SearchResponse | null> {
 	const requestSignal = AbortSignal.any([
-		AbortSignal.timeout(60000),
+		AbortSignal.timeout(120000),
 		...(options.signal ? [options.signal] : []),
 	]);
 	const apiKey = await getApiKey(requestSignal);
@@ -726,7 +726,7 @@ async function searchWithGeminiWeb(query: string, options: SearchOptions = {}): 
 	try {
 		const text = await queryWithCookies(prompt, cookies, {
 			signal: options.signal,
-			timeoutMs: 60000,
+			timeoutMs: 120000,
 		});
 
 		activityMonitor.logComplete(activityId, 200);

--- a/gemini-web.ts
+++ b/gemini-web.ts
@@ -24,6 +24,66 @@ const MODEL_HEADERS: Record<string, string> = {
 
 const REQUIRED_COOKIES = ["__Secure-1PSID", "__Secure-1PSIDTS"];
 
+// Gemini Web talks to Google's frontend inside the host agent (pi), whose
+// global undici dispatcher runs HTTP/1.1 with undici's default 16 KiB
+// maxHeaderSize. Google's gemini.google.com /app response headers routinely
+// exceed that budget over HTTP/1.1, so cookie-bearing requests fail with
+// UND_ERR_HEADERS_OVERFLOW surfaced as "fetch failed". Route these requests
+// through a dedicated undici Agent with a larger header budget instead; fall
+// back to the ambient global fetch when undici is not resolvable (e.g.
+// standalone test environments).
+let geminiFetchImpl: typeof fetch | null = null;
+
+// Test-only hook: lets tests inject a simulated transport instead of patching
+// globalThis.fetch. Gemini Web deliberately bypasses the ambient global fetch
+// (inside the pi host agent it is constrained to undici's 16 KiB
+// maxHeaderSize and cannot serve Google's /app page over HTTP/1.1), so
+// globalThis.fetch patching is no longer a reliable way to intercept these
+// requests.
+export function setGeminiFetchOverrideForTests(fetchImpl: typeof fetch | null): void {
+geminiFetchOverride = fetchImpl;
+}
+
+let geminiFetchOverride: typeof fetch | null = null;
+
+// The header budget Gemini Web needs for Google frontend responses.
+// Google's /app page exceeds undici's default 16 KiB maxHeaderSize when
+// served over HTTP/1.1, which is how pi's global dispatcher operates.
+export const GEMINI_MAX_HEADER_SIZE = 4 * 1024 * 1024;
+
+// Build a fetch that routes through a dedicated undici Agent with a larger
+// header budget than the host agent's global dispatcher allows. Exported for
+// tests so the agent configuration can be asserted without network access.
+export function createGeminiFetch(undiciImpl: typeof import("undici")): typeof fetch {
+const agent = new undiciImpl.EnvHttpProxyAgent({
+	allowH2: false,
+	maxHeaderSize: GEMINI_MAX_HEADER_SIZE,
+	pipelining: 1,
+});
+// undici 8 types its fetch request/response structurally differently from
+// the DOM lib types (duplex/textStream on Request, Symbol.dispose on
+// Headers); the shape this module uses (status, ok, headers.get, text) is
+// identical, so bridge the two.
+type UndiciFetch = typeof undiciImpl.fetch;
+return (input, init) =>
+undiciImpl.fetch(
+input as unknown as Parameters<UndiciFetch>[0],
+{ ...init, dispatcher: agent } as unknown as Parameters<UndiciFetch>[1],
+) as unknown as Promise<Response>;
+}
+
+export async function resolveGeminiFetch(): Promise<typeof fetch> {
+if (geminiFetchOverride) return geminiFetchOverride;
+if (geminiFetchImpl) return geminiFetchImpl;
+try {
+	const undici = await import("undici");
+	geminiFetchImpl = createGeminiFetch(undici);
+} catch {
+	geminiFetchImpl = fetch;
+}
+return geminiFetchImpl;
+}
+
 export interface GeminiWebOptions {
 	youtubeUrl?: string;
 	model?: string;
@@ -129,7 +189,7 @@ async function runGeminiWebOnce(
 	params.set("at", accessToken);
 	params.set("f.req", fReq);
 
-	const res = await fetch(GEMINI_STREAM_GENERATE_URL, {
+	const res = await (await resolveGeminiFetch())(GEMINI_STREAM_GENERATE_URL, {
 		method: "POST",
 		redirect: "error",
 		headers: {
@@ -192,7 +252,7 @@ async function fetchWithCookieRedirects(
 	let current = url;
 	const allowedOrigin = new URL(url).origin;
 	for (let i = 0; i <= maxRedirects; i++) {
-		const res = await fetch(current, {
+		const res = await (await resolveGeminiFetch())(current, {
 			headers: { "user-agent": USER_AGENT, cookie: cookieHeader },
 			redirect: "manual",
 			signal,
@@ -302,7 +362,7 @@ async function uploadFile(
 		Buffer.from(footer, "utf-8"),
 	]);
 
-	const res = await fetch(GEMINI_UPLOAD_URL, {
+	const res = await (await resolveGeminiFetch())(GEMINI_UPLOAD_URL, {
 		method: "POST",
 		redirect: "error",
 		headers: {

--- a/gemini-web.ts
+++ b/gemini-web.ts
@@ -57,6 +57,7 @@ export const GEMINI_MAX_HEADER_SIZE = 4 * 1024 * 1024;
 export function createGeminiFetch(undiciImpl: typeof import("undici")): typeof fetch {
 const agent = new undiciImpl.EnvHttpProxyAgent({
 	allowH2: false,
+	connectTimeout: 30_000,
 	maxHeaderSize: GEMINI_MAX_HEADER_SIZE,
 	pipelining: 1,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "promise.try": "^2.0.1",
         "turndown": "^7.2.0",
         "typebox": "^1.1.38",
+        "undici": "^8.9.0",
         "unpdf": "^1.6.2"
       },
       "devDependencies": {
@@ -5320,6 +5321,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "promise.try": "^2.0.1",
     "turndown": "^7.2.0",
     "typebox": "^1.1.38",
-    "unpdf": "^1.6.2"
+    "unpdf": "^1.6.2",
+    "undici": "^8.9.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/test/gemini-web-cookie-opt-in.test.mjs
+++ b/test/gemini-web-cookie-opt-in.test.mjs
@@ -24,92 +24,84 @@ function runCookieAccessCheck(home, extraEnv = {}) {
 }
 
 test("Gemini Web never forwards browser cookies across origins", async () => {
-	const originalFetch = globalThis.fetch;
+	const { getActiveGoogleEmail, setGeminiFetchOverrideForTests } = await import(geminiWebUrl);
 	const calls = [];
+	setGeminiFetchOverrideForTests(async (url, init = {}) => {
+		calls.push({ url: String(url), cookie: init.headers?.cookie, redirect: init.redirect });
+		if (String(url).startsWith("https://gemini.google.com/") || String(url).startsWith("https://accounts.google.com/")) {
+			return new Response(null, { status: 302, headers: { location: "https://attacker.example/collect" } });
+		}
+		throw new Error(`Unexpected cross-origin request: ${url}`);
+	});
 	try {
-		globalThis.fetch = async (url, init = {}) => {
-			calls.push({ url: String(url), cookie: init.headers?.cookie, redirect: init.redirect });
-			if (String(url).startsWith("https://gemini.google.com/") || String(url).startsWith("https://accounts.google.com/")) {
-				return new Response(null, { status: 302, headers: { location: "https://attacker.example/collect" } });
-			}
-			throw new Error(`Unexpected cross-origin request: ${url}`);
-		};
-
-		const { getActiveGoogleEmail } = await import(geminiWebUrl);
 		const email = await getActiveGoogleEmail({ "__Secure-1PSID": "sensitive-cookie" });
 		assert.equal(email, null);
 		assert.equal(calls.some((call) => call.url.startsWith("https://attacker.example/")), false);
 		assert.equal(calls.every((call) => call.redirect === "manual"), true);
 	} finally {
-		globalThis.fetch = originalFetch;
+		setGeminiFetchOverrideForTests(null);
 	}
 });
 
 test("Gemini Web generation rejects automatic redirects", async () => {
-	const originalFetch = globalThis.fetch;
+	const { queryWithCookies, setGeminiFetchOverrideForTests } = await import(geminiWebUrl);
+	setGeminiFetchOverrideForTests(async (url, init = {}) => {
+		if (String(url) === "https://gemini.google.com/app") {
+			return new Response('"SNlM0e":"test-token"', { status: 200 });
+		}
+		if (String(url).includes("BardFrontendService/StreamGenerate")) {
+			assert.equal(init.redirect, "error");
+			throw new Error("generation transport reached");
+		}
+		throw new Error(`Unexpected request: ${url}`);
+	});
 	try {
-		globalThis.fetch = async (url, init = {}) => {
-			if (String(url) === "https://gemini.google.com/app") {
-				return new Response('"SNlM0e":"test-token"', { status: 200 });
-			}
-			if (String(url).includes("BardFrontendService/StreamGenerate")) {
-				assert.equal(init.redirect, "error");
-				throw new Error("generation transport reached");
-			}
-			throw new Error(`Unexpected request: ${url}`);
-		};
-
-		const { queryWithCookies } = await import(geminiWebUrl);
 		await assert.rejects(
 			queryWithCookies("search", { "__Secure-1PSID": "cookie" }, { model: "gemini-3.1-pro" }),
 			/generation transport reached/,
 		);
 	} finally {
-		globalThis.fetch = originalFetch;
+		setGeminiFetchOverrideForTests(null);
 	}
 });
 
 test("Gemini Web rejects unsupported models instead of falling back to 2.5 Flash", async () => {
-	const originalFetch = globalThis.fetch;
+	const { queryWithCookies, setGeminiFetchOverrideForTests } = await import(geminiWebUrl);
+	setGeminiFetchOverrideForTests(async () => {
+		throw new Error("transport should not be reached");
+	});
 	try {
-		globalThis.fetch = async () => {
-			throw new Error("transport should not be reached");
-		};
-
-		const { queryWithCookies } = await import(geminiWebUrl);
 		await assert.rejects(
 			queryWithCookies("search", { "__Secure-1PSID": "cookie" }, { model: "gemini-3.6-flash" }),
 			/Gemini Web does not support model gemini-3\.6-flash/,
 		);
 	} finally {
-		globalThis.fetch = originalFetch;
+		setGeminiFetchOverrideForTests(null);
 	}
 });
 
 test("Gemini Web file uploads read the file and reject automatic redirects", async () => {
-	const originalFetch = globalThis.fetch;
 	const dir = await mkdtemp(join(tmpdir(), "pi-web-access-gemini-upload-"));
 	const filePath = join(dir, "sample.txt");
 	await writeFile(filePath, "sample", "utf8");
+	const { queryWithCookies, setGeminiFetchOverrideForTests } = await import(geminiWebUrl);
+	setGeminiFetchOverrideForTests(async (url, init = {}) => {
+		if (String(url) === "https://gemini.google.com/app") {
+			return new Response('"SNlM0e":"test-token"', { status: 200 });
+		}
+		if (String(url) === "https://content-push.googleapis.com/upload") {
+			assert.equal(init.redirect, "error");
+			throw new Error("upload transport reached");
+		}
+		throw new Error(`Unexpected request: ${url}`);
+	});
 	try {
-		globalThis.fetch = async (url, init = {}) => {
-			if (String(url) === "https://gemini.google.com/app") {
-				return new Response('"SNlM0e":"test-token"', { status: 200 });
-			}
-			if (String(url) === "https://content-push.googleapis.com/upload") {
-				assert.equal(init.redirect, "error");
-				throw new Error("upload transport reached");
-			}
-			throw new Error(`Unexpected request: ${url}`);
-		};
-
-		const { queryWithCookies } = await import(geminiWebUrl);
 		await assert.rejects(
 			queryWithCookies("inspect file", { "__Secure-1PSID": "cookie" }, { files: [filePath], model: "gemini-3.1-pro" }),
 			/upload transport reached/,
 		);
 	} finally {
-		globalThis.fetch = originalFetch;
+		setGeminiFetchOverrideForTests(null);
 	}
 });
 

--- a/test/gemini-web-header-overflow.test.mjs
+++ b/test/gemini-web-header-overflow.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { createGeminiFetch, GEMINI_MAX_HEADER_SIZE, resolveGeminiFetch } from "../gemini-web.ts";
+
+// Proxy env vars would route the dedicated EnvHttpProxyAgent (and the
+// simulated host-agent dispatcher) away from the local test server.
+const PROXY_ENV = [
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"ALL_PROXY",
+	"all_proxy",
+	"NO_PROXY",
+	"no_proxy",
+];
+
+test("createGeminiFetch wires a dedicated agent with a >16 KiB header budget", async () => {
+	const agentOpts = [];
+	const agentInstances = [];
+	const fetchCalls = [];
+	const stubUndici = {
+		EnvHttpProxyAgent: class {
+			constructor(opts) {
+				agentOpts.push(opts);
+				agentInstances.push(this);
+			}
+		},
+		fetch: async (input, init) => {
+			fetchCalls.push({ input, init });
+			return new Response("ok");
+		},
+	};
+
+	const geminiFetch = createGeminiFetch(stubUndici);
+	await geminiFetch("https://gemini.google.com/app", { headers: { cookie: "a=b" } });
+
+	assert.equal(agentOpts.length, 1);
+	const opts = agentOpts[0];
+	assert.equal(opts.maxHeaderSize, GEMINI_MAX_HEADER_SIZE);
+	// The whole point: Google frontend responses exceed undici's 16 KiB default
+	// over HTTP/1.1, so the dedicated budget must be well above it.
+	assert.ok(opts.maxHeaderSize > 16 * 1024, "header budget must exceed undici's 16 KiB default");
+	assert.equal(opts.allowH2, false);
+	assert.equal(opts.pipelining, 1);
+
+	assert.equal(fetchCalls.length, 1);
+	// Requests must go through the dedicated agent, not the ambient global dispatcher.
+	assert.equal(fetchCalls[0].input, "https://gemini.google.com/app");
+	assert.equal(fetchCalls[0].init.dispatcher, agentInstances[0]);
+});
+
+test("dedicated agent fetches oversized-header responses the pi-style global dispatcher rejects", async () => {
+	const server = createServer((req, res) => {
+		// ~85 KiB of response headers: Google's /app page routinely exceeds the
+		// 16 KiB default maxHeaderSize when served over HTTP/1.1.
+		for (let i = 0; i < 40; i++) res.setHeader(`X-Large-${i}`, "x".repeat(2048));
+		res.end("payload-ok");
+	});
+	await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const url = `http://127.0.0.1:${server.address().port}/`;
+
+	const undici = await import("undici");
+	const savedDispatcher = undici.getGlobalDispatcher();
+	const savedEnv = Object.fromEntries(PROXY_ENV.map((k) => [k, process.env[k]]));
+	for (const k of PROXY_ENV) delete process.env[k];
+
+	try {
+		// Simulate the host agent (pi): an HTTP/1.1-only global dispatcher with
+		// undici's default 16 KiB maxHeaderSize.
+		undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent({ allowH2: false }));
+
+		// Control: the ambient global fetch must choke on the oversized headers.
+		await assert.rejects(
+			() => fetch(url).then((r) => r.text()),
+			(err) => {
+				const detail = String(err.cause?.code ?? err.message);
+				assert.match(detail, /HEADERS_OVERFLOW|fetch failed/i);
+				return true;
+			},
+		);
+
+		// Fix: the dedicated agent returns the same response without error.
+		const geminiFetch = createGeminiFetch(undici);
+		const res = await geminiFetch(url);
+		assert.equal(res.status, 200);
+		assert.equal(await res.text(), "payload-ok");
+	} finally {
+		undici.setGlobalDispatcher(savedDispatcher);
+		for (const k of PROXY_ENV) {
+			if (savedEnv[k] === undefined) delete process.env[k];
+			else process.env[k] = savedEnv[k];
+		}
+		server.close();
+	}
+});
+
+test("resolveGeminiFetch falls back to the ambient global fetch when undici is not resolvable", () => {
+	const dir = mkdtempSync(join(tmpdir(), "gw-fallback-"));
+	try {
+		// Copy just the module graph (no node_modules) so the dynamic undici
+		// import fails and the fallback path is exercised.
+		for (const f of ["gemini-web.ts", "chrome-cookies.ts", "gemini-web-config.ts", "utils.ts"]) {
+			copyFileSync(join(import.meta.dirname, "..", f), join(dir, f));
+		}
+		const script = [
+			"import { resolveGeminiFetch } from './gemini-web.ts';",
+			"const f = await resolveGeminiFetch();",
+			"console.log('FETCH_KIND:' + (f === globalThis.fetch ? 'FALLBACK' : 'UNDICI'));",
+		].join("\n");
+		const r = spawnSync(process.execPath, ["-e", script], { cwd: dir, encoding: "utf8" });
+		assert.equal(r.status, 0, r.stderr);
+		assert.match(r.stdout, /FETCH_KIND:FALLBACK/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Problem

Gemini Web search fails inside pi with `fetch failed` — the underlying undici error is `UND_ERR_HEADERS_OVERFLOW`. Standalone node works fine.

**Root cause:** pi's core installs a global undici dispatcher (`EnvHttpProxyAgent` with `allowH2: false`, i.e. HTTP/1.1-only, keeping undici's default **16 KiB `maxHeaderSize`**). Google's `gemini.google.com/app` response headers routinely exceed 16 KiB when served over HTTP/1.1, so undici aborts with `UND_ERR_HEADERS_OVERFLOW`, which the fetch API surfaces as a generic `fetch failed`.

Why it's host-agent-specific: with the default fetch dispatcher (HTTP/2), Google's headers are HPACK-compressed and stay under the limit — which is why the standalone reproduction works while the same code inside pi fails.

## Fix

Route the three cookie-bearing Gemini Web requests (`/app`, `StreamGenerate`, content-push upload) through a **dedicated undici `EnvHttpProxyAgent`** with a 4 MiB `maxHeaderSize` instead of the ambient global fetch:

- `createGeminiFetch(undici)` builds the wrapped fetch with the dedicated agent (exported for test injection).
- `resolveGeminiFetch()` lazily imports undici and falls back to the ambient global fetch when undici isn't resolvable (e.g. standalone test environments).
- A test-only override hook (`setGeminiFetchOverrideForTests`) lets tests inject simulated transports — `globalThis.fetch` patching no longer intercepts these requests by design, so the existing cookie-opt-in tests were migrated to the hook.

Adds `undici` as a runtime dependency.

## Regression test

`test/gemini-web-header-overflow.test.mjs`:

1. **Agent wiring** — asserts the dedicated agent carries `maxHeaderSize: 4 MiB`, `allowH2: false`, and that requests are dispatched through that agent (not the global dispatcher).
2. **End-to-end overflow reproduction** — spins up a local HTTP server returning ~85 KiB of response headers, installs a pi-style global dispatcher (`EnvHttpProxyAgent`, HTTP/1.1, default 16 KiB), proves the ambient global fetch rejects the response with `UND_ERR_HEADERS_OVERFLOW`, and proves the dedicated agent serves the same response (`200`, correct body).
3. **Fallback** — copies the module graph to a temp dir without `node_modules` and asserts `resolveGeminiFetch()` returns the ambient global fetch when undici can't be imported.

## Verification

- `tsc --noEmit` — clean
- Full suite: 419 tests, 418 pass. The single failure (`Firecrawl extraction … defaults to lockdown`) is pre-existing and environment-dependent — it reads the user's global `web-search.json` which enables `firecrawlFreshScrape` (fresh scraping is the documented opt-in that disables lockdown); it fails identically with these changes stashed.
- Live check against gemini.google.com with the pi-style dispatcher installed: the patched transport returns real answers.
