### PR TITLE
feat: support summary model thinking suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added `summaryModel` thinking-level suffix support. Thanks to [@pkos98](https://github.com/pkos98) for issue #264.
 - Route nested model calls through Pi's model registry. Thanks to [@rany2](https://github.com/rany2) for #263.
 - Added explicit-only Parallel Search MCP support for keyless search and opt-in hosted fetch. Thanks to [@happytomatoe](https://github.com/happytomatoe) for #257.
 - Added explicit-only Valyu and Serper search providers. Thanks to [@mikhel01](https://github.com/mikhel01) for issues #259 and #260.

--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
 }
 ```
 
+`summaryModel` accepts an optional thinking-level suffix, such as `anthropic/claude-haiku-4-5:low`. Supported suffixes are `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
+
 All provider API-key fields (`openaiApiKey`, `braveApiKey`, `parallelApiKey`, `tinyfishApiKey`, `search1apiApiKey`, `searchinfinityApiKey`, `queritApiKey`, `tavilyApiKey`, `jinaApiKey`, `serpdiveApiKey`, `kagiApiKey`, `bochaApiKey`, `ollamaApiKey`, `serpbaseApiKey`, `anysearchApiKey`, `xaiApiKey`, `brightdataApiKey`, `firecrawlApiKey`, `exaApiKey`, `perplexityApiKey`, `geminiApiKey`, `datalabApiKey`, and `cloudflareApiKey`) accept explicit credential sources. Use `$NAME` or `${NAME}` to read one named environment variable, or prefix a trusted local shell command with `!` to resolve one value at provider request time. Escape `$$` as a literal leading `$` and `$!` as a literal leading `!`:
 
 ```json

--- a/index.ts
+++ b/index.ts
@@ -68,7 +68,7 @@ import { isSerpBaseAvailable } from "./serpbase.ts";
 import { isSerperAvailable } from "./serper.ts";
 import { isValyuAvailable } from "./valyu.ts";
 import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
-import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
+import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns, splitThinkingSuffix } from "./summary-model-scope.ts";
 import {
 	buildResearchArtifact,
 	withClaimAssessment,
@@ -1184,16 +1184,22 @@ export default function (pi: ExtensionAPI) {
 		];
 
 		const resolveAvailableModelValue = (selector: string): string | null => {
-			const slashIndex = selector.indexOf("/");
-			if (slashIndex <= 0 || slashIndex >= selector.length - 1) return null;
+			const parsed = splitThinkingSuffix(selector);
+			const slashIndex = parsed.value.indexOf("/");
+			if (slashIndex <= 0 || slashIndex >= parsed.value.length - 1) return null;
 			const model = findModelWithProviderRouting(
 				summaryContext.modelRegistry,
-				selector.slice(0, slashIndex),
-				selector.slice(slashIndex + 1),
+				parsed.value.slice(0, slashIndex),
+				parsed.value.slice(slashIndex + 1),
 			);
 			if (!model) return null;
 			const value = `${model.provider}/${model.id}`;
-			return availableValues.has(value) ? value : null;
+			if (!availableValues.has(value)) return null;
+			if (selector !== value && !seen.has(selector)) {
+				seen.add(selector);
+				summaryModels.push({ value: selector, label: selector });
+			}
+			return selector;
 		};
 
 		let defaultSummaryModel: string | null = null;

--- a/summary-model-scope.ts
+++ b/summary-model-scope.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 
 const THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
 
+export type SummaryThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+
 interface SummaryModelScopeContext {
 	cwd: string;
 	isProjectTrusted(): boolean;
@@ -78,11 +80,17 @@ export function summaryModelValue(model: ModelLike): string {
 	return `${model.provider}/${model.id}`;
 }
 
+export function splitThinkingSuffix(value: string): { value: string; thinkingLevel?: SummaryThinkingLevel } {
+	const index = value.lastIndexOf(":");
+	if (index < 0) return { value };
+	const suffix = value.slice(index + 1);
+	return THINKING_LEVELS.has(suffix)
+		? { value: value.slice(0, index), thinkingLevel: suffix as SummaryThinkingLevel }
+		: { value };
+}
+
 function stripThinkingSuffix(pattern: string): string {
-	const index = pattern.lastIndexOf(":");
-	if (index < 0) return pattern;
-	const suffix = pattern.slice(index + 1);
-	return THINKING_LEVELS.has(suffix) ? pattern.slice(0, index) : pattern;
+ return splitThinkingSuffix(pattern).value;
 }
 
 function globToRegExp(pattern: string): RegExp {

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -1,6 +1,7 @@
-import { complete, type Api, type Message, type Model } from "@earendil-works/pi-ai/compat";
+import { clampThinkingLevel, type ModelThinkingLevel, type ThinkingLevel } from "@earendil-works/pi-ai";
+import { complete, completeSimple, type Api, type Message, type Model } from "@earendil-works/pi-ai/compat";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
+import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns, splitThinkingSuffix, type SummaryThinkingLevel } from "./summary-model-scope.ts";
 import type { QueryResultData } from "./storage.ts";
 
 type ProviderHeaders = Record<string, string | null>;
@@ -186,28 +187,35 @@ export function buildDeterministicSummary(results: QueryResultData[]): { summary
 	};
 }
 
-function parseModelSelector(value: string): { provider: string; id: string } {
-	const slashIndex = value.indexOf("/");
-	if (slashIndex <= 0 || slashIndex >= value.length - 1) {
+function parseModelSelector(value: string): { provider: string; id: string; thinkingLevel?: SummaryThinkingLevel } {
+	const selector = splitThinkingSuffix(value);
+	const slashIndex = selector.value.indexOf("/");
+	if (slashIndex <= 0 || slashIndex >= selector.value.length - 1) {
 		throw new Error(`Invalid summary model: ${value}. Use provider/model-id.`);
 	}
 	return {
-		provider: value.slice(0, slashIndex),
-		id: value.slice(slashIndex + 1),
+		provider: selector.value.slice(0, slashIndex),
+		id: selector.value.slice(slashIndex + 1),
+		thinkingLevel: selector.thinkingLevel,
 	};
+}
+
+function resolveThinkingLevel(model: Model<Api>, requested?: SummaryThinkingLevel): ModelThinkingLevel | undefined {
+	if (!requested) return undefined;
+	return clampThinkingLevel(model, requested as ModelThinkingLevel);
 }
 
 async function resolveSummaryModelCandidates(
 	ctx: SummaryGenerationContext,
 	modelOverride?: string,
-): Promise<{ candidates: Array<{ model: Model<Api>; apiKey?: string; headers?: ProviderHeaders }>; errors: string[] }> {
+): Promise<{ candidates: Array<{ model: Model<Api>; apiKey?: string; headers?: ProviderHeaders; thinkingLevel?: SummaryThinkingLevel }>; errors: string[] }> {
 	const enabledModelPatterns = loadEnabledModelPatterns(ctx);
-	const specs: Array<{ provider: string; id: string }> = [];
+	const specs: Array<{ provider: string; id: string; thinkingLevel?: SummaryThinkingLevel }> = [];
 	const normalizedOverride = typeof modelOverride === "string" ? modelOverride.trim() : "";
 	if (normalizedOverride.length > 0) specs.push(parseModelSelector(normalizedOverride));
 	specs.push(...PREFERRED_SUMMARY_MODELS);
 
-	const candidates: Array<{ model: Model<Api>; apiKey?: string; headers?: ProviderHeaders }> = [];
+	const candidates: Array<{ model: Model<Api>; apiKey?: string; headers?: ProviderHeaders; thinkingLevel?: SummaryThinkingLevel }> = [];
 	const errors: string[] = [];
 	const seen = new Set<string>();
 	for (const spec of specs) {
@@ -229,7 +237,7 @@ async function resolveSummaryModelCandidates(
 			errors.push(`No API key available for summary model ${value}`);
 			continue;
 		}
-		candidates.push({ model, apiKey: auth.apiKey, headers: auth.headers });
+		candidates.push({ model, apiKey: auth.apiKey, headers: auth.headers, thinkingLevel: spec.thinkingLevel });
 	}
 	return { candidates, errors };
 }
@@ -285,7 +293,8 @@ export async function generateSummaryDraft(
 	}
 
 	const registry = ctx.modelRegistry as SummaryModelRegistry;
-	const usesRegistryComplete = !completeFn && typeof registry.complete === "function";
+	const customCompleteFn = completeFn !== undefined;
+	const usesRegistryComplete = !customCompleteFn && typeof registry.complete === "function";
 	completeFn ??= usesRegistryComplete ? registry.complete!.bind(registry) as CompleteFunction : complete;
 
 	const generationStartedAt = Date.now();
@@ -343,7 +352,7 @@ export async function generateSummaryDraft(
 		}
 
 		let lastError = resolved.errors.at(-1);
-		for (const { model, apiKey, headers } of resolved.candidates) {
+		for (const { model, apiKey, headers, thinkingLevel } of resolved.candidates) {
 			const startedAt = Date.now();
 			try {
 				const userMessage: Message = {
@@ -351,12 +360,21 @@ export async function generateSummaryDraft(
 					content: [{ type: "text", text: prompt }],
 					timestamp: Date.now(),
 				};
+				const requestedThinkingLevel = resolveThinkingLevel(model, thinkingLevel);
+				const enabledThinkingLevel = requestedThinkingLevel && requestedThinkingLevel !== "off"
+					? requestedThinkingLevel as ThinkingLevel
+					: undefined;
+				const completionOptions = {
+					...(usesRegistryComplete ? {} : { apiKey, headers }),
+					signal: completionSignal,
+					...(requestedThinkingLevel ? { reasoning: requestedThinkingLevel } : {}),
+					...(enabledThinkingLevel ? { reasoningEffort: enabledThinkingLevel } : {}),
+				};
+				const completion = thinkingLevel !== undefined && !customCompleteFn && !usesRegistryComplete
+					? completeSimple(model, { messages: [userMessage] }, { apiKey, headers, signal: completionSignal, ...(enabledThinkingLevel ? { reasoning: enabledThinkingLevel } : {}) })
+					: completeFn(model, { messages: [userMessage] }, completionOptions);
 
-				const response = await raceSummaryOperation(Promise.resolve(completeFn(
-					model,
-					{ messages: [userMessage] },
-					usesRegistryComplete ? { signal: completionSignal } : { apiKey, headers, signal: completionSignal },
-				)));
+				const response = await raceSummaryOperation(Promise.resolve(completion));
 				if (response.stopReason === "aborted") {
 					throw new Error("Aborted");
 				}

--- a/test/auto-summary-source.test.mjs
+++ b/test/auto-summary-source.test.mjs
@@ -16,6 +16,9 @@ test("auto-summary skips curator and reuses summary model fallback plumbing", ()
 	assert.match(indexSrc, /const shouldCurate = workflow === "summary-review"/);
 	assert.match(indexSrc, /if \(workflow === "auto-summary"\)/);
 	assert.match(indexSrc, /await loadSummaryModelChoices\(summaryContext\)/);
+	assert.match(indexSrc, /const parsed = splitThinkingSuffix\(selector\)/);
+	assert.match(indexSrc, /summaryModels\.push\(\{ value: selector, label: selector \}\)/);
+	assert.match(indexSrc, /return selector/);
 	assert.match(indexSrc, /await generateSummaryDraft\(\s*searchResults,\s*summaryContext,\s*signal,\s*summaryModelChoices\.defaultSummaryModel \?\? undefined,\s*undefined,\s*undefined,\s*getSummaryGenerationDeadlineMs\(\),\s*\)/);
 	assert.match(indexSrc, /workflow: workflow === "auto-summary" \? "auto-summary" : undefined/);
 });

--- a/test/summary-model-scope.test.mjs
+++ b/test/summary-model-scope.test.mjs
@@ -38,7 +38,7 @@ const summaryResults = [{
 
 const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 const testAgentDir = await mkdtemp(join(tmpdir(), "pi-web-access-summary-deadline-"));
-await writeFile(join(testAgentDir, "settings.json"), JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }));
+await writeFile(join(testAgentDir, "settings.json"), JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5", "openrouter/nvidia/nemotron-3-super-120b-a12b:free"] }));
 process.env.PI_CODING_AGENT_DIR = testAgentDir;
 after(() => {
 	if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
@@ -161,6 +161,102 @@ test("summary generation resolves preferred models through routed providers", as
 	assert.equal(completeCalled, true);
 	assert.equal(result.meta.fallbackUsed, false);
 	assert.equal(result.meta.model, "openrouter/anthropic/claude-haiku-4-5");
+});
+
+test("summaryModel thinking suffix strips before lookup and reaches completion options", async () => {
+	const model = { provider: "anthropic", id: "claude-haiku-4-5", reasoning: true };
+	const lookups = [];
+	let options;
+	const result = await generateSummaryDraft(
+		summaryResults,
+		{
+			modelRegistry: {
+				find: (provider, id) => {
+					lookups.push({ provider, id });
+					return model;
+				},
+				getAvailable: () => [],
+				getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-key" }),
+			},
+			cwd: process.cwd(),
+			isProjectTrusted: () => false,
+		},
+		undefined,
+		"anthropic/claude-haiku-4-5:low",
+		undefined,
+		(_model, _request, requestOptions) => {
+			options = requestOptions;
+			return Promise.resolve({ stopReason: "stop", content: [{ type: "text", text: "Low-thinking summary" }] });
+		},
+		1000,
+	);
+
+	assert.ok(lookups.some(lookup => lookup.provider === "anthropic" && lookup.id === "claude-haiku-4-5"));
+	assert.equal(options.reasoning, "low");
+	assert.equal(options.reasoningEffort, "low");
+	assert.equal(result.meta.model, "anthropic/claude-haiku-4-5");
+});
+
+test("summaryModel keeps non-thinking colons in model ids", async () => {
+	const model = { provider: "openrouter", id: "nvidia/nemotron-3-super-120b-a12b:free", reasoning: true };
+	const lookups = [];
+	let options;
+	const result = await generateSummaryDraft(
+		summaryResults,
+		{
+			modelRegistry: {
+				find: (provider, id) => {
+					lookups.push({ provider, id });
+					return model;
+				},
+				getAvailable: () => [],
+				getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-key" }),
+			},
+			cwd: process.cwd(),
+			isProjectTrusted: () => false,
+		},
+		undefined,
+		"openrouter/nvidia/nemotron-3-super-120b-a12b:free",
+		undefined,
+		(_model, _request, requestOptions) => {
+			options = requestOptions;
+			return Promise.resolve({ stopReason: "stop", content: [{ type: "text", text: "Free model summary" }] });
+		},
+		1000,
+	);
+
+	assert.ok(lookups.some(lookup => lookup.provider === "openrouter" && lookup.id === "nvidia/nemotron-3-super-120b-a12b:free"));
+	assert.equal(options.reasoning, undefined);
+	assert.equal(options.reasoningEffort, undefined);
+	assert.equal(result.meta.model, "openrouter/nvidia/nemotron-3-super-120b-a12b:free");
+});
+
+test("summaryModel thinking suffix omits effort for non-reasoning models", async () => {
+	const model = { provider: "anthropic", id: "claude-haiku-4-5", reasoning: false };
+	let options;
+	await generateSummaryDraft(
+		summaryResults,
+		{
+			modelRegistry: {
+				find: () => model,
+				getAvailable: () => [model],
+				getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-key" }),
+			},
+			cwd: process.cwd(),
+			isProjectTrusted: () => false,
+		},
+		undefined,
+		"anthropic/claude-haiku-4-5:low",
+		undefined,
+		(_model, _request, requestOptions) => {
+			options = requestOptions;
+			return Promise.resolve({ stopReason: "stop", content: [{ type: "text", text: "No-thinking summary" }] });
+		},
+		1000,
+	);
+
+	assert.equal(options.reasoning, "off");
+	assert.equal(options.reasoningEffort, undefined);
 });
 
 test("preferred models resolve through routed providers", () => {


### PR DESCRIPTION
Closes #264.

This adds an optional thinking-level suffix to `summaryModel`, such as `anthropic/claude-haiku-4-5:low`. The suffix is stripped before model lookup and enabled-model matching, then passed to summary completion when supported. No-suffix behavior and deterministic fallback behavior stay unchanged.

Validation:
- `npm test -- test/summary-model-scope.test.mjs test/summary-provider-routing.test.mjs`
- `npm run typecheck`
- `git diff --check`
- Fresh-context review: No issues found

Credit is in `CHANGELOG.md`: Thanks to [@pkos98](https://github.com/pkos98) for issue #264.
