### PR TITLE
feat: add feature registration gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added per-tool and per-command registration gates plus image and PDF extraction gates. Thanks @jaudiger for issue #234.
+
 ### Fixed
 - Document `get_search_content` parameter constraints in the tool schema. Thanks `@iwangjie` for PR #233.
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,21 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "webSearch": {
     "enabled": true
   },
+  "tools": {
+    "webSearch": { "enabled": true },
+    "sourceCheck": { "enabled": true },
+    "fetchContent": { "enabled": true },
+    "getSearchContent": { "enabled": true }
+  },
+  "commands": {
+    "websearch": { "enabled": true },
+    "curator": { "enabled": true },
+    "search": { "enabled": true },
+    "google-account": { "enabled": true }
+  },
+  "image": {
+    "enabled": true
+  },
   "chromeProfile": "Profile 2",
   "allowBrowserCookies": false,
   "searchModel": "gemini-3.6-flash",
@@ -384,6 +399,7 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
     "maxSizeMB": 50
   },
   "pdf": {
+    "enabled": true,
     "maxSizeMB": 20,
     "provider": "auto"
   },
@@ -768,7 +784,7 @@ Both shortcuts are configurable via `~/.pi/web-search.json`:
 
 Values use the same format as pi keybindings (e.g. `ctrl+s`, `ctrl+shift+s`, `alt+r`). Changes take effect on next pi restart.
 
-Set `"enabled": false` under any feature to disable it. For GitHub specifically, `githubClone.enabled: false` only skips clone/API specialization; it does not unregister `fetch_content` or block generic URL extraction. Config changes require a Pi restart.
+Set `"enabled": false` under `tools`, `commands`, `image`, or `pdf` to disable that feature. Tool-specific settings override the legacy `webSearch.enabled` shorthand; without an override, it still disables `web_search` and `source_check`. `image.enabled: false` blocks direct image fetches and video frame extraction, and prevents video thumbnails. `pdf.enabled: false` blocks PDF extraction. For GitHub specifically, `githubClone.enabled: false` only skips clone/API specialization; it does not unregister `fetch_content` or block generic URL extraction. Pi restart is required for tool and command registration changes.
 
 Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Search, TinyFish, Search1API, and Searchinfinity apply the plan limits documented by their APIs. Querit Search and Contents subscriptions are independent. Content fetches run 3 concurrent with a 30s timeout for the direct HTTP fetch of each URL. Remote extraction fallbacks carry their own budgets and are not covered by that number: Jina Reader 30s, Firecrawl 60s, Kagi Extract 60s, Ollama Web Fetch 60s, Bright Data Web Unlocker 60s, TinyFish up to 150s, Gemini 120s, Datalab 120s (capped at 300s, rate-limited to 25 requests/minute on the free tier). `pdf.maxSizeMB` defaults to 20 and is capped at 50.
 

--- a/extract.ts
+++ b/extract.ts
@@ -23,11 +23,12 @@ import { isVideoFile, extractVideo, extractVideoFrame, getLocalVideoDuration } f
 import { appendDeclaredWebLinks, discoverDeclaredWebLinks, type DeclaredWebLink } from "./declared-web-links.ts";
 import { fetchRemoteUrl, loadFetchContentDomainPolicy, loadSsrfConfig, validateRemoteUrl, type Lookup } from "./ssrf-protection.ts";
 import { formatSeconds, getWebSearchConfigPath } from "./utils.ts";
+import { isImageEnabled } from "./feature-config.ts";
 
 const DEFAULT_TIMEOUT_MS = 30000;
 const CONCURRENT_LIMIT = 3;
 
-const NON_RECOVERABLE_ERRORS = ["Unsupported content type", "Response too large"];
+const NON_RECOVERABLE_ERRORS = ["Unsupported content type", "Response too large", "PDF extraction is disabled", "Image fetching is disabled"];
 const MIN_USEFUL_CONTENT = 500;
 const SUPPORTED_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
 const WEB_SEARCH_CONFIG_PATH = getWebSearchConfigPath();
@@ -63,6 +64,14 @@ function isRedirectPolicyError(message: string): boolean {
 		message === "Only HTTP and HTTPS URLs can be fetched remotely" ||
 		message === "URL must include a hostname" ||
 		message.startsWith("Failed to resolve ");
+}
+
+function imageGateError(): string | null {
+	try {
+		return isImageEnabled() ? null : "Image fetching is disabled by image.enabled";
+	} catch (err) {
+		return errorMessage(err);
+	}
 }
 
 function loadFetchRouting(): FetchRouting {
@@ -346,6 +355,11 @@ export async function extractContent(
 		return extractViaHttp(url, signal, options);
 	}
 
+	if (options?.frames || options?.timestamp) {
+		const disabled = imageGateError();
+		if (disabled) return { url, title: "", content: "", error: disabled };
+	}
+
 	if (options?.frames && !options.timestamp) {
 		const frameCount = options.frames;
 		const ytInfo = isYouTubeURL(url);
@@ -573,7 +587,7 @@ export async function extractContent(
 		declaredLinks = discoveredLinks;
 		if (signal?.aborted) return abortedResult(url);
 		if (!httpResult.error) return httpResult;
-		if (NON_RECOVERABLE_ERRORS.some(prefix => httpResult!.error!.startsWith(prefix)) || isRedirectPolicyError(httpResult.error)) {
+		if (NON_RECOVERABLE_ERRORS.some(prefix => httpResult!.error!.startsWith(prefix)) || isRedirectPolicyError(httpResult.error) || isConfigParseError(httpResult.error)) {
 			return httpResult;
 		}
 		return null;
@@ -940,6 +954,10 @@ async function extractViaHttp(
 		const mimeType = contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
 		const isPDFContent = isPDF(url, contentType);
 		const pdfConfig = isPDFContent ? loadPDFConfig() : null;
+		if (isPDFContent && pdfConfig && !pdfConfig.enabled) {
+			activityMonitor.logComplete(activityId, response.status);
+			return { url, title: "", content: "", error: "PDF extraction is disabled by pdf.enabled", mimeType, status: response.status };
+		}
 		const maxResponseSize = (pdfConfig?.maxSizeMB ?? 5) * 1024 * 1024;
 		if (contentLengthHeader) {
 			const contentLength = Number.parseInt(contentLengthHeader, 10);
@@ -967,6 +985,11 @@ async function extractViaHttp(
 		}
 
 		if (SUPPORTED_IMAGE_TYPES.has(mimeType)) {
+			const disabled = imageGateError();
+			if (disabled) {
+				activityMonitor.logComplete(activityId, response.status);
+				return { url, title: "", content: "", error: disabled, mimeType, status: response.status };
+			}
 			try {
 				const buffer = await readResponseBufferWithLimit(response, maxResponseSize, () => responseSizeLimitError(maxResponseSize));
 				const resized = await resizeImage(new Uint8Array(buffer), mimeType, { maxWidth: 2000, maxHeight: 2000 });

--- a/feature-config.ts
+++ b/feature-config.ts
@@ -1,0 +1,29 @@
+import { existsSync, readFileSync } from "node:fs";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const CONFIG_PATH = getWebSearchConfigPath();
+
+type FeatureConfig = { image?: { enabled?: unknown } };
+
+function loadFeatureConfig(): FeatureConfig {
+	if (!existsSync(CONFIG_PATH)) return {};
+	try {
+		const raw: unknown = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+		return raw && typeof raw === "object" ? raw as FeatureConfig : {};
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+}
+
+export function isImageEnabled(): boolean {
+	return loadFeatureConfig().image?.enabled !== false;
+}
+
+export function canAttachImages(): boolean {
+	try {
+		return isImageEnabled();
+	} catch {
+		return false;
+	}
+}

--- a/index.ts
+++ b/index.ts
@@ -124,6 +124,8 @@ interface WebSearchConfig {
 	webSearch?: {
 		enabled?: boolean;
 	};
+	tools?: Partial<Record<keyof ToolNames, { enabled?: boolean }>>;
+	commands?: Partial<Record<"websearch" | "curator" | "search" | "google-account", { enabled?: boolean }>>;
 	toolNames?: Partial<ToolNames>;
 	shortcuts?: {
 		curate?: KeyId;
@@ -232,6 +234,23 @@ function searchProviderSchema(description: string) {
 	], { description });
 }
 
+function isToolEnabled(config: WebSearchConfig, key: keyof ToolNames): boolean {
+	const override = config.tools?.[key]?.enabled;
+	if (typeof override === "boolean") return override;
+	return key !== "webSearch" && key !== "sourceCheck" || config.webSearch?.enabled !== false;
+}
+
+function isCommandEnabled(config: WebSearchConfig, name: "websearch" | "curator" | "search" | "google-account"): boolean {
+	return config.commands?.[name]?.enabled !== false;
+}
+
+function joinToolNames(names: string[]): string {
+	if (names.length === 0) return "stored content";
+	if (names.length === 1) return names[0];
+	if (names.length === 2) return `${names[0]} or ${names[1]}`;
+	return `${names.slice(0, -1).join(", ")}, or ${names[names.length - 1]}`;
+}
+
 function resolveToolNames(config: WebSearchConfig): ToolNames {
 	if (config.toolNames !== undefined && (!config.toolNames || typeof config.toolNames !== "object" || Array.isArray(config.toolNames))) {
 		throw new Error(`toolNames in ${WEB_SEARCH_CONFIG_PATH} must be an object`);
@@ -247,9 +266,8 @@ function resolveToolNames(config: WebSearchConfig): ToolNames {
 		}
 		names[key] = trimmed;
 	}
-	const registeredKeys: Array<keyof ToolNames> = config.webSearch?.enabled === false
-		? ["fetchContent", "getSearchContent"]
-		: ["webSearch", "sourceCheck", "fetchContent", "getSearchContent"];
+	const registeredKeys = (Object.keys(DEFAULT_TOOL_NAMES) as Array<keyof ToolNames>)
+		.filter(key => isToolEnabled(config, key));
 	const seen = new Map<string, keyof ToolNames>();
 	for (const key of registeredKeys) {
 		const name = names[key];
@@ -572,7 +590,7 @@ function formatSearchSummary(results: SearchResult[], answer: string): string {
 	return output;
 }
 
-function formatSourceCheckResult(artifact: ResearchArtifact, getSearchContentTool = DEFAULT_TOOL_NAMES.getSearchContent): string {
+function formatSourceCheckResult(artifact: ResearchArtifact, getSearchContentTool: string | null = DEFAULT_TOOL_NAMES.getSearchContent): string {
 	const assessment = artifact.claims?.[0];
 	const lines = [`# Source check: ${artifact.query}`, ""];
 	if (assessment) {
@@ -588,7 +606,9 @@ function formatSourceCheckResult(artifact: ResearchArtifact, getSearchContentToo
 		lines.push("");
 	}
 	if (artifact.errors?.length) lines.push(`Search errors: ${artifact.errors.map((entry) => `${entry.query}: ${entry.error}`).join("; ")}`);
-	lines.push(`Artifact responseId: ${artifact.id} (retrievable via ${getSearchContentTool}).`);
+	lines.push(getSearchContentTool
+		? `Artifact responseId: ${artifact.id} (retrievable via ${getSearchContentTool}).`
+		: `Artifact responseId: ${artifact.id}. Content retrieval is not registered.`);
 	return lines.join("\n");
 }
 
@@ -868,12 +888,21 @@ function handleSessionChange(ctx: ExtensionContext): void {
 export default function (pi: ExtensionAPI) {
 	const initConfig = loadConfigForExtensionInit();
 	const toolNames = resolveToolNames(initConfig);
-	const storedContentSources = initConfig.webSearch?.enabled === false
-		? toolNames.fetchContent
-		: `${toolNames.webSearch}, ${toolNames.sourceCheck}, or ${toolNames.fetchContent}`;
-	const searchQueryDescription = initConfig.webSearch?.enabled === false
-		? "Get content for a stored search query"
-		: `Get content for this query (${toolNames.webSearch})`;
+	const webSearchEnabled = isToolEnabled(initConfig, "webSearch");
+	const sourceCheckEnabled = isToolEnabled(initConfig, "sourceCheck");
+	const fetchContentEnabled = isToolEnabled(initConfig, "fetchContent");
+	const getSearchContentEnabled = isToolEnabled(initConfig, "getSearchContent");
+	const storedContentSources = joinToolNames([
+		...(webSearchEnabled ? [toolNames.webSearch] : []),
+		...(sourceCheckEnabled ? [toolNames.sourceCheck] : []),
+		...(fetchContentEnabled ? [toolNames.fetchContent] : []),
+	]);
+	const searchQueryDescription = webSearchEnabled
+		? `Get content for this query (${toolNames.webSearch})`
+		: "Get content for a stored search query";
+	const fetchContentStorageNote = getSearchContentEnabled
+		? `Full original content is stored for retrieval with ${toolNames.getSearchContent}.`
+		: "Full original content is stored internally, but the retrieval tool is not registered.";
 	const curateKey = initConfig.shortcuts?.curate || DEFAULT_SHORTCUTS.curate;
 	const activityKey = initConfig.shortcuts?.activity || DEFAULT_SHORTCUTS.activity;
 
@@ -1570,7 +1599,7 @@ export default function (pi: ExtensionAPI) {
 		widgetVisible = false;
 	});
 
-	if (initConfig.webSearch?.enabled !== false) pi.registerTool({
+	if (webSearchEnabled) pi.registerTool({
 		name: toolNames.webSearch,
 		label: "Web Search",
 		description:
@@ -2134,7 +2163,7 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	if (initConfig.webSearch?.enabled !== false) pi.registerTool({
+	if (sourceCheckEnabled) pi.registerTool({
 		name: toolNames.sourceCheck,
 		label: "Source Check",
 		description: "Check a claim against web sources and return a bounded machine-readable research artifact with exact passage citations.",
@@ -2222,16 +2251,16 @@ export default function (pi: ExtensionAPI) {
 				artifact,
 			});
 			return {
-				content: [{ type: "text", text: formatSourceCheckResult(artifact, toolNames.getSearchContent) }],
+				content: [{ type: "text", text: formatSourceCheckResult(artifact, getSearchContentEnabled ? toolNames.getSearchContent : null) }],
 				details: { responseId: artifact.id, artifact, sourceCount: artifact.sources.length, passageCount: artifact.passages.length },
 			};
 		},
 	});
 
-	pi.registerTool({
+	if (fetchContentEnabled) pi.registerTool({
 		name: toolNames.fetchContent,
 		label: "Fetch Content",
-		description: `Fetch URL(s) and extract readable content as markdown. Use mode "raw" for exact textual HTTP response bodies or mode "answer" with prompt to answer using only fetched content. Direct image URLs return resized image content. Supports YouTube transcripts, GitHub repositories, PDFs, and local videos. Full original content is stored for retrieval with ${toolNames.getSearchContent}.`,
+		description: `Fetch URL(s) and extract readable content as markdown. Use mode "raw" for exact textual HTTP response bodies or mode "answer" with prompt to answer using only fetched content. Direct image URLs return resized image content. Supports YouTube transcripts, GitHub repositories, PDFs, and local videos. ${fetchContentStorageNote}`,
 		promptSnippet:
 			"Use to fetch readable or raw URL content, direct images, GitHub repos, and videos. Mode answer answers a prompt using only the fetched source.",
 		parameters: Type.Object({
@@ -2353,8 +2382,10 @@ export default function (pi: ExtensionAPI) {
 				let output = slice.text;
 
 				if (truncated) {
-					output += `\n\n---\nShowing ${slice.endOffset} of ${fullLength} chars, ${slice.shownBytes} of ${slice.totalBytes} bytes, and ${slice.shownLines} of ${slice.totalLines} lines. ` +
-						`Use ${toolNames.getSearchContent}({ responseId: "${responseId}", urlIndex: 0, offset: ${slice.endOffset} }) for the next slice.`;
+					output += `\n\n---\nShowing ${slice.endOffset} of ${fullLength} chars, ${slice.shownBytes} of ${slice.totalBytes} bytes, and ${slice.shownLines} of ${slice.totalLines} lines. `;
+					output += getSearchContentEnabled
+						? `Use ${toolNames.getSearchContent}({ responseId: "${responseId}", urlIndex: 0, offset: ${slice.endOffset} }) for the next slice.`
+						: "Content retrieval is not registered.";
 				}
 
 				const content: Array<TextContent | ImageContent> = [];
@@ -2405,7 +2436,9 @@ export default function (pi: ExtensionAPI) {
 					output += `- ${title || url} (${content.length} chars)\n`;
 				}
 			}
-			output += `\n---\nUse ${toolNames.getSearchContent}({ responseId: "${responseId}", urlIndex: 0 }) to retrieve bounded content slices.`;
+			output += getSearchContentEnabled
+				? `\n---\nUse ${toolNames.getSearchContent}({ responseId: "${responseId}", urlIndex: 0 }) to retrieve bounded content slices.`
+				: "\n---\nContent retrieval is not registered.";
 
 			return {
 				content: [{ type: "text", text: output }],
@@ -2533,7 +2566,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			const countColor = (details?.successful ?? 0) > 0 ? "success" : "error";
-			const statusLine = theme.fg(countColor, `${details?.successful}/${details?.urlCount} URLs`) + theme.fg("muted", " (content stored)");
+			const statusLine = theme.fg(countColor, `${details?.successful}/${details?.urlCount} URLs`) + theme.fg("muted", getSearchContentEnabled ? " (content stored)" : " (content fetched)");
 			if (!expanded) {
 				return new Text(statusLine, 0, 0);
 			}
@@ -2543,7 +2576,7 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerTool({
+	if (getSearchContentEnabled) pi.registerTool({
 		name: toolNames.getSearchContent,
 		label: "Get Search Content",
 		description: `Retrieve bounded content slices or find matching passages in a previous ${storedContentSources} call.`,
@@ -2842,7 +2875,7 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerCommand("websearch", {
+	if (isCommandEnabled(initConfig, "websearch")) pi.registerCommand("websearch", {
 		description: "Open web search curator",
 		handler: async (args, ctx) => {
 			const sessionToken = randomUUID();
@@ -3103,7 +3136,7 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerCommand("curator", {
+	if (isCommandEnabled(initConfig, "curator")) pi.registerCommand("curator", {
 		description: "Toggle or configure the search curator workflow",
 		handler: async (args, ctx) => {
 			const arg = args.trim().toLowerCase();
@@ -3145,7 +3178,7 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerCommand("google-account", {
+	if (isCommandEnabled(initConfig, "google-account")) pi.registerCommand("google-account", {
 		description: "Show the active Google account for Gemini Web",
 		handler: async () => {
 			if (!isBrowserCookieAccessAllowed()) {
@@ -3187,7 +3220,7 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerCommand("search", {
+	if (isCommandEnabled(initConfig, "search")) pi.registerCommand("search", {
 		description: "Browse stored web search results",
 		handler: async (_args, ctx) => {
 			const results = getAllResults();

--- a/pdf-extract.ts
+++ b/pdf-extract.ts
@@ -49,6 +49,7 @@ export const PDF_PROVIDER_VALUES = new Set<PDFProvider>([
 ]);
 
 export interface PDFConfig {
+	enabled: boolean;
 	maxSizeMB: number;
 	provider: PDFProvider;
 	datalabMode: DatalabMode;
@@ -63,18 +64,15 @@ const DEFAULT_OUTPUT_DIR = join(tmpdir(), "pi-web-pdf");
 const CONFIG_PATH = getWebSearchConfigPath();
 const PAGE_MARKER_PATTERN = /^<!-- Page (\d+) -->$/gm;
 
-let cachedPDFConfig: PDFConfig | null = null;
-
 export function loadPDFConfig(): PDFConfig {
-	if (cachedPDFConfig) return { ...cachedPDFConfig };
 	if (!existsSync(CONFIG_PATH)) {
-		cachedPDFConfig = {
+		return {
+			enabled: true,
 			maxSizeMB: DEFAULT_PDF_MAX_SIZE_MB,
 			provider: "auto",
 			datalabMode: normalizeDatalabMode(process.env.DATALAB_MODE),
 			datalabTimeoutMs: DEFAULT_DATALAB_TIMEOUT_MS,
 		};
-		return { ...cachedPDFConfig };
 	}
 
 	const rawText = readFileSync(CONFIG_PATH, "utf-8");
@@ -92,6 +90,7 @@ export function loadPDFConfig(): PDFConfig {
 		root.pdf && typeof root.pdf === "object"
 			? (root.pdf as Record<string, unknown>)
 			: {};
+	const enabled = pdf.enabled !== false;
 	const configured = pdf.maxSizeMB;
 	const normalized =
 		typeof configured === "number" &&
@@ -118,13 +117,13 @@ export function loadPDFConfig(): PDFConfig {
 			? Math.min(configuredTimeout, MAX_DATALAB_TIMEOUT_MS)
 			: DEFAULT_DATALAB_TIMEOUT_MS;
 
-	cachedPDFConfig = {
+	return {
+		enabled,
 		maxSizeMB: normalized,
 		provider,
 		datalabMode,
 		datalabTimeoutMs,
 	};
-	return { ...cachedPDFConfig };
 }
 
 async function getUnpdf() {

--- a/test/fetch-routing.test.mjs
+++ b/test/fetch-routing.test.mjs
@@ -6,16 +6,22 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 const extractUrl = new URL("../extract.ts", import.meta.url).href;
+const featureConfigUrl = new URL("../feature-config.ts", import.meta.url).href;
 
-async function runExtract(config) {
-	const root = await mkdtemp(join(tmpdir(), "pi-fetch-routing-"));
-	await writeFile(join(root, "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+function cleanProviderEnv(root) {
 	const childEnv = { ...process.env, PI_CODING_AGENT_DIR: root, HOME: root, USERPROFILE: root };
 	for (const key of [
 		"FIRECRAWL_BASE_URL", "FIRECRAWL_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY",
 		"SEARCH1API_KEY", "SEARCH1API_API_KEY", "QUERIT_API_KEY", "KAGI_API_KEY", "OLLAMA_API_KEY",
 		"BRIGHTDATA_API_KEY", "BRIGHTDATA_UNLOCKER_ZONE", "GEMINI_API_KEY", "GOOGLE_GEMINI_API_KEY", "GOOGLE_API_KEY",
 	]) delete childEnv[key];
+	return childEnv;
+}
+
+async function runExtract(config) {
+	const root = await mkdtemp(join(tmpdir(), "pi-fetch-routing-"));
+	await writeFile(join(root, "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	const childEnv = cleanProviderEnv(root);
 
 	const child = spawnSync(process.execPath, ["--input-type=module"], {
 		input: `
@@ -30,6 +36,36 @@ async function runExtract(config) {
 			};
 			const { extractContent } = await import(${JSON.stringify(extractUrl)});
 			const result = await extractContent("https://example.com/routed", undefined, { lookup: async () => [{ address: "93.184.216.34", family: 4 }] });
+			console.log(JSON.stringify({ calls, result }));
+		`,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+	assert.equal(child.status, 0, child.stderr);
+	return JSON.parse(child.stdout.trim());
+}
+
+async function runTypedExtract(config, contentType) {
+	const root = await mkdtemp(join(tmpdir(), "pi-fetch-routing-typed-"));
+	await writeFile(join(root, "web-search.json"), typeof config === "string" ? config : JSON.stringify(config) + "\n", "utf8");
+	const childEnv = cleanProviderEnv(root);
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const calls = [];
+			globalThis.fetch = async (url) => {
+				const text = String(url);
+				calls.push(text);
+				if (text === "https://example.com/typed") {
+					return new Response("typed", { status: 200, headers: { "content-type": ${JSON.stringify(contentType)} } });
+				}
+				if (text.startsWith("https://r.jina.ai/")) {
+					return new Response("Markdown Content:\\n# Bypassed\\n\\n" + "content ".repeat(80), { status: 200 });
+				}
+				throw new Error("Unexpected fetch " + text);
+			};
+			const { extractContent } = await import(${JSON.stringify(extractUrl)});
+			const result = await extractContent("https://example.com/typed", undefined, { lookup: async () => [{ address: "93.184.216.34", family: 4 }] });
 			console.log(JSON.stringify({ calls, result }));
 		`,
 		encoding: "utf8",
@@ -64,6 +100,44 @@ test("fetchRouting without providers uses the default order when remote hosted p
 	]);
 	assert.equal(output.result.error, null);
 	assert.equal(output.result.title, "Routed");
+});
+
+test("disabled image fetching does not fall through to hosted providers", async () => {
+	const output = await runTypedExtract({ image: { enabled: false }, fetchRouting: { providers: ["http", "jina"], allowRemoteHostedProviders: true } }, "image/png");
+	assert.deepEqual(output.calls, ["https://example.com/typed"]);
+	assert.match(output.result.error, /Image fetching is disabled by image\.enabled/);
+});
+
+test("disabled PDF extraction does not fall through to hosted providers", async () => {
+	const output = await runTypedExtract({ pdf: { enabled: false }, fetchRouting: { providers: ["http", "jina"], allowRemoteHostedProviders: true } }, "application/pdf");
+	assert.deepEqual(output.calls, ["https://example.com/typed"]);
+	assert.match(output.result.error, /PDF extraction is disabled by pdf\.enabled/);
+});
+
+test("malformed config returns a parse error without hosted fallback", async () => {
+	const output = await runTypedExtract("{", "image/png");
+	assert.deepEqual(output.calls, []);
+	assert.match(output.result.error, /Failed to parse .*web-search\.json/);
+});
+
+test("image attachment gate suppresses malformed config", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-feature-config-"));
+	await writeFile(join(root, "web-search.json"), "{", "utf8");
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			process.env.PI_CODING_AGENT_DIR = ${JSON.stringify(root)};
+			const { canAttachImages, isImageEnabled } = await import(${JSON.stringify(featureConfigUrl)});
+			let parseError = "";
+			try { isImageEnabled(); } catch (err) { parseError = err instanceof Error ? err.message : String(err); }
+			console.log(JSON.stringify({ canAttach: canAttachImages(), parseError }));
+		`,
+		encoding: "utf8",
+		env: cleanProviderEnv(root),
+	});
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.canAttach, false);
+	assert.match(output.parseError, /Failed to parse .*web-search\.json/);
 });
 
 test("Ollama Web Fetch is disabled for remote URLs without hosted-provider opt-in", async () => {

--- a/test/pdf-config.test.mjs
+++ b/test/pdf-config.test.mjs
@@ -8,6 +8,16 @@ import { readPDFResponseBuffer } from "../extract.ts";
 
 const pdfModuleUrl = new URL("../pdf-extract.ts", import.meta.url).href;
 
+test("pdf.enabled defaults to true and accepts false", () => {
+	assert.equal(readConfig(undefined).enabled, true);
+	assert.equal(readConfig({ pdf: { enabled: false } }).enabled, false);
+	assert.equal(readConfig({ pdf: { enabled: "false" } }).enabled, true);
+});
+
+test("pdf config reloads after the config file changes", () => {
+	assert.deepEqual(readConfigSequence([{ pdf: { enabled: false } }, { pdf: { enabled: true } }]), [false, true]);
+});
+
 test("pdf.maxSizeMB defaults to 20 and accepts values through 50", () => {
 	assert.equal(readConfig(undefined).maxSizeMB, 20);
 	assert.equal(readConfig({ pdf: { maxSizeMB: 30 } }).maxSizeMB, 30);
@@ -88,17 +98,27 @@ test("PDF streamed byte enforcement rejects a headerless response above the limi
 });
 
 function readConfig(config) {
+	return readConfigSequence([config]);
+}
+
+function readConfigSequence(configs) {
 	const configDir = mkdtempSync(join(tmpdir(), "pi-web-access-pdf-config-"));
 	try {
-		if (config !== undefined) {
-			writeFileSync(join(configDir, "web-search.json"), JSON.stringify(config));
-		}
 		const child = spawnSync(process.execPath, ["--input-type=module"], {
 			input: `
+				import { writeFileSync } from "node:fs";
+				import { join } from "node:path";
 				process.env.PI_CODING_AGENT_DIR = ${JSON.stringify(configDir)};
 				delete process.env.DATALAB_MODE;
+				const configs = ${JSON.stringify(configs)};
 				const { loadPDFConfig } = await import(${JSON.stringify(pdfModuleUrl)});
-				console.log(JSON.stringify(loadPDFConfig()));
+				const values = [];
+				for (const config of configs) {
+					if (config !== null) writeFileSync(join(${JSON.stringify(configDir)}, "web-search.json"), JSON.stringify(config));
+					values.push(loadPDFConfig().enabled);
+				}
+				if (configs.length === 1) console.log(JSON.stringify(loadPDFConfig()));
+				else console.log(JSON.stringify(values));
 			`,
 			encoding: "utf8",
 			env: { ...process.env, PI_CODING_AGENT_DIR: configDir },

--- a/test/tool-registration-config.test.mjs
+++ b/test/tool-registration-config.test.mjs
@@ -17,23 +17,36 @@ function runRegistration(config) {
 		input: `
 			const { default: initializeExtension } = await import(${JSON.stringify(indexUrl)});
 			const tools = [];
+			const commands = [];
 			initializeExtension({
-				registerTool(tool) { tools.push(tool.name); },
-				registerCommand() {},
+				registerTool(tool) { tools.push({ name: tool.name, description: tool.description, promptSnippet: tool.promptSnippet }); },
+				registerCommand(name) { commands.push(name); },
 				registerShortcut() {},
 				on() {},
 			});
-			console.log(JSON.stringify(tools));
+			console.log(JSON.stringify({ tools, commands }));
 		`,
 		encoding: "utf8",
 		env: { ...process.env, PI_CODING_AGENT_DIR: root, XDG_CONFIG_HOME: "", HOME: join(root, "home"), USERPROFILE: join(root, "home") },
 	});
 }
 
-function registeredToolNames(config) {
+function registered(config) {
 	const child = runRegistration(config);
 	assert.equal(child.status, 0, child.stderr);
 	return JSON.parse(child.stdout);
+}
+
+function registeredToolNames(config) {
+	return registered(config).tools.map(tool => tool.name);
+}
+
+function registeredTool(config, name) {
+	return registered(config).tools.find(tool => tool.name === name);
+}
+
+function registeredCommandNames(config) {
+	return registered(config).commands;
 }
 
 function registrationError(config) {
@@ -42,18 +55,29 @@ function registrationError(config) {
 	return child.stderr;
 }
 
-test("web_search registration is gated by webSearch.enabled", () => {
-	assert.match(indexSrc, /webSearch\?: \{\n\t\tenabled\?: boolean;\n\t\};/);
-	assert.match(indexSrc, /toolNames\?: Partial<ToolNames>;/);
-	assert.match(indexSrc, /if \(initConfig\.webSearch\?\.enabled !== false\) pi\.registerTool\(\{\n\t\tname: toolNames\.webSearch/);
+test("tool registration gates support legacy and per-tool config", () => {
+	assert.deepEqual(registeredToolNames({ webSearch: { enabled: false } }), ["fetch_content", "get_search_content"]);
+	assert.deepEqual(registeredToolNames({
+		webSearch: { enabled: false },
+		tools: { webSearch: { enabled: true }, sourceCheck: { enabled: true }, fetchContent: { enabled: false } },
+	}), ["web_search", "source_check", "get_search_content"]);
+	assert.deepEqual(registeredToolNames({
+		tools: { sourceCheck: { enabled: false }, getSearchContent: { enabled: false } },
+	}), ["web_search", "fetch_content"]);
 });
 
-test("fetch tools remain registered outside the web_search gate", () => {
-	const gateIndex = indexSrc.indexOf("if (initConfig.webSearch?.enabled !== false)");
-	const fetchIndex = indexSrc.indexOf("name: toolNames.fetchContent");
-	assert.ok(gateIndex >= 0, "web_search gate not found");
-	assert.ok(fetchIndex > gateIndex, "fetch_content registration should remain after web_search gate");
-	assert.match(indexSrc, /\n\t}\);\n\n\tpi\.registerTool\(\{\n\t\tname: toolNames\.fetchContent/);
+test("command registration gates default to enabled", () => {
+	assert.deepEqual(registeredCommandNames({}), ["websearch", "curator", "google-account", "search"]);
+	assert.deepEqual(registeredCommandNames({
+		commands: { websearch: { enabled: false }, search: { enabled: false } },
+	}), ["curator", "google-account"]);
+});
+
+test("registered tools do not advertise disabled get_search_content", () => {
+	const fetchTool = registeredTool({ tools: { getSearchContent: { enabled: false } } }, "fetch_content");
+	assert.ok(fetchTool);
+	assert.doesNotMatch(fetchTool.description, /get_search_content/);
+	assert.match(fetchTool.description, /retrieval tool is not registered/);
 });
 
 test("web activity shortcut renders through the supported string-array API", async () => {
@@ -116,8 +140,9 @@ test("webSearch.enabled false registers only fetch tools and ignores disabled-na
 	}), /duplicates/);
 });
 
-test("README documents webSearch.enabled and toolNames", () => {
-	assert.match(readmeSrc, /"webSearch": \{\n    "enabled": true\n  \}/);
-	assert.match(readmeSrc, /webSearch\.enabled` to `false` to unregister the configured search and source-check tools/);
+test("README documents registration gates and toolNames", () => {
+	assert.match(readmeSrc, /"tools": \{/);
+	assert.match(readmeSrc, /"commands": \{/);
+	assert.match(readmeSrc, /Pi restart is required for tool and command registration changes/);
 	assert.match(readmeSrc, /`toolNames` can opt into alternate public tool names/);
 });

--- a/video-extract.ts
+++ b/video-extract.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { resolve, extname, basename, join, dirname } from "node:path";
 import { activityMonitor } from "./activity.ts";
+import { canAttachImages } from "./feature-config.ts";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.ts";
 import { queryGeminiApiWithVideo, getApiKey, fetchGeminiApi, getVersionedApiBase, getUploadBase, redactGeminiApiResponse } from "./gemini-api.ts";
 import { extractHeadingTitle, type ExtractedContent, type ExtractOptions, type FrameResult } from "./extract.ts";
@@ -181,9 +182,11 @@ export async function extractVideo(
 		?? await tryVideoGeminiWeb(info, effectivePrompt, effectiveModel, signal);
 
 	if (result) {
-		const thumbnail = await extractVideoFrame(info.absolutePath);
-		if (!("error" in thumbnail)) {
-			result.thumbnail = thumbnail;
+		if (canAttachImages()) {
+			const thumbnail = await extractVideoFrame(info.absolutePath);
+			if (!("error" in thumbnail)) {
+				result.thumbnail = thumbnail;
+			}
 		}
 		activityMonitor.logComplete(activityId, 200);
 		return result;

--- a/youtube-extract.ts
+++ b/youtube-extract.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { activityMonitor } from "./activity.ts";
+import { canAttachImages } from "./feature-config.ts";
 import { isGeminiWebAvailable, queryWithCookies } from "./gemini-web.ts";
 import { isGeminiApiAvailable, queryGeminiApiWithVideo } from "./gemini-api.ts";
 import { isPerplexityAvailable, searchWithPerplexity } from "./perplexity.ts";
@@ -116,7 +117,7 @@ export async function extractYouTube(
 
 	if (result) {
 		result.url = url;
-		if (!result.error && videoId) {
+		if (!result.error && videoId && canAttachImages()) {
 			const thumb = await fetchYouTubeThumbnail(videoId);
 			if (thumb) result.thumbnail = thumb;
 		}


### PR DESCRIPTION
## Summary

This adds default-on gates for the extension surfaces that users may want to hide from Pi context:

- per-tool registration gates under `tools.*.enabled`
- per-command registration gates under `commands.*.enabled`
- `image.enabled` for direct image fetches, frame extraction, and thumbnails
- `pdf.enabled` for PDF extraction

The legacy `webSearch.enabled: false` shorthand still disables `web_search` and `source_check` unless a tool-specific setting overrides it.

Fixes #234.

## Validation

- `npm test -- test/tool-registration-config.test.mjs test/pdf-config.test.mjs test/fetch-routing.test.mjs`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
