### PR TITLE
fix: recover weak RSC page extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Added configurable API base URLs for Brave, keyed Exa, and Tavily requests, with credential stripping across redirect origins. Thanks to [@XWIlluDelu](https://github.com/XWIlluDelu) for #265.
 
 ### Fixed
+- Recover useful Next.js RSC content when Readability only extracts a loading shell, and report full, partial, or failed background content fetches accurately (#272, #273).
 - Keep valid AnySearch results when the API omits or nulls result content. Thanks to [@mikhel01](https://github.com/mikhel01) for #258.
 
 ## [0.23.0] - 2026-08-15

--- a/extract.ts
+++ b/extract.ts
@@ -1159,7 +1159,7 @@ async function extractViaHttp(
 
 		if (!article) {
 			const rscResult = extractRSCContent(text);
-			if (rscResult) {
+			if (rscResult && rscResult.content.length >= MIN_USEFUL_CONTENT) {
 				activityMonitor.logComplete(activityId, response.status);
 				return {
 					url,
@@ -1192,6 +1192,16 @@ async function extractViaHttp(
 		activityMonitor.logComplete(activityId, response.status);
 
 		if (markdown.length < MIN_USEFUL_CONTENT) {
+			const rscResult = extractRSCContent(text);
+			if (rscResult && rscResult.content.length >= MIN_USEFUL_CONTENT) {
+				return {
+					url,
+					title: rscResult.title,
+					content: appendDeclaredWebLinks(rscResult.content, declaredLinks),
+					error: null,
+					declaredLinks,
+				};
+			}
 			return {
 				url,
 				title: article.title || documentTitle,

--- a/index.ts
+++ b/index.ts
@@ -984,10 +984,15 @@ export default function (pi: ExtensionAPI) {
 				} satisfies StoredSearchData & { type: "fetch"; urls: ExtractedContent[] };
 				pi.appendEntry("web-search-results", storeFetchedContentResult(fetchId, data));
 				const ok = fetched.filter(f => !f.error).length;
+				const availability = ok === fetched.length
+					? "Full page content now available."
+					: ok > 0
+						? "Partial page content now available."
+						: "No page content was fetched. Stored fetch diagnostics are available.";
 				pi.sendMessage(
 					{
 						customType: "web-search-content-ready",
-						content: `Content fetched for ${ok}/${fetched.length} URLs [${fetchId}]. Full page content now available.`,
+						content: `Content fetched for ${ok}/${fetched.length} URLs [${fetchId}]. ${availability}`,
 						display: true,
 					},
 					{ triggerTurn: true },

--- a/test/rsc-fallback.test.mjs
+++ b/test/rsc-fallback.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import { extractContent } from "../extract.ts";
+
+const indexSrc = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
+const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
+const originalFetch = globalThis.fetch;
+
+test("weak Readability output falls back to useful RSC content", async (t) => {
+	t.after(() => { globalThis.fetch = originalFetch; });
+	const article = "RSC article content survives the loading shell. ".repeat(20);
+	const payload = `23:${JSON.stringify(["$", "article", null, { children: ["$", "p", null, { children: article }] }])}\n`;
+	globalThis.fetch = async () => new Response(
+		`<!doctype html><html><head><title>RSC article</title></head><body><article>Loading...</article><script>self.__next_f.push([1,${JSON.stringify(payload)}])</script></body></html>`,
+		{
+			status: 200,
+			headers: {
+				"content-type": "text/html",
+				link: '</openapi.json>; rel="service-desc"',
+			},
+		},
+	);
+
+	const result = await extractContent("https://example.com/rsc", undefined, { lookup });
+	assert.equal(result.error, null);
+	assert.equal(result.title, "RSC article");
+	assert.match(result.content, /RSC article content survives the loading shell/);
+	assert.match(result.content, /https:\/\/example\.com\/openapi\.json/);
+});
+
+test("short non-RSC pages remain incomplete", async (t) => {
+	t.after(() => { globalThis.fetch = originalFetch; });
+	globalThis.fetch = async () => new Response(
+		"<!doctype html><html><head><title>Short</title></head><body><article>Loading...</article></body></html>",
+		{ status: 200, headers: { "content-type": "text/html" } },
+	);
+
+	const result = await extractContent("https://example.com/short", undefined, { lookup });
+	assert.notEqual(result.error, null);
+});
+
+test("short RSC payloads remain incomplete", async (t) => {
+	t.after(() => { globalThis.fetch = originalFetch; });
+	const payload = `23:${JSON.stringify(["$", "article", null, { children: "Short RSC content" }])}\n`;
+	globalThis.fetch = async () => new Response(
+		`<!doctype html><html><head><title>Short RSC</title></head><body><script>self.__next_f.push([1,${JSON.stringify(payload)}])</script></body></html>`,
+		{ status: 200, headers: { "content-type": "text/html" } },
+	);
+
+	const result = await extractContent("https://example.com/short-rsc", undefined, { lookup });
+	assert.notEqual(result.error, null);
+});
+
+test("background fetch notification distinguishes full, partial, and failed content", () => {
+	assert.match(indexSrc, /ok === fetched\.length\n\s*\? "Full page content now available\."/);
+	assert.match(indexSrc, /ok > 0\n\s*\? "Partial page content now available\."/);
+	assert.match(indexSrc, /"No page content was fetched\. Stored fetch diagnostics are available\."/);
+	assert.match(indexSrc, /Content fetched for \$\{ok\}\/\$\{fetched\.length\} URLs \[\$\{fetchId\}\]\. \$\{availability\}/);
+});


### PR DESCRIPTION
Fixes #272.\nFixes #273.\n\nThis recovers useful Next.js RSC content when Readability only extracts a loading shell, and makes background includeContent notifications distinguish full, partial, and failed content fetches.\n\nValidation:\n- npm test -- test/rsc-fallback.test.mjs test/declared-web-links.test.mjs test/curator-fallback.test.mjs\n- npm run typecheck\n- git diff --check HEAD~1..HEAD\n- live smoke: fetch_content extraction for https://modem.dev/blog/how-coding-agents-read-your-code returned the article with error null