### PR TITLE
refactor: tighten Datalab and Gemini Web internals

### DIFF
--- a/datalab-pdf-extract.ts
+++ b/datalab-pdf-extract.ts
@@ -115,9 +115,9 @@ export function getDatalabProcessingLocation(): DatalabProcessingLocation {
 
 export function normalizeDatalabMode(value: unknown): DatalabMode {
 	const raw = normalizeString(value);
-	const normalized = raw ? (raw.toLowerCase() as DatalabMode) : null;
-	if (normalized && DATALAB_MODE_VALUES.has(normalized)) return normalized;
-	if (normalized === null) return DEFAULT_DATALAB_MODE;
+	if (!raw) return DEFAULT_DATALAB_MODE;
+	const normalized = raw.toLowerCase() as DatalabMode;
+	if (DATALAB_MODE_VALUES.has(normalized)) return normalized;
 	throw new Error(
 		`Failed to parse datalab mode: expected "fast", "balanced", or "accurate", got "${value}"`,
 	);
@@ -201,8 +201,10 @@ export async function extractPDFViaDatalab(
 	const processingLocation =
 		options.processingLocation ?? getDatalabProcessingLocation();
 	const timeoutMs =
-		Number.isFinite(options.timeoutMs) && (options.timeoutMs ?? 0) > 0
-			? Math.floor(options.timeoutMs ?? 0)
+		typeof options.timeoutMs === "number" &&
+		Number.isFinite(options.timeoutMs) &&
+		options.timeoutMs > 0
+			? Math.floor(options.timeoutMs)
 			: DEFAULT_TIMEOUT_MS;
 	const deadline = Date.now() + timeoutMs;
 
@@ -315,11 +317,9 @@ export async function extractPDFViaDatalab(
 
 		throw new Error("Datalab PDF conversion timed out");
 	} finally {
-		if (fileId !== undefined && fileId !== null) {
-			// File deletion is best-effort. Do not extend a caller's timeout or
-			// cancellation while waiting for a remote cleanup request.
-			void deleteDatalabFile(apiKey, String(fileId));
-		}
+		// File deletion is best-effort. Do not extend a caller's timeout or
+		// cancellation while waiting for a remote cleanup request.
+		void deleteDatalabFile(apiKey, fileId);
 	}
 }
 
@@ -348,7 +348,7 @@ async function requestUploadUrl(options: {
 		},
 		apiKey,
 	);
-	return readJsonResponse(response, apiKey) as Promise<DatalabUploadRequest>;
+	return readJsonResponse(response, apiKey);
 }
 
 async function confirmUpload(
@@ -366,7 +366,7 @@ async function confirmUpload(
 		},
 		apiKey,
 	);
-	return readJsonResponse(response, apiKey) as Promise<DatalabConfirmResponse>;
+	return readJsonResponse(response, apiKey);
 }
 
 async function deleteDatalabFile(
@@ -506,11 +506,20 @@ async function readJsonResponse(
 			: `Datalab PDF conversion failed: HTTP ${response.status} ${response.statusText}`;
 		throw new Error(redactCredential(message, apiKey));
 	}
+	return parseJsonRecord(text);
+}
+
+function parseJsonRecord(text: string): Record<string, unknown> {
+	let parsed: unknown;
 	try {
-		return JSON.parse(text) as Record<string, unknown>;
-	} catch {
-		throw new Error("Datalab PDF conversion returned invalid JSON");
+		parsed = JSON.parse(text);
+	} catch (error) {
+		throw new Error("Datalab PDF conversion returned invalid JSON", { cause: error });
 	}
+	if (Object.prototype.toString.call(parsed) !== "[object Object]") {
+		throw new Error("Datalab PDF conversion returned invalid JSON object");
+	}
+	return parsed as Record<string, unknown>;
 }
 
 async function readResponseText(response: Response): Promise<string> {

--- a/gemini-web.ts
+++ b/gemini-web.ts
@@ -41,7 +41,7 @@ let geminiFetchImpl: typeof fetch | null = null;
 // globalThis.fetch patching is no longer a reliable way to intercept these
 // requests.
 export function setGeminiFetchOverrideForTests(fetchImpl: typeof fetch | null): void {
-geminiFetchOverride = fetchImpl;
+	geminiFetchOverride = fetchImpl;
 }
 
 let geminiFetchOverride: typeof fetch | null = null;
@@ -55,34 +55,38 @@ export const GEMINI_MAX_HEADER_SIZE = 4 * 1024 * 1024;
 // header budget than the host agent's global dispatcher allows. Exported for
 // tests so the agent configuration can be asserted without network access.
 export function createGeminiFetch(undiciImpl: typeof import("undici")): typeof fetch {
-const agent = new undiciImpl.EnvHttpProxyAgent({
-	allowH2: false,
-	connectTimeout: 30_000,
-	maxHeaderSize: GEMINI_MAX_HEADER_SIZE,
-	pipelining: 1,
-});
-// undici 8 types its fetch request/response structurally differently from
-// the DOM lib types (duplex/textStream on Request, Symbol.dispose on
-// Headers); the shape this module uses (status, ok, headers.get, text) is
-// identical, so bridge the two.
-type UndiciFetch = typeof undiciImpl.fetch;
-return (input, init) =>
-undiciImpl.fetch(
-input as unknown as Parameters<UndiciFetch>[0],
-{ ...init, dispatcher: agent } as unknown as Parameters<UndiciFetch>[1],
-) as unknown as Promise<Response>;
+	const agent = new undiciImpl.EnvHttpProxyAgent({
+		allowH2: false,
+		connectTimeout: 30_000,
+		maxHeaderSize: GEMINI_MAX_HEADER_SIZE,
+		pipelining: 1,
+	});
+	// undici 8 types its fetch request/response structurally differently from
+	// the DOM lib types (duplex/textStream on Request, Symbol.dispose on
+	// Headers); the shape this module uses (status, ok, headers.get, text) is
+	// identical, so bridge the two.
+	type UndiciFetch = typeof undiciImpl.fetch;
+	return (input, init) =>
+		undiciImpl.fetch(
+			input as unknown as Parameters<UndiciFetch>[0],
+			{ ...init, dispatcher: agent } as unknown as Parameters<UndiciFetch>[1],
+		) as unknown as Promise<Response>;
 }
 
 export async function resolveGeminiFetch(): Promise<typeof fetch> {
-if (geminiFetchOverride) return geminiFetchOverride;
-if (geminiFetchImpl) return geminiFetchImpl;
-try {
-	const undici = await import("undici");
+	if (geminiFetchOverride) return geminiFetchOverride;
+	if (geminiFetchImpl) return geminiFetchImpl;
+
+	let undici: typeof import("undici");
+	try {
+		undici = await import("undici");
+	} catch {
+		geminiFetchImpl = fetch;
+		return geminiFetchImpl;
+	}
+
 	geminiFetchImpl = createGeminiFetch(undici);
-} catch {
-	geminiFetchImpl = fetch;
-}
-return geminiFetchImpl;
+	return geminiFetchImpl;
 }
 
 export interface GeminiWebOptions {

--- a/test/datalab-pdf-extract.test.mjs
+++ b/test/datalab-pdf-extract.test.mjs
@@ -164,6 +164,23 @@ test("Datalab conversion rejects a missing file_id before uploading", async () =
 	);
 });
 
+test("Datalab conversion rejects valid JSON that is not an object", async () => {
+	globalThis.fetch = async (url, init) => {
+		if (String(url).endsWith("/files/upload")) {
+			return new Response("null", {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}
+		return route(url, init);
+	};
+
+	await assert.rejects(
+		extractPDFViaDatalab(new ArrayBuffer(1), { maxPages: 1, title: "Doc" }),
+		/invalid JSON object/,
+	);
+});
+
 test("Datalab conversion returns immediately when the convert response is complete", async () => {
 	let convertCalls = 0;
 	globalThis.fetch = async (url, init) => {

--- a/test/gemini-web-header-overflow.test.mjs
+++ b/test/gemini-web-header-overflow.test.mjs
@@ -121,3 +121,19 @@ test("resolveGeminiFetch falls back to the ambient global fetch when undici is n
 		rmSync(dir, { recursive: true, force: true });
 	}
 });
+
+test("resolveGeminiFetch surfaces dedicated agent construction errors", () => {
+	const env = { ...process.env, HTTPS_PROXY: "not a url" };
+	const script = [
+		`import { resolveGeminiFetch } from ${JSON.stringify(new URL("../gemini-web.ts", import.meta.url).href)};`,
+		"await resolveGeminiFetch();",
+	].join("\n");
+	const result = spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env,
+	});
+
+	assert.notEqual(result.status, 0);
+	assert.match(result.stderr, /Invalid URL/);
+});


### PR DESCRIPTION
Tightens the recent Datalab and Gemini Web internals without changing user-facing behavior.

Changes:
- keeps Datalab JSON parsing typed as `unknown` until the response is proven to be an object;
- removes endpoint response promise casts;
- preserves invalid JSON parse errors as `cause`;
- lets Gemini Web dedicated-agent construction errors surface instead of silently falling back to ambient fetch;
- keeps the earlier TypeScript cleanup for Datalab mode/timeout handling and Gemini helper indentation.

Validation:
- `git diff --check`
- `node --test test/datalab-pdf-extract.test.mjs test/gemini-web-header-overflow.test.mjs test/gemini-web-cookie-opt-in.test.mjs` — 27 passed
- `npm run typecheck -- --pretty false`
- `npm test` — 425 passed
- `npx --yes fallow audit --format json --quiet` — passed, no introduced findings
- final fresh deslop review — no findings
