### PR TITLE
refactor: clarify local video info state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - Added Firecrawl as a `web_search` provider using the existing Firecrawl configuration. Thanks Andrés Sanabria (`@andy-spike`) for issue #246.
 - Added macOS Brave profile support for opt-in Gemini Web browser-cookie access. Thanks Rajyavardhan Singh (`@imrajyavardhan12`) for PR #248.
 
+### Changed
+- Made local-video detection use an explicit result state in extraction code.
+
 ### Fixed
 - Preserve summary draft completion routing through the model registry. Thanks `@limwa` for PR #249.
 - Constrain numeric tool parameters to supported integer ranges. Thanks `@jaudiger` for issue #250 and PR #251.

--- a/extract.ts
+++ b/extract.ts
@@ -313,11 +313,17 @@ async function extractLocalFrames(
 	return { frames, error: frames.length === 0 && firstError ? firstError.error : null };
 }
 
-function safeVideoInfo(url: string): { info: ReturnType<typeof isVideoFile>; error?: string } {
+type LocalVideoInfoResult =
+	| { status: "video"; info: NonNullable<ReturnType<typeof isVideoFile>> }
+	| { status: "not-video" }
+	| { status: "invalid"; error: string };
+
+function safeVideoInfo(url: string): LocalVideoInfoResult {
 	try {
-		return { info: isVideoFile(url) };
+		const info = isVideoFile(url);
+		return info ? { status: "video", info } : { status: "not-video" };
 	} catch (err) {
-		return { info: null, error: errorMessage(err) };
+		return { status: "invalid", error: errorMessage(err) };
 	}
 }
 
@@ -380,10 +386,10 @@ export async function extractContent(
 		}
 
 		const localVideo = safeVideoInfo(url);
-		if (localVideo.error) {
+		if (localVideo.status === "invalid") {
 			return { url, title: "", content: "", error: localVideo.error };
 		}
-		if (localVideo.info) {
+		if (localVideo.status === "video") {
 			const durationResult = await getLocalVideoDuration(localVideo.info.absolutePath);
 			if (typeof durationResult !== "number") {
 				return { url, title: "Frames", content: durationResult.error, error: durationResult.error };
@@ -463,10 +469,10 @@ export async function extractContent(
 		}
 
 		const localVideo = safeVideoInfo(url);
-		if (localVideo.error) {
+		if (localVideo.status === "invalid") {
 			return { url, title: "", content: "", error: localVideo.error };
 		}
-		if (localVideo.info) {
+		if (localVideo.status === "video") {
 			if (spec.type === "range") {
 				const timestamps = frameCount
 					? computeRangeTimestamps(spec.start, spec.end, frameCount)
@@ -495,10 +501,10 @@ export async function extractContent(
 	}
 
 	const localVideo = safeVideoInfo(url);
-	if (localVideo.error) {
+	if (localVideo.status === "invalid") {
 		return { url, title: "", content: "", error: localVideo.error };
 	}
-	if (localVideo.info) {
+	if (localVideo.status === "video") {
 		try {
 			const result = await extractVideo(localVideo.info, signal, options);
 			if (signal?.aborted) return abortedResult(url);


### PR DESCRIPTION
## Summary

This is a small TypeScript polish pass from the code quality review.

It changes local-video detection in `extract.ts` from an optional `error`/`info` result bag to an explicit discriminated result state. The extraction branches now narrow on `status`, so the invalid, non-video, and video states cannot overlap.

## Validation

- `node --test test/local-video-oversize.test.mjs`
- `npm test`
- `npm run typecheck`
- `git diff --check`
