### PR TITLE
fix: externalize fetched content storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Added per-tool and per-command registration gates plus image and PDF extraction gates. Thanks @jaudiger for issue #234.
 
 ### Fixed
+- Store full fetched content in an external cache instead of embedding it in session JSONL entries, preventing large search-heavy sessions from ballooning on restore. Thanks Igor Samokhovets (`@samohovets`) for issue #236.
 - Document `get_search_content` parameter constraints in the tool schema. Thanks `@iwangjie` for PR #233.
 
 ## [0.20.0] - 2026-08-10

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ fetch_content({ url: "https://example.com/diagram.png" })
 
 ### get_search_content
 
-Retrieve stored content from previous searches or fetches. Fetched URL content is stored in full, including when `fetch_content` uses answer mode. Use `findText` to locate bounded matching passages without paging through a large page, or use `offset` and `limit` to retrieve slices intentionally.
+Retrieve stored content from previous searches or fetches. Fetched URL content is stored in full in a private `web-search-cache` directory under the Pi config directory, not in the session JSONL. This includes `fetch_content` answer mode, which stores the original page content. Cache entries use the same one-hour lifetime as in-session result IDs. Use `findText` to locate bounded matching passages without paging through a large page, or use `offset` and `limit` to retrieve slices intentionally.
 
 ```typescript
 get_search_content({ responseId: "abc123", urlIndex: 0 })

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ import {
 	getAllResults,
 	getResult,
 	restoreFromSession,
+	storeFetchedContentResult,
 	storeResult,
 	type QueryResultData,
 	type StoredSearchData,
@@ -914,14 +915,13 @@ export default function (pi: ExtensionAPI) {
 		fetchAllContent(urls, controller.signal)
 			.then((fetched) => {
 				if (!sessionActive || !pendingFetches.has(fetchId)) return;
-				const data: StoredSearchData = {
+				const data = {
 					id: fetchId,
 					type: "fetch",
 					timestamp: Date.now(),
 					urls: stripThumbnails(fetched),
-				};
-				storeResult(fetchId, data);
-				pi.appendEntry("web-search-results", data);
+				} satisfies StoredSearchData & { type: "fetch"; urls: ExtractedContent[] };
+				pi.appendEntry("web-search-results", storeFetchedContentResult(fetchId, data));
 				const ok = fetched.filter(f => !f.error).length;
 				pi.sendMessage(
 					{
@@ -1236,14 +1236,13 @@ export default function (pi: ExtensionAPI) {
 		let fetchId: string | null = null;
 		if (hasInlineReady && opts.inlineContent) {
 			fetchId = generateId();
-			const data: StoredSearchData = {
+			const data = {
 				id: fetchId,
 				type: "fetch",
 				timestamp: Date.now(),
 				urls: opts.inlineContent,
-			};
-			storeResult(fetchId, data);
-			pi.appendEntry("web-search-results", data);
+			} satisfies StoredSearchData & { type: "fetch"; urls: ExtractedContent[] };
+			pi.appendEntry("web-search-results", storeFetchedContentResult(fetchId, data));
 			if (!hasApprovedSummary) {
 				output += `---\nFull content for ${opts.inlineContent.length} sources available [${fetchId}].`;
 			}
@@ -2357,14 +2356,13 @@ export default function (pi: ExtensionAPI) {
 
 			// ALWAYS store results (even for single URL)
 			const responseId = generateId();
-			const data: StoredSearchData = {
+			const data = {
 				id: responseId,
 				type: "fetch",
 				timestamp: Date.now(),
 				urls: stripThumbnails(fetchResults),
-			};
-			storeResult(responseId, data);
-			pi.appendEntry("web-search-results", data);
+			} satisfies StoredSearchData & { type: "fetch"; urls: ExtractedContent[] };
+			pi.appendEntry("web-search-results", storeFetchedContentResult(responseId, data));
 
 			// Single URL: return content directly (possibly truncated) with responseId
 			if (urlList.length === 1) {
@@ -3237,8 +3235,8 @@ export default function (pi: ExtensionAPI) {
 					const query = r.queries[0]?.query || "unknown";
 					return `[${r.id.slice(0, 6)}] "${query}" (${r.queries.length} queries) - ${ageStr}`;
 				}
-				if (r.type === "fetch" && r.urls) {
-					return `[${r.id.slice(0, 6)}] ${r.urls.length} URLs fetched - ${ageStr}`;
+				if (r.type === "fetch" && (r.urls || r.urlMetadata)) {
+					return `[${r.id.slice(0, 6)}] ${(r.urls ?? r.urlMetadata ?? []).length} URLs fetched - ${ageStr}`;
 				}
 				return `[${r.id.slice(0, 6)}] ${r.type} - ${ageStr}`;
 			});
@@ -3270,15 +3268,17 @@ export default function (pi: ExtensionAPI) {
 						info += `... and ${selected.queries.length - 10} more\n`;
 					}
 				}
-				if (selected.type === "fetch" && selected.urls) {
+				if (selected.type === "fetch" && (selected.urls || selected.urlMetadata)) {
 					info += "URLs:\n";
-					const urls = selected.urls.slice(0, 10);
+					const urlItems = selected.urls ?? selected.urlMetadata ?? [];
+					const urls = urlItems.slice(0, 10);
 					for (const u of urls) {
 						const urlDisplay = u.url.length > 50 ? u.url.slice(0, 47) + "..." : u.url;
-						info += `- ${urlDisplay} (${u.error || `${u.content.length} chars`})\n`;
+						const contentLength = "content" in u ? u.content.length : u.contentLength;
+						info += `- ${urlDisplay} (${u.error || `${contentLength} chars`})\n`;
 					}
-					if (selected.urls.length > 10) {
-						info += `... and ${selected.urls.length - 10} more\n`;
+					if (urlItems.length > 10) {
+						info += `... and ${urlItems.length - 10} more\n`;
 					}
 				}
 				ctx.ui.notify(info, "info");

--- a/storage.ts
+++ b/storage.ts
@@ -1,8 +1,16 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ExtractedContent } from "./extract.ts";
 import type { SearchResult } from "./perplexity.ts";
+import { getWebSearchConfigDir } from "./utils.ts";
 
 const CACHE_TTL_MS = 60 * 60 * 1000;
+const FETCH_CACHE_DIR = "web-search-cache";
+const FETCH_CACHE_VERSION = 1;
+const CACHE_KEY_PATTERN = /^[A-Za-z0-9_-]+\.json$/;
+const CACHE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const MAX_METADATA_TEXT = 8192;
 
 export interface QueryResultData {
 	query: string;
@@ -12,6 +20,22 @@ export interface QueryResultData {
 	provider?: string;
 }
 
+interface FetchCacheRef {
+	version: typeof FETCH_CACHE_VERSION;
+	key: string;
+	storedAt: number;
+}
+
+interface StoredFetchUrlMetadata {
+	url: string;
+	title: string;
+	error: string | null;
+	contentLength: number;
+	mimeType?: string;
+	status?: number;
+	duration?: number;
+}
+
 export interface StoredSearchData {
 	id: string;
 	type: "search" | "fetch" | "research";
@@ -19,6 +43,9 @@ export interface StoredSearchData {
 	queries?: QueryResultData[];
 	urls?: ExtractedContent[];
 	artifact?: unknown;
+	fetchCache?: FetchCacheRef;
+	urlMetadata?: StoredFetchUrlMetadata[];
+	fetchCacheError?: string;
 }
 
 const storedResults = new Map<string, StoredSearchData>();
@@ -27,12 +54,190 @@ export function generateId(): string {
 	return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
 }
 
+export function getFetchCacheDir(): string {
+	return join(getWebSearchConfigDir(), FETCH_CACHE_DIR);
+}
+
+function fetchCachePath(key: string): string | null {
+	if (!CACHE_KEY_PATTERN.test(key)) return null;
+	return join(getFetchCacheDir(), key);
+}
+
+function cacheKeyForId(id: string): string {
+	if (!CACHE_ID_PATTERN.test(id)) {
+		throw new Error(`Invalid fetched content cache id: ${id}`);
+	}
+	return `${id}.json`;
+}
+
+function truncateMetadataText(value: string | undefined): string {
+	if (!value) return "";
+	return value.length > MAX_METADATA_TEXT ? `${value.slice(0, MAX_METADATA_TEXT)}...` : value;
+}
+
+function metadataForUrls(urls: ExtractedContent[]): StoredFetchUrlMetadata[] {
+	return urls.map((url) => ({
+		url: truncateMetadataText(url.url),
+		title: truncateMetadataText(url.title),
+		error: url.error ? truncateMetadataText(url.error) : null,
+		contentLength: url.content.length,
+		...(url.mimeType ? { mimeType: truncateMetadataText(url.mimeType) } : {}),
+		...(typeof url.status === "number" ? { status: url.status } : {}),
+		...(typeof url.duration === "number" ? { duration: url.duration } : {}),
+	}));
+}
+
+function isFetchCacheRef(value: unknown): value is FetchCacheRef {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const ref = value as Record<string, unknown>;
+	return ref.version === FETCH_CACHE_VERSION &&
+		typeof ref.key === "string" && CACHE_KEY_PATTERN.test(ref.key) &&
+		typeof ref.storedAt === "number" && Number.isFinite(ref.storedAt);
+}
+
+function isStoredFetchUrlMetadata(value: unknown): value is StoredFetchUrlMetadata {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const meta = value as Record<string, unknown>;
+	return typeof meta.url === "string" &&
+		typeof meta.title === "string" &&
+		(meta.error === null || typeof meta.error === "string") &&
+		typeof meta.contentLength === "number" && Number.isFinite(meta.contentLength) && meta.contentLength >= 0 &&
+		(meta.mimeType === undefined || typeof meta.mimeType === "string") &&
+		(meta.status === undefined || typeof meta.status === "number") &&
+		(meta.duration === undefined || typeof meta.duration === "number");
+}
+
+function isInlineFetchedUrl(value: unknown): value is ExtractedContent {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const url = value as Record<string, unknown>;
+	return typeof url.url === "string" &&
+		typeof url.title === "string" &&
+		typeof url.content === "string" &&
+		(url.error === null || typeof url.error === "string");
+}
+
+function isInlineFetchData(data: StoredSearchData): data is StoredSearchData & { urls: ExtractedContent[] } {
+	return data.type === "fetch" && Array.isArray(data.urls) && data.urls.every(isInlineFetchedUrl);
+}
+
+function writeFetchCache(data: StoredSearchData & { urls: ExtractedContent[] }): FetchCacheRef {
+	const dir = getFetchCacheDir();
+	mkdirSync(dir, { recursive: true, mode: 0o700 });
+	const key = cacheKeyForId(data.id);
+	const finalPath = join(dir, key);
+	const tmpPath = join(dir, `${key}.${process.pid}.${Date.now()}.tmp`);
+	try {
+		writeFileSync(tmpPath, JSON.stringify(data), { mode: 0o600 });
+		renameSync(tmpPath, finalPath);
+	} catch (err) {
+		try { unlinkSync(tmpPath); } catch {}
+		throw err;
+	}
+	return { version: FETCH_CACHE_VERSION, key, storedAt: Date.now() };
+}
+
+function cacheWriteError(err: unknown): string {
+	const message = err instanceof Error ? err.message : String(err);
+	return `Failed to write fetched content cache: ${message}`;
+}
+
+function createFetchSessionData(data: StoredSearchData & { urls: ExtractedContent[] }, ref: FetchCacheRef | null, cacheError?: string): StoredSearchData {
+	return {
+		id: data.id,
+		type: "fetch",
+		timestamp: data.timestamp,
+		urlMetadata: metadataForUrls(data.urls),
+		...(ref ? { fetchCache: ref } : {}),
+		...(cacheError ? { fetchCacheError: truncateMetadataText(cacheError) } : {}),
+	};
+}
+
+function fetchUrlMetadata(data: StoredSearchData): StoredFetchUrlMetadata[] {
+	if (data.urlMetadata) return data.urlMetadata;
+	return isInlineFetchData(data) ? metadataForUrls(data.urls) : [];
+}
+
+function unavailableFetchData(data: StoredSearchData, reason: string): StoredSearchData {
+	return {
+		...data,
+		urls: fetchUrlMetadata(data).map((meta) => ({
+			url: meta.url,
+			title: meta.title,
+			content: "",
+			error: reason,
+			...(meta.mimeType ? { mimeType: meta.mimeType } : {}),
+			...(typeof meta.status === "number" ? { status: meta.status } : {}),
+			...(typeof meta.duration === "number" ? { duration: meta.duration } : {}),
+		})),
+	};
+}
+
+function readCachedFetchData(data: StoredSearchData, now = Date.now()): StoredSearchData {
+	if (data.type !== "fetch") return data;
+	if (now - data.timestamp >= CACHE_TTL_MS) {
+		return unavailableFetchData(data, "Cached fetched content is missing or expired");
+	}
+	if (isInlineFetchData(data)) return data;
+	if (!data.fetchCache) {
+		return unavailableFetchData(data, data.fetchCacheError ?? "Cached fetched content is unavailable");
+	}
+	const path = fetchCachePath(data.fetchCache.key);
+	if (!path || !existsSync(path)) {
+		return unavailableFetchData(data, "Cached fetched content is missing or expired");
+	}
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
+		if (!isValidStoredData(parsed) || parsed.type !== "fetch" || parsed.id !== data.id || !isInlineFetchData(parsed)) {
+			return unavailableFetchData(data, "Cached fetched content is invalid");
+		}
+		return { ...parsed, fetchCache: data.fetchCache, urlMetadata: data.urlMetadata };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return unavailableFetchData(data, `Cached fetched content could not be read: ${message}`);
+	}
+}
+
+export function pruneExpiredFetchCache(now = Date.now()): void {
+	const dir = getFetchCacheDir();
+	if (!existsSync(dir)) return;
+	let entries: string[];
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		if (!CACHE_KEY_PATTERN.test(entry)) continue;
+		const path = join(dir, entry);
+		try {
+			if (now - statSync(path).mtimeMs >= CACHE_TTL_MS) unlinkSync(path);
+		} catch {}
+	}
+}
+
 export function storeResult(id: string, data: StoredSearchData): void {
 	storedResults.set(id, data);
 }
 
+export function storeFetchedContentResult(id: string, data: StoredSearchData & { type: "fetch"; urls: ExtractedContent[] }): StoredSearchData {
+	pruneExpiredFetchCache();
+	let ref: FetchCacheRef | null = null;
+	let cacheError: string | undefined;
+	try {
+		ref = writeFetchCache(data);
+	} catch (err) {
+		cacheError = cacheWriteError(err);
+	}
+	storedResults.set(id, ref ? { ...data, fetchCache: ref, urlMetadata: metadataForUrls(data.urls) } : { ...data, fetchCacheError: cacheError });
+	return createFetchSessionData(data, ref, cacheError);
+}
+
 export function getResult(id: string): StoredSearchData | null {
-	return storedResults.get(id) ?? null;
+	const data = storedResults.get(id);
+	if (!data) return null;
+	const loaded = readCachedFetchData(data);
+	if (loaded !== data) storedResults.set(id, loaded);
+	return loaded;
 }
 
 export function getAllResults(): StoredSearchData[] {
@@ -40,6 +245,11 @@ export function getAllResults(): StoredSearchData[] {
 }
 
 export function deleteResult(id: string): boolean {
+	const data = storedResults.get(id);
+	if (data?.fetchCache) {
+		const path = fetchCachePath(data.fetchCache.key);
+		if (path) try { unlinkSync(path); } catch {}
+	}
 	return storedResults.delete(id);
 }
 
@@ -54,7 +264,11 @@ function isValidStoredData(data: unknown): data is StoredSearchData {
 	if (d.type !== "search" && d.type !== "fetch" && d.type !== "research") return false;
 	if (typeof d.timestamp !== "number") return false;
 	if (d.type === "search" && !Array.isArray(d.queries)) return false;
-	if (d.type === "fetch" && !Array.isArray(d.urls)) return false;
+	if (d.type === "fetch") {
+		if (Array.isArray(d.urls)) return d.urls.every(isInlineFetchedUrl);
+		if (!Array.isArray(d.urlMetadata) || !d.urlMetadata.every(isStoredFetchUrlMetadata)) return false;
+		return d.fetchCache === undefined ? d.fetchCacheError === undefined || typeof d.fetchCacheError === "string" : isFetchCacheRef(d.fetchCache);
+	}
 	if (d.type === "research" && (!d.artifact || typeof d.artifact !== "object")) return false;
 	return true;
 }
@@ -62,6 +276,7 @@ function isValidStoredData(data: unknown): data is StoredSearchData {
 export function restoreFromSession(ctx: ExtensionContext): void {
 	storedResults.clear();
 	const now = Date.now();
+	pruneExpiredFetchCache(now);
 
 	for (const entry of ctx.sessionManager.getBranch()) {
 		if (entry.type === "custom" && entry.customType === "web-search-results") {

--- a/test/fetch-cache-storage.test.mjs
+++ b/test/fetch-cache-storage.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, test } from "node:test";
+
+import initializeExtension from "../index.ts";
+import { clearResults, getFetchCacheDir, restoreFromSession } from "../storage.ts";
+
+const originalFetch = globalThis.fetch;
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const originalDateNow = Date.now;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	Date.now = originalDateNow;
+	if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+	clearResults();
+});
+
+async function useTempAgentDir() {
+	const dir = await mkdtemp(join(tmpdir(), "pi-web-access-fetch-cache-"));
+	process.env.PI_CODING_AGENT_DIR = dir;
+	return dir;
+}
+
+function registerTools() {
+	const tools = [];
+	const entries = [];
+	initializeExtension({
+		registerTool(tool) { tools.push(tool); },
+		registerCommand() {},
+		registerShortcut() {},
+		on() {},
+		appendEntry(type, data) { entries.push({ type, data }); },
+	});
+	return {
+		entries,
+		fetchTool: tools.find((tool) => tool.name === "fetch_content"),
+		getContentTool: tools.find((tool) => tool.name === "get_search_content"),
+	};
+}
+
+function restoreEntry(data) {
+	restoreFromSession({
+		sessionManager: {
+			getBranch: () => [{ type: "custom", customType: "web-search-results", data }],
+		},
+	});
+}
+
+test("fetch_content stores full content in cache and writes a bounded session entry", async () => {
+	await useTempAgentDir();
+	const pageContent = "Cached page content. ".repeat(4_000);
+	globalThis.fetch = async () => new Response(pageContent, { status: 200, headers: { "content-type": "text/plain" } });
+
+	const { entries, fetchTool, getContentTool } = registerTools();
+	assert.ok(fetchTool);
+	assert.ok(getContentTool);
+
+	const result = await fetchTool.execute("call", { url: "https://93.184.216.34/page" });
+	const entry = entries.find((candidate) => candidate.type === "web-search-results");
+	assert.ok(entry);
+	assert.equal(entry.data.type, "fetch");
+	assert.equal(entry.data.urls, undefined);
+	assert.ok(entry.data.fetchCache?.key);
+	assert.equal(entry.data.urlMetadata?.[0]?.contentLength, pageContent.length);
+
+	const serialized = JSON.stringify(entry.data);
+	assert.ok(serialized.length < 5_000, `session entry was ${serialized.length} chars`);
+	assert.doesNotMatch(serialized, /Cached page content\. Cached page content\./);
+
+	clearResults();
+	restoreEntry(entry.data);
+	const restored = await getContentTool.execute("call", {
+		responseId: result.details.responseId,
+		urlIndex: 0,
+		offset: pageContent.length - 21,
+		limit: 21,
+	});
+	assert.equal(restored.details.returnedChars, 21);
+	assert.match(restored.content[0].text, /Cached page content\./);
+});
+
+test("legacy inline fetched session entries remain readable", async () => {
+	await useTempAgentDir();
+	const { getContentTool } = registerTools();
+	assert.ok(getContentTool);
+	const legacy = {
+		id: "legacy-fetch",
+		type: "fetch",
+		timestamp: Date.now(),
+		urls: [{ url: "https://example.com/legacy", title: "Legacy", content: "legacy inline content", error: null }],
+	};
+
+	restoreEntry(legacy);
+	const result = await getContentTool.execute("call", { responseId: "legacy-fetch", urlIndex: 0 });
+	assert.match(result.content[0].text, /legacy inline content/);
+	assert.equal(result.details.contentLength, "legacy inline content".length);
+});
+
+test("loaded cached fetched content expires after the result lifetime", async () => {
+	const startedAt = originalDateNow();
+	Date.now = () => startedAt;
+	await useTempAgentDir();
+	const pageContent = "expiring cache-backed content";
+	globalThis.fetch = async () => new Response(pageContent, { status: 200, headers: { "content-type": "text/plain" } });
+
+	const { entries, fetchTool, getContentTool } = registerTools();
+	assert.ok(fetchTool);
+	assert.ok(getContentTool);
+	const result = await fetchTool.execute("call", { url: "https://93.184.216.34/expiring-cache" });
+	const entry = entries.find((candidate) => candidate.type === "web-search-results");
+	assert.ok(entry?.data.fetchCache?.key);
+
+	clearResults();
+	restoreEntry(entry.data);
+	const loaded = await getContentTool.execute("call", { responseId: result.details.responseId, urlIndex: 0 });
+	assert.match(loaded.content[0].text, /expiring cache-backed content/);
+
+	Date.now = () => startedAt + 60 * 60 * 1000;
+	const expired = await getContentTool.execute("call", { responseId: result.details.responseId, urlIndex: 0 });
+	assert.equal(expired.details.error, "Cached fetched content is missing or expired");
+	assert.match(expired.content[0].text, /Cached fetched content is missing or expired/);
+	assert.doesNotMatch(expired.content[0].text, /expiring cache-backed content/);
+});
+
+test("missing cache files return an actionable fetched-content error", async () => {
+	const agentDir = await useTempAgentDir();
+	const pageContent = "cache-backed content";
+	globalThis.fetch = async () => new Response(pageContent, { status: 200, headers: { "content-type": "text/plain" } });
+
+	const { entries, fetchTool, getContentTool } = registerTools();
+	assert.ok(fetchTool);
+	assert.ok(getContentTool);
+	const result = await fetchTool.execute("call", { url: "https://93.184.216.34/missing-cache" });
+	const entry = entries.find((candidate) => candidate.type === "web-search-results");
+	assert.ok(entry?.data.fetchCache?.key);
+	rmSync(join(getFetchCacheDir(), entry.data.fetchCache.key), { force: true });
+
+	clearResults();
+	restoreEntry(entry.data);
+	const missing = await getContentTool.execute("call", { responseId: result.details.responseId, urlIndex: 0 });
+	assert.equal(missing.details.error, "Cached fetched content is missing or expired");
+	assert.match(missing.content[0].text, /Cached fetched content is missing or expired/);
+	rmSync(agentDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
Fixes #236.

This moves full fetched-page bodies out of Pi session custom entries and into a private cache. Session entries now keep bounded metadata plus cache references, while `get_search_content` still loads the content on demand. Legacy inline session entries remain readable.

Validation:
- `npm test -- test/fetch-cache-storage.test.mjs test/get-search-content.test.mjs test/fetch-answer-storage.test.mjs`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Credit: thanks Igor Samokhovets (`@samohovets`) for the report and recovery measurements in #236.
