### PR TITLE
fix: tolerate optional AnySearch content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Keep valid AnySearch results when the API omits or nulls result content. Thanks to [@mikhel01](https://github.com/mikhel01) for #258.
+
 ## [0.23.0] - 2026-08-15
 
 ### Added

--- a/anysearch.ts
+++ b/anysearch.ts
@@ -103,9 +103,11 @@ function parseResponse(value: unknown): AnySearchResponse {
 		if (typeof title !== "string") throw invalidResponse(`expected data.results[${index}].title string`);
 		if (typeof url !== "string") throw invalidResponse(`expected data.results[${index}].url string`);
 		if (typeof snippet !== "string") throw invalidResponse(`expected data.results[${index}].snippet string`);
-		if (typeof content !== "string") throw invalidResponse(`expected data.results[${index}].content string`);
+		if (content !== undefined && content !== null && typeof content !== "string") {
+			throw invalidResponse(`expected data.results[${index}].content string`);
+		}
 		if (!url) throw invalidResponse(`expected data.results[${index}].url to be non-empty`);
-		results.push({ title, url, snippet, content });
+		results.push({ title, url, snippet, content: typeof content === "string" ? content : "" });
 	}
 
 	return { code: 0, data: { results, metadata: data.metadata as Record<string, unknown> } };

--- a/test/anysearch-provider.test.mjs
+++ b/test/anysearch-provider.test.mjs
@@ -60,6 +60,33 @@ test("AnySearch supports anonymous success with a minimal request and gated cont
 	assert.deepEqual(output.withContent.inlineContent, [{ url: "https://example.com/result", title: "AnySearch result", content: "full page", error: null }]);
 });
 
+test("AnySearch accepts missing or null result content", async () => {
+	const home = await createHome({});
+	const child = runChild(`
+		globalThis.fetch = async () => new Response(JSON.stringify({ code: 0, data: { results: [
+			{ title: "Missing content", url: "https://example.com/missing", snippet: "missing" },
+			{ title: "Null content", url: "https://example.com/null", snippet: "null", content: null },
+			{ title: "Full content", url: "https://example.com/full", snippet: "full", content: "page body" },
+		], metadata: {} } }), { status: 200 });
+		const { searchWithAnySearch } = await import(${JSON.stringify(anysearchModuleUrl)});
+		console.log(JSON.stringify(await searchWithAnySearch("partial content", { includeContent: true })));
+	`, { PI_CODING_AGENT_DIR: home });
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.results.map(result => result.url), ["https://example.com/missing", "https://example.com/null", "https://example.com/full"]);
+	assert.deepEqual(output.inlineContent, [{ url: "https://example.com/full", title: "Full content", content: "page body", error: null }]);
+	const invalidChild = runChild(`
+		globalThis.fetch = async () => new Response(JSON.stringify({ code: 0, data: { results: [
+			{ title: "Invalid content", url: "https://example.com/invalid", snippet: "invalid", content: 123 },
+		], metadata: {} } }), { status: 200 });
+		const { searchWithAnySearch } = await import(${JSON.stringify(anysearchModuleUrl)});
+		try { await searchWithAnySearch("invalid content"); console.log(JSON.stringify({ ok: true })); }
+		catch (error) { console.log(JSON.stringify({ ok: false, error: String(error) })); }
+	`, { PI_CODING_AGENT_DIR: home });
+	assert.equal(invalidChild.status, 0, invalidChild.stderr);
+	assert.match(JSON.parse(invalidChild.stdout.trim()).error, /expected data\.results\[0\]\.content string/);
+});
+
 test("AnySearch sends keyed auth and resolves command credentials lazily", async () => {
 	const marker = join(await mkdtemp(join(tmpdir(), "pi-web-access-anysearch-marker-")), "ran");
 	const home = await createHome({ anysearchApiKey: `!touch ${marker} && printf anysearch-command-key` });


### PR DESCRIPTION
## Summary

Fixes #258 by treating missing or `null` AnySearch result `content` as empty text, while preserving strict validation for other malformed content values.

The focused test covers missing content, `null` content, non-empty inline content, and numeric content rejection.

Thanks to [@mikhel01](https://github.com/mikhel01) for #258.

## Validation

- `npm test -- test/anysearch-provider.test.mjs`
- `npm run typecheck`
- `git diff --check`
