### PR TITLE
fix: preserve provider summary completion routing

### DIFF
--- a/summary-review.ts
+++ b/summary-review.ts
@@ -1,4 +1,4 @@
-import { complete, type Api, type Message, type Model } from "@earendil-works/pi-ai/compat";
+import { type Api, type Message, type Model } from "@earendil-works/pi-ai/compat";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 import type { QueryResultData } from "./storage.ts";
@@ -198,14 +198,14 @@ function parseModelSelector(value: string): { provider: string; id: string } {
 async function resolveSummaryModelCandidates(
 	ctx: SummaryGenerationContext,
 	modelOverride?: string,
-): Promise<{ candidates: Array<{ model: Model<Api>; apiKey: string; headers?: ProviderHeaders }>; errors: string[] }> {
+): Promise<{ candidates: Array<{ model: Model<Api>; }>; errors: string[] }> {
 	const enabledModelPatterns = loadEnabledModelPatterns(ctx);
 	const specs: Array<{ provider: string; id: string }> = [];
 	const normalizedOverride = typeof modelOverride === "string" ? modelOverride.trim() : "";
 	if (normalizedOverride.length > 0) specs.push(parseModelSelector(normalizedOverride));
 	specs.push(...PREFERRED_SUMMARY_MODELS);
 
-	const candidates: Array<{ model: Model<Api>; apiKey: string; headers?: ProviderHeaders }> = [];
+	const candidates: Array<{ model: Model<Api>; }> = [];
 	const errors: string[] = [];
 	const seen = new Set<string>();
 	for (const spec of specs) {
@@ -223,11 +223,11 @@ async function resolveSummaryModelCandidates(
 			continue;
 		}
 		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-		if (!auth.ok || !auth.apiKey) {
+		if (!auth.ok) {
 			errors.push(`No API key available for summary model ${value}`);
 			continue;
 		}
-		candidates.push({ model, apiKey: auth.apiKey, headers: auth.headers });
+		candidates.push({ model });
 	}
 	return { candidates, errors };
 }
@@ -275,12 +275,14 @@ export async function generateSummaryDraft(
 	signal?: AbortSignal,
 	modelOverride?: string,
 	feedback?: string,
-	completeFn: typeof complete = complete,
+	completeFn?: typeof ctx.modelRegistry.complete,
 	deadlineMs = SUMMARY_GENERATION_DEADLINE_MS,
 ): Promise<{ summary: string; meta: SummaryMeta }> {
 	if (!ctx || !ctx.modelRegistry) {
 		throw new Error("Summary generation context unavailable");
 	}
+
+	completeFn ??= ctx.modelRegistry.complete;
 
 	const generationStartedAt = Date.now();
 	const deadlineController = new AbortController();
@@ -337,7 +339,7 @@ export async function generateSummaryDraft(
 		}
 
 		let lastError = resolved.errors.at(-1);
-		for (const { model, apiKey, headers } of resolved.candidates) {
+		for (const { model } of resolved.candidates) {
 			const startedAt = Date.now();
 			try {
 				const userMessage: Message = {
@@ -349,7 +351,7 @@ export async function generateSummaryDraft(
 				const response = await raceSummaryOperation(Promise.resolve(completeFn(
 					model,
 					{ messages: [userMessage] },
-					{ apiKey, headers, signal: completionSignal },
+					{ signal: completionSignal },
 				)));
 				if (response.stopReason === "aborted") {
 					throw new Error("Aborted");

--- a/test/summary-provider-routing.test.mjs
+++ b/test/summary-provider-routing.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, test } from "node:test";
+
+import { generateSummaryDraft } from "../summary-review.ts";
+
+const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+const testAgentDir = await mkdtemp(join(tmpdir(), "pi-web-access-provider-summary-"));
+process.env.PI_CODING_AGENT_DIR = testAgentDir;
+
+after(async () => {
+	if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	await rm(testAgentDir, { recursive: true, force: true });
+});
+
+test("summary generation preserves registered provider behavior", async () => {
+	const model = {
+		provider: "custom-gateway",
+		id: "upstream/test-model",
+		api: "custom-gateway-api",
+		baseUrl: "https://gateway.example.test",
+	};
+	const result = await generateSummaryDraft(
+		[{
+			query: "test query",
+			answer: "Provider search answer.",
+			results: [{ title: "Source", url: "https://example.test/source" }],
+			error: null,
+			provider: "search-provider",
+		}],
+		{
+			modelRegistry: {
+				find: () => model,
+				getAvailable: () => [model],
+				getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-key" }),
+				complete: async () => ({
+					stopReason: "stop",
+					content: [{ type: "text", text: "Summary from the registered gateway provider." }],
+				}),
+			},
+			cwd: process.cwd(),
+			isProjectTrusted: () => false,
+		},
+		undefined,
+		"custom-gateway/upstream/test-model",
+		undefined,
+		undefined,
+		1000,
+	);
+
+	assert.equal(result.summary, "Summary from the registered gateway provider.");
+});


### PR DESCRIPTION
Always route summary completions through the model registry.

Fixes an issue with custom providers that wrap provider streams, namely by intercepting requests and modifying headers, or rewriting model IDs. Summary generation with these providers fails, as the `complete` function from the compat model doesn't call the provider's functions.