### PR TITLE
feat: refresh default summary models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Refreshed default summary and query rewrite model preferences. Thanks to [@hyein-cbio](https://github.com/hyein-cbio) for #266.
 - Added `summaryModel` thinking-level suffix support. Thanks to [@pkos98](https://github.com/pkos98) for issue #264.
 - Route nested model calls through Pi's model registry. Thanks to [@rany2](https://github.com/rany2) for #263.
 - Added explicit-only Parallel Search MCP support for keyless search and opt-in hosted fetch. Thanks to [@happytomatoe](https://github.com/happytomatoe) for #257.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
 }
 ```
 
-In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first for local/private search, then OpenAI when suitable and available, Exa (direct API if keyed, MCP if not), Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Perplexity, Gemini API, and Gemini Web when browser-cookie access is enabled. With no SearXNG configured, the existing zero-config order is unchanged. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
+In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first for local/private search, then OpenAI when suitable and available, Exa (direct API if keyed, MCP if not), Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Perplexity, Gemini API, and Gemini Web when browser-cookie access is enabled. With no SearXNG configured, the existing zero-config order is unchanged. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model, defaulting to Claude Haiku, Codex Luna, Codex Terra, Gemini 3.6 Flash, GPT-5 mini, then DeepSeek V4 Flash when available. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
 
 If your OpenAI key belongs to a third-party Responses-compatible gateway, set `openaiResponsesUrl` to that gateway's full Responses endpoint. The default remains `https://api.openai.com/v1/responses`.
 

--- a/index.ts
+++ b/index.ts
@@ -1180,7 +1180,11 @@ export default function (pi: ExtensionAPI) {
 		const configuredSummaryModel = typeof config.summaryModel === "string" ? config.summaryModel.trim() : "";
 		const preferredDefaults = [
 			{ provider: "anthropic", id: "claude-haiku-4-5" },
-			{ provider: "openai-codex", id: "gpt-5.3-codex-spark" },
+			{ provider: "openai-codex", id: "gpt-5.6-luna" },
+			{ provider: "openai-codex", id: "gpt-5.6-terra" },
+			{ provider: "google", id: "gemini-3.6-flash" },
+			{ provider: "openai", id: "gpt-5-mini" },
+			{ provider: "deepseek", id: "deepseek-v4-flash" },
 		];
 
 		const resolveAvailableModelValue = (selector: string): string | null => {

--- a/query-rewrite.ts
+++ b/query-rewrite.ts
@@ -24,7 +24,7 @@ export async function rewriteSearchQuery(
 	const { model, apiKey, headers } = await resolveFirstAvailableModel(ctx, [
 		{ provider: "anthropic", id: "claude-haiku-4-5" },
 		{ provider: "google", id: "gemini-3.6-flash" },
-		{ provider: "openai", id: "gpt-4.1-mini" },
+		{ provider: "openai", id: "gpt-5-mini" },
 	]);
 	const registry = ctx.modelRegistry as typeof ctx.modelRegistry & { complete?: typeof complete };
 	const usesRegistryComplete = typeof registry.complete === "function";

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -10,7 +10,11 @@ type SummaryModelRegistry = SummaryGenerationContext["modelRegistry"] & { comple
 
 const PREFERRED_SUMMARY_MODELS = [
 	{ provider: "anthropic", id: "claude-haiku-4-5" },
-	{ provider: "openai-codex", id: "gpt-5.3-codex-spark" },
+	{ provider: "openai-codex", id: "gpt-5.6-luna" },
+	{ provider: "openai-codex", id: "gpt-5.6-terra" },
+	{ provider: "google", id: "gemini-3.6-flash" },
+	{ provider: "openai", id: "gpt-5-mini" },
+	{ provider: "deepseek", id: "deepseek-v4-flash" },
 ] as const;
 
 export const SUMMARY_GENERATION_DEADLINE_MS = 30_000;

--- a/test/summary-model-scope.test.mjs
+++ b/test/summary-model-scope.test.mjs
@@ -376,3 +376,16 @@ test("summary generation no longer uses catalog fallback or first available mode
 	assert.doesNotMatch(indexSrc, /defaultSummaryModel = summaryModels\[0\]\.value/);
 	assert.match(indexSrc, /modelMatchesEnabledPatterns\(model, enabledModelPatterns\)/);
 });
+
+test("summary and query rewrite defaults use the refreshed model order", () => {
+	for (const src of [summarySrc, indexSrc]) {
+		assert(src.indexOf('id: "claude-haiku-4-5"') < src.indexOf('id: "gpt-5.6-luna"'));
+		assert(src.indexOf('id: "gpt-5.6-luna"') < src.indexOf('id: "gpt-5.6-terra"'));
+		assert(src.indexOf('id: "gpt-5.6-terra"') < src.indexOf('id: "gemini-3.6-flash"'));
+		assert(src.indexOf('id: "gemini-3.6-flash"') < src.indexOf('id: "gpt-5-mini"'));
+		assert(src.indexOf('id: "gpt-5-mini"') < src.indexOf('id: "deepseek-v4-flash"'));
+		assert.doesNotMatch(src, /gpt-5\.3-codex-spark/);
+	}
+	assert.match(queryRewriteSrc, /id: "gpt-5-mini"/);
+	assert.doesNotMatch(queryRewriteSrc, /gpt-4\.1-mini/);
+});


### PR DESCRIPTION
Replaces #266 with a clean maintainer branch based on current main.\n\nThis refreshes the default curator summary model order, updates the query rewrite OpenAI fallback to GPT-5 mini, and preserves credit for @hyein-cbio in the changelog.\n\nValidation:\n- npm test -- test/summary-model-scope.test.mjs test/query-rewrite.test.mjs test/auto-summary-source.test.mjs\n- npm run typecheck\n- git diff --check