### PR TITLE
fix: bound and harden fetched-content cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Hardened the fetched-content cache against symlink traversal and unsafe permissions, and bounded it to 128 entries and 128 MiB with oldest-entry eviction.
+
 ## [0.21.0] - 2026-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Hardened the fetched-content cache against symlink traversal and unsafe permissions, and bounded it to 128 entries and 128 MiB with oldest-entry eviction.
+- Hardened the fetched-content cache against symlink traversal and unsafe permissions, and bounded it to 128 entries and 128 MiB with oldest-entry eviction. Thanks `@HerbertGao` for issue #240 and PR #241.
 
 ## [0.21.0] - 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ fetch_content({ url: "https://example.com/diagram.png" })
 
 ### get_search_content
 
-Retrieve stored content from previous searches or fetches. Fetched URL content is stored in full in a private `web-search-cache` directory under the Pi config directory, not in the session JSONL. This includes `fetch_content` answer mode, which stores the original page content. Cache entries use the same one-hour lifetime as in-session result IDs. Use `findText` to locate bounded matching passages without paging through a large page, or use `offset` and `limit` to retrieve slices intentionally.
+Retrieve stored content from previous searches or fetches. Fetched URL content is stored in full in a private `web-search-cache` directory under the Pi config directory, not in the session JSONL. This includes `fetch_content` answer mode, which stores the original page content. The cache has a one-hour lifetime and fixed limits of 128 entries and 128 MiB; when either limit is reached, the oldest entries are removed first. On macOS and Linux the cache directory and files are kept at permissions `0700` and `0600`, respectively. Use `findText` to locate bounded matching passages without paging through a large page, or use `offset` and `limit` to retrieve slices intentionally.
 
 ```typescript
 get_search_content({ responseId: "abc123", urlIndex: 0 })

--- a/storage.ts
+++ b/storage.ts
@@ -224,17 +224,28 @@ function openRegularFile(path: string): { fd: number; info: Stats } {
 	}
 }
 
-function unlinkCacheFile(dir: string, file: CacheFile): boolean {
+type CacheUnlinkResult = "removed" | "missing" | "changed" | "error";
+
+function unlinkCacheFile(dir: string, file: CacheFile): CacheUnlinkResult {
 	try {
 		const root = lstatSync(dir);
-		if (root.isSymbolicLink() || !root.isDirectory()) return false;
+		if (root.isSymbolicLink() || !root.isDirectory()) return "changed";
 		const path = join(dir, file.name);
-		const current = lstatSync(path);
-		if (current.isSymbolicLink() || !current.isFile() || current.dev !== file.dev || current.ino !== file.ino) return false;
-		unlinkSync(path);
-		return true;
+		let current: Stats;
+		try {
+			current = lstatSync(path);
+		} catch (err) {
+			return (err as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "error";
+		}
+		if (current.isSymbolicLink() || !current.isFile() || current.dev !== file.dev || current.ino !== file.ino) return "changed";
+		try {
+			unlinkSync(path);
+			return "removed";
+		} catch (err) {
+			return (err as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "error";
+		}
 	} catch {
-		return false;
+		return "error";
 	}
 }
 
@@ -273,7 +284,8 @@ function pruneFetchCache(now: number, limits: FetchCacheLimits, preferredKey?: s
 		closeSync(opened.fd);
 		const file = { name: entry, size: opened.info.size, mtimeMs: opened.info.mtimeMs, dev: opened.info.dev, ino: opened.info.ino };
 		if (now - file.mtimeMs >= CACHE_TTL_MS) {
-			if (!unlinkCacheFile(dir, file)) return false;
+			const removed = unlinkCacheFile(dir, file);
+			if (removed !== "removed" && removed !== "missing") return false;
 			continue;
 		}
 		if (CACHE_KEY_PATTERN.test(entry)) files.push(file);
@@ -294,7 +306,8 @@ function pruneFetchCache(now: number, limits: FetchCacheLimits, preferredKey?: s
 		if (index < 0) break;
 		const file = files[index];
 		attempted.add(file.name);
-		if (unlinkCacheFile(dir, file)) files.splice(index, 1);
+		const removed = unlinkCacheFile(dir, file);
+		if (removed === "removed" || removed === "missing") files.splice(index, 1);
 		usage = projectedUsage();
 	}
 	return usage.entries <= limits.maxEntries && usage.bytes <= limits.maxBytes;

--- a/storage.ts
+++ b/storage.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { closeSync, constants, fchmodSync, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, type Stats, unlinkSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ExtractedContent } from "./extract.ts";
@@ -9,8 +10,25 @@ const CACHE_TTL_MS = 60 * 60 * 1000;
 const FETCH_CACHE_DIR = "web-search-cache";
 const FETCH_CACHE_VERSION = 1;
 const CACHE_KEY_PATTERN = /^[A-Za-z0-9_-]+\.json$/;
+const CACHE_TMP_PATTERN = /^[A-Za-z0-9_-]+\.json\.\d+\.\d+(?:\.[a-f0-9]{32})?\.tmp$/;
 const CACHE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 const MAX_METADATA_TEXT = 8192;
+const DEFAULT_CACHE_LIMITS = { maxEntries: 128, maxBytes: 128 * 1024 * 1024 };
+const O_DIRECTORY = process.platform === "win32" ? 0 : (constants.O_DIRECTORY ?? 0);
+const O_NOFOLLOW = process.platform === "win32" ? 0 : (constants.O_NOFOLLOW ?? 0);
+
+interface FetchCacheLimits {
+	maxEntries: number;
+	maxBytes: number;
+}
+
+interface CacheFile {
+	name: string;
+	size: number;
+	mtimeMs: number;
+	dev: number;
+	ino: number;
+}
 
 export interface QueryResultData {
 	query: string;
@@ -120,17 +138,207 @@ function isInlineFetchData(data: StoredSearchData): data is StoredSearchData & {
 	return data.type === "fetch" && Array.isArray(data.urls) && data.urls.every(isInlineFetchedUrl);
 }
 
-function writeFetchCache(data: StoredSearchData & { urls: ExtractedContent[] }): FetchCacheRef {
-	const dir = getFetchCacheDir();
-	mkdirSync(dir, { recursive: true, mode: 0o700 });
-	const key = cacheKeyForId(data.id);
-	const finalPath = join(dir, key);
-	const tmpPath = join(dir, `${key}.${process.pid}.${Date.now()}.tmp`);
+function cacheLimits(limits?: Partial<FetchCacheLimits>): FetchCacheLimits {
+	const resolved = {
+		maxEntries: limits?.maxEntries ?? DEFAULT_CACHE_LIMITS.maxEntries,
+		maxBytes: limits?.maxBytes ?? DEFAULT_CACHE_LIMITS.maxBytes,
+	};
+	if (!Number.isFinite(resolved.maxEntries) || !Number.isInteger(resolved.maxEntries) || resolved.maxEntries <= 0 ||
+		!Number.isFinite(resolved.maxBytes) || !Number.isInteger(resolved.maxBytes) || resolved.maxBytes <= 0) {
+		throw new Error("Fetched content cache limits must be finite positive integers");
+	}
+	return resolved;
+}
+
+function enforceDirectoryMode(fd: number): void {
 	try {
-		writeFileSync(tmpPath, JSON.stringify(data), { mode: 0o600 });
-		renameSync(tmpPath, finalPath);
+		fchmodSync(fd, 0o700);
 	} catch (err) {
-		try { unlinkSync(tmpPath); } catch {}
+		if (process.platform !== "win32") throw err;
+	}
+}
+
+function enforceFileMode(fd: number): void {
+	try {
+		fchmodSync(fd, 0o600);
+	} catch (err) {
+		if (process.platform !== "win32") throw err;
+	}
+}
+
+function safeFetchCacheDir(create: true): string;
+function safeFetchCacheDir(create: false): string | null;
+function safeFetchCacheDir(create: boolean): string | null {
+	const dir = getFetchCacheDir();
+	if (create) mkdirSync(dir, { recursive: true, mode: 0o700 });
+	let before: Stats;
+	try {
+		before = lstatSync(dir);
+	} catch (err) {
+		if (!create && (err as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw err;
+	}
+	if (before.isSymbolicLink() || !before.isDirectory()) {
+		throw new Error("Fetched content cache path is not a safe directory");
+	}
+	if (process.platform === "win32") {
+		const after = lstatSync(dir);
+		if (after.isSymbolicLink() || !after.isDirectory() || after.dev !== before.dev || after.ino !== before.ino) {
+			throw new Error("Fetched content cache directory changed while securing it");
+		}
+		return dir;
+	}
+	let fd: number | null = null;
+	try {
+		fd = openSync(dir, constants.O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+		const opened = fstatSync(fd);
+		if (!opened.isDirectory() || opened.dev !== before.dev || opened.ino !== before.ino) {
+			throw new Error("Fetched content cache directory changed while opening");
+		}
+		enforceDirectoryMode(fd);
+		closeSync(fd);
+		fd = null;
+		const after = lstatSync(dir);
+		if (after.isSymbolicLink() || !after.isDirectory() || after.dev !== before.dev || after.ino !== before.ino) {
+			throw new Error("Fetched content cache directory changed while securing it");
+		}
+		return dir;
+	} finally {
+		if (fd !== null) try { closeSync(fd); } catch {}
+	}
+}
+
+function openRegularFile(path: string): { fd: number; info: Stats } {
+	const before = lstatSync(path);
+	if (before.isSymbolicLink() || !before.isFile()) throw new Error("Fetched content cache entry is not a regular file");
+	const fd = openSync(path, constants.O_RDONLY | O_NOFOLLOW);
+	try {
+		const info = fstatSync(fd);
+		if (!info.isFile() || info.dev !== before.dev || info.ino !== before.ino) {
+			throw new Error("Fetched content cache entry changed while opening");
+		}
+		return { fd, info };
+	} catch (err) {
+		closeSync(fd);
+		throw err;
+	}
+}
+
+function unlinkCacheFile(dir: string, file: CacheFile): boolean {
+	try {
+		const root = lstatSync(dir);
+		if (root.isSymbolicLink() || !root.isDirectory()) return false;
+		const path = join(dir, file.name);
+		const current = lstatSync(path);
+		if (current.isSymbolicLink() || !current.isFile() || current.dev !== file.dev || current.ino !== file.ino) return false;
+		unlinkSync(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function pruneFetchCache(now: number, limits: FetchCacheLimits, preferredKey?: string, reservation?: { key: string; bytes: number }): boolean {
+	let dir: string | null;
+	try {
+		dir = safeFetchCacheDir(false);
+	} catch {
+		return false;
+	}
+	if (!dir) return true;
+
+	let entries: string[];
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return false;
+	}
+
+	const files: CacheFile[] = [];
+	for (const entry of entries) {
+		if (!CACHE_KEY_PATTERN.test(entry) && !CACHE_TMP_PATTERN.test(entry)) continue;
+		const path = join(dir, entry);
+		let opened: ReturnType<typeof openRegularFile>;
+		try {
+			opened = openRegularFile(path);
+		} catch {
+			continue;
+		}
+		try {
+			enforceFileMode(opened.fd);
+		} catch {
+			closeSync(opened.fd);
+			continue;
+		}
+		closeSync(opened.fd);
+		const file = { name: entry, size: opened.info.size, mtimeMs: opened.info.mtimeMs, dev: opened.info.dev, ino: opened.info.ino };
+		if (now - file.mtimeMs >= CACHE_TTL_MS) {
+			if (!unlinkCacheFile(dir, file)) return false;
+			continue;
+		}
+		if (CACHE_KEY_PATTERN.test(entry)) files.push(file);
+	}
+
+	files.sort((a, b) => a.mtimeMs - b.mtimeMs || a.name.localeCompare(b.name));
+	const projectedUsage = () => {
+		const replaced = reservation ? files.find((file) => file.name === reservation.key) : undefined;
+		return {
+			entries: files.length + (reservation && !replaced ? 1 : 0),
+			bytes: files.reduce((total, file) => total + file.size, 0) + (reservation ? reservation.bytes - (replaced?.size ?? 0) : 0),
+		};
+	};
+	const attempted = new Set<string>();
+	let usage = projectedUsage();
+	while (usage.entries > limits.maxEntries || usage.bytes > limits.maxBytes) {
+		const index = files.findIndex((file) => file.name !== preferredKey && !attempted.has(file.name));
+		if (index < 0) break;
+		const file = files[index];
+		attempted.add(file.name);
+		if (unlinkCacheFile(dir, file)) files.splice(index, 1);
+		usage = projectedUsage();
+	}
+	return usage.entries <= limits.maxEntries && usage.bytes <= limits.maxBytes;
+}
+
+function writeFetchCache(data: StoredSearchData & { urls: ExtractedContent[] }): FetchCacheRef {
+	const limits = DEFAULT_CACHE_LIMITS;
+	const serialized = JSON.stringify(data);
+	const size = Buffer.byteLength(serialized);
+	if (size > limits.maxBytes) throw new Error(`Fetched content cache entry exceeds ${limits.maxBytes} bytes`);
+
+	const dir = safeFetchCacheDir(true);
+	const key = cacheKeyForId(data.id);
+	if (!pruneFetchCache(Date.now(), limits, key, { key, bytes: size })) {
+		throw new Error("Fetched content cache could not reserve space for a new entry");
+	}
+	const finalPath = join(dir, key);
+	const tmpName = `${key}.${process.pid}.${Date.now()}.${randomBytes(16).toString("hex")}.tmp`;
+	const tmpPath = join(dir, tmpName);
+	let fd: number | null = null;
+	let tmpFile: CacheFile | null = null;
+	let renamed = false;
+	try {
+		fd = openSync(tmpPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | O_NOFOLLOW, 0o600);
+		const tmpInfo = fstatSync(fd);
+		tmpFile = { name: tmpName, size: tmpInfo.size, mtimeMs: tmpInfo.mtimeMs, dev: tmpInfo.dev, ino: tmpInfo.ino };
+		enforceFileMode(fd);
+		writeFileSync(fd, serialized, "utf8");
+		fsyncSync(fd);
+		closeSync(fd);
+		fd = null;
+		safeFetchCacheDir(false);
+		renameSync(tmpPath, finalPath);
+		renamed = true;
+		const written = lstatSync(finalPath);
+		if (!written.isFile() || written.dev !== tmpFile.dev || written.ino !== tmpFile.ino) {
+			throw new Error("Fetched content cache entry changed after writing");
+		}
+		if (!pruneFetchCache(Date.now(), limits, key)) {
+			throw new Error("Fetched content cache could not meet its limits after writing");
+		}
+	} catch (err) {
+		if (fd !== null) try { closeSync(fd); } catch {}
+		if (tmpFile) unlinkCacheFile(dir, { ...tmpFile, name: renamed ? key : tmpName });
 		throw err;
 	}
 	return { version: FETCH_CACHE_VERSION, key, storedAt: Date.now() };
@@ -182,37 +390,32 @@ function readCachedFetchData(data: StoredSearchData, now = Date.now()): StoredSe
 		return unavailableFetchData(data, data.fetchCacheError ?? "Cached fetched content is unavailable");
 	}
 	const path = fetchCachePath(data.fetchCache.key);
-	if (!path || !existsSync(path)) {
-		return unavailableFetchData(data, "Cached fetched content is missing or expired");
-	}
+	if (!path) return unavailableFetchData(data, "Cached fetched content is missing or expired");
+	let fd: number | null = null;
 	try {
-		const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
+		if (!safeFetchCacheDir(false)) return unavailableFetchData(data, "Cached fetched content is missing or expired");
+		const opened = openRegularFile(path);
+		fd = opened.fd;
+		enforceFileMode(fd);
+		const parsed: unknown = JSON.parse(readFileSync(fd, "utf8"));
 		if (!isValidStoredData(parsed) || parsed.type !== "fetch" || parsed.id !== data.id || !isInlineFetchData(parsed)) {
 			return unavailableFetchData(data, "Cached fetched content is invalid");
 		}
 		return { ...parsed, fetchCache: data.fetchCache, urlMetadata: data.urlMetadata };
 	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+			return unavailableFetchData(data, "Cached fetched content is missing or expired");
+		}
 		const message = err instanceof Error ? err.message : String(err);
 		return unavailableFetchData(data, `Cached fetched content could not be read: ${message}`);
+	} finally {
+		if (fd !== null) try { closeSync(fd); } catch {}
 	}
 }
 
-export function pruneExpiredFetchCache(now = Date.now()): void {
-	const dir = getFetchCacheDir();
-	if (!existsSync(dir)) return;
-	let entries: string[];
-	try {
-		entries = readdirSync(dir);
-	} catch {
-		return;
-	}
-	for (const entry of entries) {
-		if (!CACHE_KEY_PATTERN.test(entry)) continue;
-		const path = join(dir, entry);
-		try {
-			if (now - statSync(path).mtimeMs >= CACHE_TTL_MS) unlinkSync(path);
-		} catch {}
-	}
+export function pruneExpiredFetchCache(now = Date.now(), requestedLimits?: Partial<FetchCacheLimits>): void {
+	const limits = cacheLimits(requestedLimits);
+	try { pruneFetchCache(now, limits); } catch {}
 }
 
 export function storeResult(id: string, data: StoredSearchData): void {
@@ -220,7 +423,6 @@ export function storeResult(id: string, data: StoredSearchData): void {
 }
 
 export function storeFetchedContentResult(id: string, data: StoredSearchData & { type: "fetch"; urls: ExtractedContent[] }): StoredSearchData {
-	pruneExpiredFetchCache();
 	let ref: FetchCacheRef | null = null;
 	let cacheError: string | undefined;
 	try {
@@ -247,8 +449,16 @@ export function getAllResults(): StoredSearchData[] {
 export function deleteResult(id: string): boolean {
 	const data = storedResults.get(id);
 	if (data?.fetchCache) {
-		const path = fetchCachePath(data.fetchCache.key);
-		if (path) try { unlinkSync(path); } catch {}
+		try {
+			const dir = safeFetchCacheDir(false);
+			const path = fetchCachePath(data.fetchCache.key);
+			if (dir && path) {
+				const info = lstatSync(path);
+				if (!info.isSymbolicLink() && info.isFile()) {
+					unlinkCacheFile(dir, { name: data.fetchCache.key, size: info.size, mtimeMs: info.mtimeMs, dev: info.dev, ino: info.ino });
+				}
+			}
+		} catch {}
 	}
 	return storedResults.delete(id);
 }

--- a/test/fetch-cache-storage.test.mjs
+++ b/test/fetch-cache-storage.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, truncateSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, truncateSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -318,7 +318,7 @@ test("cache directory symlinks are rejected for writes and deletes", { skip: pro
 	assert.match(rejected.fetchCacheError, /not a safe directory/);
 	assert.deepEqual(readdirSync(outside), []);
 
-	rmSync(cacheDir);
+	unlinkSync(cacheDir);
 	const stored = storeFetchedContentResult("delete-link", fetchedData("delete-link"));
 	assert.ok(stored.fetchCache);
 	rmSync(cacheDir, { recursive: true });

--- a/test/fetch-cache-storage.test.mjs
+++ b/test/fetch-cache-storage.test.mjs
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
-import { rmSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, truncateSync, utimesSync, writeFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, test } from "node:test";
 
 import initializeExtension from "../index.ts";
-import { clearResults, getFetchCacheDir, restoreFromSession } from "../storage.ts";
+import { clearResults, deleteResult, getFetchCacheDir, getResult, pruneExpiredFetchCache, restoreFromSession, storeFetchedContentResult } from "../storage.ts";
 
 const originalFetch = globalThis.fetch;
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -49,6 +49,15 @@ function restoreEntry(data) {
 			getBranch: () => [{ type: "custom", customType: "web-search-results", data }],
 		},
 	});
+}
+
+function fetchedData(id, content = "cached content") {
+	return {
+		id,
+		type: "fetch",
+		timestamp: Date.now(),
+		urls: [{ url: `https://example.com/${id}`, title: id, content, error: null }],
+	};
 }
 
 test("fetch_content stores full content in cache and writes a bounded session entry", async () => {
@@ -146,4 +155,176 @@ test("missing cache files return an actionable fetched-content error", async () 
 	assert.equal(missing.details.error, "Cached fetched content is missing or expired");
 	assert.match(missing.content[0].text, /Cached fetched content is missing or expired/);
 	rmSync(agentDir, { recursive: true, force: true });
+});
+
+test("cache pruning evicts the oldest entries by count and bytes", async () => {
+	await useTempAgentDir();
+	const cacheDir = getFetchCacheDir();
+	mkdirSync(cacheDir, { recursive: true });
+	const now = Date.now();
+	for (const [name, content, ageSeconds] of [
+		["oldest.json", "1111", 30],
+		["middle.json", "222222", 20],
+		["newest.json", "33333333", 10],
+	]) {
+		const path = join(cacheDir, name);
+		writeFileSync(path, content);
+		utimesSync(path, new Date(now - ageSeconds * 1000), new Date(now - ageSeconds * 1000));
+	}
+
+	pruneExpiredFetchCache(now, { maxEntries: 2, maxBytes: 1024 });
+	assert.deepEqual(readdirSync(cacheDir).sort(), ["middle.json", "newest.json"]);
+
+	pruneExpiredFetchCache(now, { maxEntries: 10, maxBytes: 8 });
+	assert.deepEqual(readdirSync(cacheDir), ["newest.json"]);
+	assert.throws(() => pruneExpiredFetchCache(now, { maxEntries: 0 }), /finite positive integers/);
+	assert.throws(() => pruneExpiredFetchCache(now, { maxBytes: Infinity }), /finite positive integers/);
+});
+
+test("default cache pruning keeps the newest 128 entries", async () => {
+	await useTempAgentDir();
+	const cacheDir = getFetchCacheDir();
+	mkdirSync(cacheDir, { recursive: true });
+	const now = Date.now();
+	for (let index = 0; index < 129; index++) {
+		const path = join(cacheDir, `entry-${index.toString().padStart(3, "0")}.json`);
+		writeFileSync(path, "{}");
+		const modified = new Date(now - (129 - index) * 1000);
+		utimesSync(path, modified, modified);
+	}
+
+	pruneExpiredFetchCache(now);
+	const remaining = readdirSync(cacheDir).sort();
+	assert.equal(remaining.length, 128);
+	assert.equal(remaining.includes("entry-000.json"), false);
+	assert.equal(remaining.includes("entry-128.json"), true);
+});
+
+test("default cache pruning enforces the 128 MiB byte limit", async () => {
+	await useTempAgentDir();
+	const cacheDir = getFetchCacheDir();
+	mkdirSync(cacheDir, { recursive: true });
+	const now = Date.now();
+	for (const [name, ageSeconds] of [["older.json", 20], ["newer.json", 10]]) {
+		const path = join(cacheDir, name);
+		writeFileSync(path, "");
+		truncateSync(path, 65 * 1024 * 1024);
+		const modified = new Date(now - ageSeconds * 1000);
+		utimesSync(path, modified, modified);
+	}
+
+	pruneExpiredFetchCache(now);
+	assert.deepEqual(readdirSync(cacheDir), ["newer.json"]);
+});
+
+test("cache pruning removes only stale owned temp files", async () => {
+	await useTempAgentDir();
+	const cacheDir = getFetchCacheDir();
+	mkdirSync(cacheDir, { recursive: true });
+	const now = Date.now();
+	const stale = ["old.json.123.456.tmp", `new.json.123.456.${"a".repeat(32)}.tmp`];
+	const fresh = `fresh.json.123.456.${"b".repeat(32)}.tmp`;
+	const preserved = ["foreign.tmp", "old.json.not-ours.tmp", fresh];
+	for (const name of [...stale, ...preserved]) {
+		const path = join(cacheDir, name);
+		writeFileSync(path, name);
+		if (name !== fresh) utimesSync(path, new Date(now - 2 * 60 * 60 * 1000), new Date(now - 2 * 60 * 60 * 1000));
+	}
+
+	pruneExpiredFetchCache(now);
+	assert.deepEqual(readdirSync(cacheDir).sort(), preserved.sort());
+});
+
+test("cache pruning corrects directory and entry permissions", { skip: process.platform === "win32" }, async () => {
+	await useTempAgentDir();
+	const cacheDir = getFetchCacheDir();
+	mkdirSync(cacheDir, { recursive: true });
+	const entryPath = join(cacheDir, "permissions.json");
+	writeFileSync(entryPath, "{}");
+	chmodSync(cacheDir, 0o777);
+	chmodSync(entryPath, 0o666);
+
+	pruneExpiredFetchCache();
+	assert.equal(statSync(cacheDir).mode & 0o777, 0o700);
+	assert.equal(statSync(entryPath).mode & 0o777, 0o600);
+});
+
+test("cache write and rename failures degrade without leaving temp files", async () => {
+	await useTempAgentDir();
+	const unwritable = fetchedData("unwritable");
+	unwritable.circular = unwritable;
+	const failed = storeFetchedContentResult("unwritable", unwritable);
+	assert.equal(failed.fetchCache, undefined);
+	assert.match(failed.fetchCacheError, /circular/i);
+	assert.equal(readdirSync(dirname(getFetchCacheDir())).includes("web-search-cache"), false);
+
+	const written = storeFetchedContentResult("normal", fetchedData("normal"));
+	assert.ok(written.fetchCache);
+	mkdirSync(join(getFetchCacheDir(), "blocked.json"));
+	const blocked = storeFetchedContentResult("blocked", fetchedData("blocked"));
+	assert.equal(blocked.fetchCache, undefined);
+	assert.equal(readdirSync(getFetchCacheDir()).some((name) => name.endsWith(".tmp")), false);
+});
+
+test("corrupt cache files remain unavailable without throwing", async () => {
+	await useTempAgentDir();
+	const cacheDir = getFetchCacheDir();
+	mkdirSync(cacheDir, { recursive: true });
+	writeFileSync(join(cacheDir, "corrupt.json"), "not json");
+	restoreEntry({
+		id: "corrupt",
+		type: "fetch",
+		timestamp: Date.now(),
+		fetchCache: { version: 1, key: "corrupt.json", storedAt: Date.now() },
+		urlMetadata: [{ url: "https://example.com/corrupt", title: "corrupt", error: null, contentLength: 8 }],
+	});
+
+	const restored = getResult("corrupt");
+	assert.equal(restored.urls[0].content, "");
+	assert.match(restored.urls[0].error, /could not be read/);
+});
+
+test("cache file symlinks are not followed", { skip: process.platform === "win32" }, async () => {
+	const agentDir = await useTempAgentDir();
+	const cacheDir = getFetchCacheDir();
+	mkdirSync(cacheDir, { recursive: true });
+	const target = join(agentDir, "outside.json");
+	writeFileSync(target, JSON.stringify(fetchedData("linked")));
+	symlinkSync(target, join(cacheDir, "linked.json"));
+	restoreEntry({
+		id: "linked",
+		type: "fetch",
+		timestamp: Date.now(),
+		fetchCache: { version: 1, key: "linked.json", storedAt: Date.now() },
+		urlMetadata: [{ url: "https://example.com/linked", title: "linked", error: null, contentLength: 14 }],
+	});
+
+	const restored = getResult("linked");
+	assert.equal(restored.urls[0].content, "");
+	assert.match(restored.urls[0].error, /not a regular file/);
+	assert.match(readFileSync(target, "utf8"), /cached content/);
+});
+
+test("cache directory symlinks are rejected for writes and deletes", { skip: process.platform === "win32" }, async () => {
+	const agentDir = await useTempAgentDir();
+	const cacheDir = getFetchCacheDir();
+	const outside = join(agentDir, "outside-cache");
+	mkdirSync(dirname(cacheDir), { recursive: true });
+	mkdirSync(outside);
+	symlinkSync(outside, cacheDir);
+
+	const rejected = storeFetchedContentResult("dir-link", fetchedData("dir-link"));
+	assert.equal(rejected.fetchCache, undefined);
+	assert.match(rejected.fetchCacheError, /not a safe directory/);
+	assert.deepEqual(readdirSync(outside), []);
+
+	rmSync(cacheDir);
+	const stored = storeFetchedContentResult("delete-link", fetchedData("delete-link"));
+	assert.ok(stored.fetchCache);
+	rmSync(cacheDir, { recursive: true });
+	mkdirSync(outside, { recursive: true });
+	writeFileSync(join(outside, stored.fetchCache.key), "outside");
+	symlinkSync(outside, cacheDir);
+	assert.equal(deleteResult("delete-link"), true);
+	assert.equal(readFileSync(join(outside, stored.fetchCache.key), "utf8"), "outside");
 });


### PR DESCRIPTION
## Summary

- bound the external fetched-content cache to 128 entries and 128 MiB, evicting the oldest entries after TTL cleanup
- remove stale extension-owned temp files while preserving fresh/in-flight and unrelated files
- normalize POSIX cache directory/file permissions to `0700` / `0600`
- reject cache directory and entry symlinks, with inode checks around POSIX directory/file opens
- write through cryptographically random, exclusive temp files with `fsync` and atomic rename
- clean up the renamed final entry if a post-rename validation or quota check fails
- preserve graceful missing/corrupt/permission-error degradation and legacy inline session entries

Fixes #240

## Limits and platform behavior

The limits are fixed defaults rather than a new configuration surface. Production writes always use 128 entries / 128 MiB; the optional limits accepted by `pruneExpiredFetchCache` exist only to keep focused pruning tests small and are validated as finite positive integers.

On macOS/Linux, directory and file permissions are enforced through opened file descriptors. Windows keeps the static non-symlink/type checks but relies on Windows ACL behavior rather than POSIX modes. Node has no portable `openat`/`renameat` API, so this hardens pre-existing/static symlinks and detects inode swaps around opens; it does not claim to defeat a malicious same-user process continuously replacing the parent directory between every path operation.

## Validation

- `node --test test/fetch-cache-storage.test.mjs`: 13/13 passed
- `npm test`: 446/446 passed
- `npm run typecheck`: passed
- `npm run audit:runtime`: 0 vulnerabilities
- LSP diagnostics: clean
- `git diff --check`: passed
- additional temporary stress validation: two independent Node writers, 30 rounds, converged within test count/byte limits with no temp-file leftovers

The local full-suite run used an isolated `web-search.json` allowing `198.18.0.0/15` because this machine's TUN resolver maps `example.com` to that documented fake-IP range; without it, the unchanged `source-check` fixture is intentionally stopped by the SSRF guard before its mocked rejection.
