### PR TITLE
Constrain numeric tool parameters

### DIFF
--- a/fetch-params.ts
+++ b/fetch-params.ts
@@ -75,7 +75,7 @@ function normalizeMode(value: unknown): "readable" | "raw" | "answer" | undefine
 }
 
 function normalizeOptionalInteger(value: unknown): number | undefined {
-	if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return undefined;
+	if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 12) return undefined;
 	return value;
 }
 

--- a/fetch-params.ts
+++ b/fetch-params.ts
@@ -28,7 +28,7 @@ export function normalizeFetchContentParams(params: FetchContentParams): Normali
 	const urlList = normalizedUrls.length > 0 ? normalizedUrls : normalizeSingleUrl(params.url);
 	const prompt = normalizeOptionalString(params.prompt);
 	const timestamp = normalizeOptionalString(params.timestamp);
-	const frames = normalizeOptionalInteger(params.frames);
+	const frames = normalizeOptionalFrameCount(params.frames);
 
 	const shouldIncludeFrames = frames !== undefined && (timestamp !== undefined || frames > 1);
 
@@ -74,7 +74,7 @@ function normalizeMode(value: unknown): "readable" | "raw" | "answer" | undefine
 	throw new Error('mode must be "readable", "raw", or "answer"');
 }
 
-function normalizeOptionalInteger(value: unknown): number | undefined {
+function normalizeOptionalFrameCount(value: unknown): number | undefined {
 	if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 12) return undefined;
 	return value;
 }

--- a/index.ts
+++ b/index.ts
@@ -615,6 +615,17 @@ function normalizeFindQueries(value: string | string[]): string[] {
 	return queries;
 }
 
+function formatInputValue(value: unknown): string {
+	if (typeof value === "string") return JSON.stringify(value);
+	if (typeof value === "number") return Number.isNaN(value) ? "NaN" : String(value);
+	try {
+		const serialized = JSON.stringify(value);
+		return serialized === undefined ? String(value) : serialized;
+	} catch {
+		return String(value);
+	}
+}
+
 function formatSearchSummary(results: SearchResult[], answer: string): string {
 	if (results.length === 0) {
 		return answer ? `${answer}\n\n---\n\n**Sources:**\nNo sources returned.` : "No results found.";
@@ -2623,7 +2634,9 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	if (getSearchContentEnabled) pi.registerTool({
+	if (getSearchContentEnabled) {
+		const maxInlineContentChars = getMaxInlineContentChars();
+		pi.registerTool({
 		name: toolNames.getSearchContent,
 		label: "Get Search Content",
 		description: `Retrieve bounded content slices or find matching passages in a previous ${storedContentSources} call.`,
@@ -2636,7 +2649,7 @@ export default function (pi: ExtensionAPI) {
 			url: Type.Optional(Type.String({ description: "Get content for this URL" })),
 			urlIndex: Type.Optional(Type.Integer({ minimum: 0, description: "Get content for URL at index" })),
 			offset: Type.Optional(Type.Integer({ minimum: 0, description: "Character offset for fetched URL content slices (default 0). Cannot be combined with findText." })),
-			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_INLINE_CONTENT_CHARS, description: "Maximum characters to return for fetched URL content slices (default and max are set by maxInlineContentChars). Cannot be combined with findText." })),
+			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: maxInlineContentChars, description: "Maximum characters to return for fetched URL content slices (default and max are set by maxInlineContentChars). Cannot be combined with findText." })),
 			findText: Type.Optional(Type.Union([
 				Type.String({ minLength: 1, maxLength: 500 }),
 				Type.Array(Type.String({ minLength: 1, maxLength: 500 }), { minItems: 1, maxItems: 10 }),
@@ -2646,15 +2659,23 @@ export default function (pi: ExtensionAPI) {
 
 		async execute(_toolCallId, params): Promise<AgentToolResult<Record<string, unknown>>> {
 			if (params.findText !== undefined && (params.offset !== undefined || params.limit !== undefined)) {
-				return { content: [{ type: "text", text: "findText cannot be combined with offset or limit" }], details: { error: "Incompatible find options" } };
+				const offset = formatInputValue(params.offset);
+				const limit = formatInputValue(params.limit);
+				return {
+					content: [{ type: "text", text: `findText cannot be combined with offset or limit. Received offset=${offset}, limit=${limit}; omit offset and limit when using findText.` }],
+					details: { error: "Incompatible find options" },
+				};
 			}
 			if (params.findMode !== undefined && params.findText === undefined) {
-				return { content: [{ type: "text", text: "findMode requires findText" }], details: { error: "findMode requires findText" } };
+				return {
+					content: [{ type: "text", text: `findMode ${formatInputValue(params.findMode)} requires findText; provide findText or omit findMode.` }],
+					details: { error: "findMode requires findText" },
+				};
 			}
 			const data = getResult(params.responseId);
 			if (!data) {
 				return {
-					content: [{ type: "text", text: `Error: No stored results for "${params.responseId}"` }],
+					content: [{ type: "text", text: `Error: No stored results for responseId ${formatInputValue(params.responseId)}. Use a responseId returned by ${storedContentSources}.` }],
 					details: { error: "Not found", responseId: params.responseId },
 				};
 			}
@@ -2663,7 +2684,7 @@ export default function (pi: ExtensionAPI) {
 				const artifact = getResearchArtifact(params.responseId);
 				if (!artifact) {
 					return {
-						content: [{ type: "text", text: `Error: artifact ${params.responseId} not found` }],
+						content: [{ type: "text", text: `Error: stored research artifact for responseId ${formatInputValue(params.responseId)} was not found. Use a responseId returned by ${storedContentSources}.` }],
 						details: { error: "Artifact not found", responseId: params.responseId },
 					};
 				}
@@ -2672,13 +2693,22 @@ export default function (pi: ExtensionAPI) {
 				const offset = params.offset ?? 0;
 				const limit = params.limit ?? maxInlineContentChars;
 				if (!Number.isInteger(offset) || offset < 0) {
-					return { content: [{ type: "text", text: "offset must be a non-negative integer" }], details: { error: "Invalid offset", offset } };
+					return {
+						content: [{ type: "text", text: `Invalid offset: received ${formatInputValue(offset)} for responseId ${formatInputValue(params.responseId)}; offset must be a non-negative integer. Use 0 or a larger integer.` }],
+						details: { error: "Invalid offset", offset },
+					};
 				}
 				if (!Number.isInteger(limit) || limit <= 0 || limit > maxInlineContentChars) {
-					return { content: [{ type: "text", text: `limit must be an integer from 1 to ${maxInlineContentChars}` }], details: { error: "Invalid limit", limit, maxLimit: maxInlineContentChars } };
+					return {
+						content: [{ type: "text", text: `Invalid limit: received ${formatInputValue(limit)} for responseId ${formatInputValue(params.responseId)}; limit must be an integer from 1 to ${maxInlineContentChars}. Use a value in that range.` }],
+						details: { error: "Invalid limit", limit, maxLimit: maxInlineContentChars },
+					};
 				}
 				if (offset > serialized.length) {
-					return { content: [{ type: "text", text: `offset ${offset} is out of range (0-${serialized.length})` }], details: { error: "Offset out of range", offset, contentLength: serialized.length } };
+					return {
+						content: [{ type: "text", text: `Offset ${offset} is out of range for responseId ${formatInputValue(params.responseId)}. Received offset ${offset}; valid range is 0-${serialized.length}. Use an offset within that range.` }],
+						details: { error: "Offset out of range", offset, contentLength: serialized.length },
+					};
 				}
 				const endOffset = Math.min(offset + limit, serialized.length);
 				const artifactSlice = serialized.slice(offset, endOffset);
@@ -2697,29 +2727,30 @@ export default function (pi: ExtensionAPI) {
 					if (!queryData) {
 						const available = data.queries.map((q) => `"${q.query}"`).join(", ");
 						return {
-							content: [{ type: "text", text: `Query "${params.query}" not found. Available: ${available}` }],
+							content: [{ type: "text", text: `Query ${formatInputValue(params.query)} was not found for responseId ${formatInputValue(params.responseId)}. Received query=${formatInputValue(params.query)}. Available queries: ${available || "none"}. Use one of the available queries or queryIndex.` }],
 							details: { error: "Query not found" },
 						};
 					}
 				} else if (params.queryIndex !== undefined) {
 					queryData = data.queries[params.queryIndex];
 					if (!queryData) {
+						const available = data.queries.map((q, i) => `${i}: "${q.query}"`).join(", ");
 						return {
-							content: [{ type: "text", text: `Index ${params.queryIndex} out of range (0-${data.queries.length - 1})` }],
+							content: [{ type: "text", text: `Query index ${formatInputValue(params.queryIndex)} is out of range for responseId ${formatInputValue(params.responseId)}. Received queryIndex=${formatInputValue(params.queryIndex)}; valid indexes are 0-${data.queries.length - 1}. Available queries: ${available || "none"}. Use one of the available indexes.` }],
 							details: { error: "Index out of range" },
 						};
 					}
 				} else {
 					const available = data.queries.map((q, i) => `${i}: "${q.query}"`).join(", ");
 					return {
-						content: [{ type: "text", text: `Specify query or queryIndex. Available: ${available}` }],
+						content: [{ type: "text", text: `Specify query or queryIndex for responseId ${formatInputValue(params.responseId)}. Available queries: ${available || "none"}.` }],
 						details: { error: "No query specified" },
 					};
 				}
 
 				if (queryData.error) {
 					return {
-						content: [{ type: "text", text: `Error for "${queryData.query}": ${queryData.error}` }],
+						content: [{ type: "text", text: `Error retrieving query ${formatInputValue(queryData.query)} from responseId ${formatInputValue(params.responseId)}: ${queryData.error}. Check the stored search result and retry with another query or queryIndex if needed.` }],
 						details: { error: queryData.error, query: queryData.query },
 					};
 				}
@@ -2735,7 +2766,10 @@ export default function (pi: ExtensionAPI) {
 						};
 					} catch (err) {
 						const error = err instanceof Error ? err.message : String(err);
-						return { content: [{ type: "text", text: error }], details: { error, query: queryData.query } };
+						return {
+							content: [{ type: "text", text: `Unable to find ${formatInputValue(params.findText)} in query ${formatInputValue(queryData.query)} for responseId ${formatInputValue(params.responseId)}: ${error}. Check findText and use a supported findMode.` }],
+							details: { error, query: queryData.query },
+						};
 					}
 				}
 
@@ -2755,7 +2789,7 @@ export default function (pi: ExtensionAPI) {
 					if (!urlData) {
 						const available = data.urls.map((u) => u.url).join("\n  ");
 						return {
-							content: [{ type: "text", text: `URL not found. Available:\n  ${available}` }],
+							content: [{ type: "text", text: `URL ${formatInputValue(params.url)} was not found for responseId ${formatInputValue(params.responseId)}. Received url=${formatInputValue(params.url)}. Available URLs:\n  ${available || "  none"}\nUse one of the available URLs or urlIndex.` }],
 							details: { error: "URL not found" },
 						};
 					}
@@ -2763,22 +2797,23 @@ export default function (pi: ExtensionAPI) {
 					selectedUrlIndex = params.urlIndex;
 					urlData = data.urls[selectedUrlIndex];
 					if (!urlData) {
+						const available = data.urls.map((u, i) => `${i}: ${u.url}`).join("\n  ");
 						return {
-							content: [{ type: "text", text: `Index ${params.urlIndex} out of range (0-${data.urls.length - 1})` }],
+							content: [{ type: "text", text: `URL index ${formatInputValue(params.urlIndex)} is out of range for responseId ${formatInputValue(params.responseId)}. Received urlIndex=${formatInputValue(params.urlIndex)}; valid indexes are 0-${data.urls.length - 1}. Available URLs:\n  ${available || "  none"}\nUse one of the available indexes.` }],
 							details: { error: "Index out of range" },
 						};
 					}
 				} else {
 					const available = data.urls.map((u, i) => `${i}: ${u.url}`).join("\n  ");
 					return {
-						content: [{ type: "text", text: `Specify url or urlIndex. Available:\n  ${available}` }],
+						content: [{ type: "text", text: `Specify url or urlIndex for responseId ${formatInputValue(params.responseId)}. Available URLs:\n  ${available || "  none"}` }],
 						details: { error: "No URL specified" },
 					};
 				}
 
 				if (urlData.error) {
 					return {
-						content: [{ type: "text", text: `Error for ${urlData.url}: ${urlData.error}` }],
+						content: [{ type: "text", text: `Error retrieving URL ${formatInputValue(urlData.url)} from responseId ${formatInputValue(params.responseId)}: ${urlData.error}. Check the stored fetch result and retry with another URL or urlIndex if needed.` }],
 						details: { error: urlData.error, url: urlData.url },
 					};
 				}
@@ -2793,7 +2828,10 @@ export default function (pi: ExtensionAPI) {
 						};
 					} catch (err) {
 						const error = err instanceof Error ? err.message : String(err);
-						return { content: [{ type: "text", text: error }], details: { error, url: urlData.url } };
+						return {
+							content: [{ type: "text", text: `Unable to find ${formatInputValue(params.findText)} in URL ${formatInputValue(urlData.url)} for responseId ${formatInputValue(params.responseId)}: ${error}. Check findText and use a supported findMode.` }],
+							details: { error, url: urlData.url },
+						};
 					}
 				}
 
@@ -2802,19 +2840,19 @@ export default function (pi: ExtensionAPI) {
 				const limit = params.limit ?? maxInlineContentChars;
 				if (!Number.isInteger(offset) || offset < 0) {
 					return {
-						content: [{ type: "text", text: "offset must be a non-negative integer" }],
+						content: [{ type: "text", text: `Invalid offset: received ${formatInputValue(offset)} for URL ${formatInputValue(urlData.url)}; offset must be a non-negative integer. Use 0 or a larger integer.` }],
 						details: { error: "Invalid offset", offset },
 					};
 				}
 				if (!Number.isInteger(limit) || limit <= 0 || limit > maxInlineContentChars) {
 					return {
-						content: [{ type: "text", text: `limit must be an integer from 1 to ${maxInlineContentChars}` }],
+						content: [{ type: "text", text: `Invalid limit: received ${formatInputValue(limit)} for URL ${formatInputValue(urlData.url)}; limit must be an integer from 1 to ${maxInlineContentChars}. Use a value in that range.` }],
 						details: { error: "Invalid limit", limit, maxLimit: maxInlineContentChars },
 					};
 				}
 				if (offset > urlData.content.length) {
 					return {
-						content: [{ type: "text", text: `offset ${offset} is out of range (0-${urlData.content.length})` }],
+						content: [{ type: "text", text: `Offset ${offset} is out of range for URL ${formatInputValue(urlData.url)} in responseId ${formatInputValue(params.responseId)}. Received offset ${offset}; valid range is 0-${urlData.content.length}. Use an offset within that range.` }],
 						details: { error: "Offset out of range", offset, contentLength: urlData.content.length },
 					};
 				}
@@ -2846,7 +2884,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			return {
-				content: [{ type: "text", text: "Invalid stored data format" }],
+				content: [{ type: "text", text: `Invalid stored data for responseId ${formatInputValue(params.responseId)}: received type ${formatInputValue(data.type)}. Use a responseId returned by ${storedContentSources}.` }],
 				details: { error: "Invalid data" },
 			};
 		},
@@ -2923,6 +2961,7 @@ export default function (pi: ExtensionAPI) {
 			return new Text(statusLine + "\n" + theme.fg("dim", preview), 0, 0);
 		},
 	});
+	}
 
 	if (isCommandEnabled(initConfig, "websearch")) pi.registerCommand("websearch", {
 		description: "Open web search curator",

--- a/index.ts
+++ b/index.ts
@@ -1649,7 +1649,7 @@ export default function (pi: ExtensionAPI) {
 		parameters: Type.Object({
 			query: Type.Optional(Type.String({ description: "Single search query. For research tasks, prefer 'queries' with multiple varied angles instead." })),
 			queries: Type.Optional(Type.Array(Type.String(), { description: "Multiple queries searched in sequence, each returning its own synthesized answer. Prefer this for research — vary phrasing, scope, and angle across 2-4 queries to maximize coverage. Good: ['React vs Vue performance benchmarks 2026', 'React vs Vue developer experience comparison', 'React ecosystem size vs Vue ecosystem']. Bad: ['React vs Vue', 'React vs Vue comparison', 'React vs Vue review'] (too similar, redundant results)." })),
-			numResults: Type.Optional(Type.Number({ description: "Results per query (default: 5, max: 20)" })),
+			numResults: Type.Optional(Type.Integer({ minimum: 1, maximum: 20, description: "Results per query (default: 5, max: 20)" })),
 			includeContent: Type.Optional(Type.Boolean({ description: "Fetch full page content (async)" })),
 			recencyFilter: Type.Optional(
 				StringEnum(["day", "week", "month", "year"], { description: "Filter by recency" }),
@@ -2219,7 +2219,7 @@ export default function (pi: ExtensionAPI) {
 		parameters: Type.Object({
 			claim: Type.String({ description: "The assertion to check against web sources." }),
 			queries: Type.Optional(Type.Array(Type.String(), { description: "Search queries (default: the claim)." })),
-			numResults: Type.Optional(Type.Number({ description: "Results per query (default: 5, max: 20)." })),
+			numResults: Type.Optional(Type.Integer({ minimum: 1, maximum: 20, description: "Results per query (default: 5, max: 20)." })),
 			fetchContent: Type.Optional(Type.Boolean({ description: "Fetch up to 5 result pages for exact passage extraction." })),
 			recencyFilter: Type.Optional(StringEnum(["day", "week", "month", "year"], { description: "Filter by recency." })),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains; prefix with - to exclude." })),
@@ -2632,11 +2632,11 @@ export default function (pi: ExtensionAPI) {
 		parameters: Type.Object({
 			responseId: Type.String({ description: `The responseId from ${storedContentSources}` }),
 			query: Type.Optional(Type.String({ description: searchQueryDescription })),
-			queryIndex: Type.Optional(Type.Number({ description: "Get content for query at index" })),
+			queryIndex: Type.Optional(Type.Integer({ minimum: 0, description: "Get content for query at index" })),
 			url: Type.Optional(Type.String({ description: "Get content for this URL" })),
-			urlIndex: Type.Optional(Type.Number({ description: "Get content for URL at index" })),
-			offset: Type.Optional(Type.Number({ description: "Character offset for fetched URL content slices (default 0). Cannot be combined with findText." })),
-			limit: Type.Optional(Type.Number({ description: "Maximum characters to return for fetched URL content slices (default and max are set by maxInlineContentChars). Cannot be combined with findText." })),
+			urlIndex: Type.Optional(Type.Integer({ minimum: 0, description: "Get content for URL at index" })),
+			offset: Type.Optional(Type.Integer({ minimum: 0, description: "Character offset for fetched URL content slices (default 0). Cannot be combined with findText." })),
+			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_INLINE_CONTENT_CHARS, description: "Maximum characters to return for fetched URL content slices (default and max are set by maxInlineContentChars). Cannot be combined with findText." })),
 			findText: Type.Optional(Type.Union([
 				Type.String({ minLength: 1, maxLength: 500 }),
 				Type.Array(Type.String({ minLength: 1, maxLength: 500 }), { minItems: 1, maxItems: 10 }),

--- a/test/fetch-params.test.mjs
+++ b/test/fetch-params.test.mjs
@@ -43,7 +43,8 @@ test("fetch_content params preserve forceClone only for boolean values", () => {
 	assert.equal(normalizeFetchContentParams({ forceClone: "true" }).options.forceClone, undefined);
 });
 
-test("fetch_content params drop non-positive and non-integer frames", () => {
+test("fetch_content params drop out-of-range, non-positive, and non-integer frames", () => {
+	assert.equal(normalizeFetchContentParams({ frames: 13, timestamp: "1:23" }).options.frames, undefined);
 	assert.equal(normalizeFetchContentParams({ frames: 0, timestamp: "1:23" }).options.frames, undefined);
 	assert.equal(normalizeFetchContentParams({ frames: -1, timestamp: "1:23" }).options.frames, undefined);
 	assert.equal(normalizeFetchContentParams({ frames: 1.5, timestamp: "1:23" }).options.frames, undefined);

--- a/test/get-search-content.test.mjs
+++ b/test/get-search-content.test.mjs
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import { Value } from "typebox/value";
 
 import initializeExtension from "../index.ts";
+import { buildResearchArtifact, storeResearchArtifact } from "../source-check.ts";
 import { clearResults, storeResult } from "../storage.ts";
 
 function getContentTool() {
@@ -47,11 +48,11 @@ test("get_search_content schemas constrain numeric parameters", () => {
 
 	assert.equal(properties.limit.type, "integer");
 	assert.equal(properties.limit.minimum, 1);
-	assert.equal(properties.limit.maximum, 200_000);
-	for (const value of [0, 1.5, 200_001, Number.NaN, Number.POSITIVE_INFINITY]) {
+	assert.equal(properties.limit.maximum, 30_000);
+	for (const value of [0, 1.5, 30_001, Number.NaN, Number.POSITIVE_INFINITY]) {
 		assert.equal(Value.Check(properties.limit, value), false, `limit accepts ${value}`);
 	}
-	for (const value of [1, 30_000, 200_000]) {
+	for (const value of [1, 30_000]) {
 		assert.equal(Value.Check(properties.limit, value), true, `limit rejects ${value}`);
 	}
 });
@@ -100,13 +101,39 @@ test("get_search_content rejects unsafe fetched content ranges", async () => {
 
 	const tooLarge = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, limit: 30_001 });
 	assert.equal(tooLarge.details.error, "Invalid limit");
+	assert.match(tooLarge.content[0].text, /received 30001/);
 	assert.match(tooLarge.content[0].text, /limit must be an integer from 1 to 30000/);
 
 	const invalidOffset = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, offset: 1.5 });
 	assert.equal(invalidOffset.details.error, "Invalid offset");
+	assert.match(invalidOffset.content[0].text, /received 1\.5/);
+	assert.match(invalidOffset.content[0].text, /Use 0 or a larger integer/);
 
 	const outOfRange = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, offset: 99 });
 	assert.equal(outOfRange.details.error, "Offset out of range");
+	assert.match(outOfRange.content[0].text, /Received offset 99/);
+	assert.match(outOfRange.content[0].text, /valid range is 0-13/);
+
+	const incompatible = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, findText: "content", offset: 1 });
+	assert.equal(incompatible.details.error, "Incompatible find options");
+	assert.match(incompatible.content[0].text, /Received offset=1, limit=undefined/);
+
+	const missingFindText = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, findMode: "fuzzy" });
+	assert.equal(missingFindText.details.error, "findMode requires findText");
+	assert.match(missingFindText.content[0].text, /findMode "fuzzy" requires findText/);
+
+	const artifact = buildResearchArtifact({ query: "stored claim", results: [] });
+	artifact.id = "stored-research";
+	storeResearchArtifact(artifact);
+	const researchInvalidLimit = await tool.execute("call", { responseId: "stored-research", limit: 30_001 });
+	assert.equal(researchInvalidLimit.details.error, "Invalid limit");
+	assert.match(researchInvalidLimit.content[0].text, /received 30001/);
+	assert.match(researchInvalidLimit.content[0].text, /limit must be an integer from 1 to 30000/);
+
+	const researchOutOfRange = await tool.execute("call", { responseId: "stored-research", offset: 99_999 });
+	assert.equal(researchOutOfRange.details.error, "Offset out of range");
+	assert.match(researchOutOfRange.content[0].text, /responseId "stored-research"/);
+	assert.match(researchOutOfRange.content[0].text, /valid range is 0-/);
 });
 
 test("get_search_content returns small fetched content without continuation noise", async () => {

--- a/test/get-search-content.test.mjs
+++ b/test/get-search-content.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { Value } from "typebox/value";
 
 import initializeExtension from "../index.ts";
 import { clearResults, storeResult } from "../storage.ts";
@@ -31,6 +32,29 @@ function storeFetchedContent(content) {
 		}],
 	});
 }
+
+test("get_search_content schemas constrain numeric parameters", () => {
+	const properties = getContentTool().parameters.properties;
+
+	for (const name of ["queryIndex", "urlIndex", "offset"]) {
+		assert.equal(properties[name].type, "integer");
+		assert.equal(properties[name].minimum, 0);
+		assert.equal(properties[name].maximum, undefined);
+		for (const value of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			assert.equal(Value.Check(properties[name], value), false, `${name} accepts ${value}`);
+		}
+	}
+
+	assert.equal(properties.limit.type, "integer");
+	assert.equal(properties.limit.minimum, 1);
+	assert.equal(properties.limit.maximum, 200_000);
+	for (const value of [0, 1.5, 200_001, Number.NaN, Number.POSITIVE_INFINITY]) {
+		assert.equal(Value.Check(properties.limit, value), false, `limit accepts ${value}`);
+	}
+	for (const value of [1, 30_000, 200_000]) {
+		assert.equal(Value.Check(properties.limit, value), true, `limit rejects ${value}`);
+	}
+});
 
 test("get_search_content returns a bounded first slice for large fetched content", async () => {
 	const tool = getContentTool();

--- a/test/inline-content-config.test.mjs
+++ b/test/inline-content-config.test.mjs
@@ -31,6 +31,7 @@ async function runScenario(maxInlineContentChars) {
 			const tail = await contentTool.execute("call", { responseId: fetched.details.responseId, urlIndex: 0, offset: 40000, limit: 4 });
 			const rejected = await contentTool.execute("call", { responseId: fetched.details.responseId, urlIndex: 0, limit: ${maxInlineContentChars === undefined ? 30_001 : maxInlineContentChars + 1} });
 			console.log(JSON.stringify({
+				schemaMax: contentTool.parameters.properties.limit.maximum,
 				fetchTruncated: fetched.details.truncated,
 				fetchEndOffset: fetched.content.find(item => item.type === "text").text.indexOf("\\n\\n---"),
 				retrievedChars: retrieved.details.returnedChars,
@@ -49,6 +50,7 @@ async function runScenario(maxInlineContentChars) {
 test("inline content defaults to 30,000 characters", async () => {
 	const result = await runScenario();
 	assert.deepEqual(result, {
+		schemaMax: 30_000,
 		fetchTruncated: true,
 		fetchEndOffset: 30_000,
 		retrievedChars: 30_000,
@@ -61,6 +63,7 @@ test("inline content defaults to 30,000 characters", async () => {
 test("maxInlineContentChars applies to direct and stored content slices", async () => {
 	const result = await runScenario(40_000);
 	assert.deepEqual(result, {
+		schemaMax: 40_000,
 		fetchTruncated: true,
 		fetchEndOffset: 40_000,
 		retrievedChars: 40_000,

--- a/test/tool-registration-config.test.mjs
+++ b/test/tool-registration-config.test.mjs
@@ -4,6 +4,8 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
+import { Value } from "typebox/value";
+
 import initializeExtension from "../index.ts";
 
 const indexUrl = new URL("../index.ts", import.meta.url).href;
@@ -19,7 +21,7 @@ function runRegistration(config) {
 			const tools = [];
 			const commands = [];
 			initializeExtension({
-				registerTool(tool) { tools.push({ name: tool.name, description: tool.description, promptSnippet: tool.promptSnippet }); },
+				registerTool(tool) { tools.push({ name: tool.name, description: tool.description, promptSnippet: tool.promptSnippet, parameters: tool.parameters }); },
 				registerCommand(name) { commands.push(name); },
 				registerShortcut() {},
 				on() {},
@@ -54,6 +56,21 @@ function registrationError(config) {
 	assert.notEqual(child.status, 0, child.stdout);
 	return child.stderr;
 }
+
+test("search tools constrain numResults to integer values from 1 through 20", () => {
+	for (const name of ["web_search", "source_check"]) {
+		const schema = registeredTool({}, name).parameters.properties.numResults;
+		assert.equal(schema.type, "integer");
+		assert.equal(schema.minimum, 1);
+		assert.equal(schema.maximum, 20);
+		for (const value of [0, -1, 1.5, 21, Number.NaN, Number.POSITIVE_INFINITY]) {
+			assert.equal(Value.Check(schema, value), false, `${name} accepts ${value}`);
+		}
+		for (const value of [1, 5, 20]) {
+			assert.equal(Value.Check(schema, value), true, `${name} rejects ${value}`);
+		}
+	}
+});
 
 test("tool registration gates support legacy and per-tool config", () => {
 	assert.deepEqual(registeredToolNames({ webSearch: { enabled: false } }), ["fetch_content", "get_search_content"]);


### PR DESCRIPTION
Fixes #250

I ran into this while retrieving fetched page content.

This change:
- Adds schema bounds for numeric tool parameters.
- Improves get_search_content errors with received values, valid ranges, and retry guidance.
- Extends the existing focused tests without adding new test files.
