### PR TITLE
fix: replace inline data URIs in extracted content with bounded omission markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Added optional `openaiSearchProviders` config to choose which Pi model providers fund OpenAI `web_search`, in priority order. Thanks to [@hank-warren](https://github.com/hank-warren) for PR #276.
 
 ### Fixed
-- Replaced inline RFC 2397 `data:` URIs in extracted page content with explicit bounded omission markers (MIME type, encoding, encoded/decoded byte counts, SHA-256 digest, `retrieval=not-retained`) before content reaches tool results, the fetch cache, or session persistence. Readable prose and Markdown image alt text are preserved; typed thumbnail/frame image blocks are unaffected.
+- Replaced inline RFC 2397 `data:` URIs in extracted page content with explicit bounded omission markers (MIME type, encoding, encoded/decoded byte counts, SHA-256 digest, `retrieval=not-retained`) before content reaches tool results, the fetch cache, or session persistence. Readable prose and Markdown image alt text are preserved; typed thumbnail/frame image blocks are unaffected. Thanks to [@bbbRye007](https://github.com/bbbRye007) for #281 and #282.
 
 ## [0.24.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - Added `pdf.maxPages` to limit Datalab, Gemini, and local PDF extraction to the first N pages. Thanks to [@jaudiger](https://github.com/jaudiger) for issue #277.
 - Added optional `openaiSearchProviders` config to choose which Pi model providers fund OpenAI `web_search`, in priority order. Thanks to [@hank-warren](https://github.com/hank-warren) for PR #276.
 
+### Fixed
+- Replaced inline RFC 2397 `data:` URIs in extracted page content with explicit bounded omission markers (MIME type, encoding, encoded/decoded byte counts, SHA-256 digest, `retrieval=not-retained`) before content reaches tool results, the fetch cache, or session persistence. Readable prose and Markdown image alt text are preserved; typed thumbnail/frame image blocks are unaffected.
+
 ## [0.24.0] - 2026-08-18
 
 ### Highlights

--- a/data-uri-sanitize.ts
+++ b/data-uri-sanitize.ts
@@ -1,0 +1,406 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+
+// Replaces inline RFC 2397 data: URIs in extracted text with explicit bounded
+// omission markers so base64 payloads never reach model-visible tool results,
+// the fetch cache, or session persistence. Carved out of the original
+// persistence-safety layer; only the text-sanitization path is retained.
+
+const MAX_DATA_URI_HEADER_CHARS = 1024;
+const MAX_MIME_CHARS = 127;
+const MAX_MARKER_SOURCE_CHARS = 180;
+
+export type DataUriEncoding = "base64" | "percent-encoded";
+export type DigestBasis = "decoded" | "encoded";
+
+export interface DataUriOmission {
+	ordinal: number;
+	sourcePath: string;
+	mimeType: string;
+	encoding: DataUriEncoding;
+	encodedBytes: number;
+	decodedBytes: number | null;
+	decodeError?: string;
+	sha256: string;
+	digestBasis: DigestBasis;
+	retrieval: "not-retained";
+}
+
+
+interface InternalDataUriOmission extends DataUriOmission {
+	markerStart: number;
+	markerEnd: number;
+}
+
+interface SanitizationState {
+	nextOrdinal: number;
+	omissions: InternalDataUriOmission[];
+}
+
+
+function sha256Bytes(value: string | Uint8Array): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+
+function asciiLowerCode(code: number): number {
+	return code >= 65 && code <= 90 ? code + 32 : code;
+}
+
+function matchesDataScheme(text: string, index: number): boolean {
+	return index + 5 <= text.length
+		&& asciiLowerCode(text.charCodeAt(index)) === 100
+		&& asciiLowerCode(text.charCodeAt(index + 1)) === 97
+		&& asciiLowerCode(text.charCodeAt(index + 2)) === 116
+		&& asciiLowerCode(text.charCodeAt(index + 3)) === 97
+		&& text.charCodeAt(index + 4) === 58;
+}
+
+function isSchemeBoundary(text: string, index: number): boolean {
+	if (index === 0) return true;
+	const code = text.charCodeAt(index - 1);
+	const alphaNumeric = (code >= 48 && code <= 57)
+		|| (code >= 65 && code <= 90)
+		|| (code >= 97 && code <= 122);
+	return !alphaNumeric && code !== 43 && code !== 45 && code !== 46;
+}
+
+function findNextDataScheme(text: string, from: number): number {
+	for (let i = from; i + 5 <= text.length; i++) {
+		if (matchesDataScheme(text, i) && isSchemeBoundary(text, i)) return i;
+	}
+	return -1;
+}
+
+type DataUriEnclosure =
+	| { kind: "quote"; close: "\"" | "'" | "`" }
+	| { kind: "parentheses" }
+	| { kind: "angle" }
+	| null;
+
+interface ScannedDataUriCandidate {
+	end: number;
+	comma: number;
+	enclosure: DataUriEnclosure;
+}
+
+function dataUriEnclosure(text: string, start: number): DataUriEnclosure {
+	if (start === 0) return null;
+	const immediateIndex = start - 1;
+	const immediate = text[immediateIndex];
+	if (immediate === "\"" || immediate === "'" || immediate === "`") {
+		const beforeQuote = immediateIndex > 0 ? text[immediateIndex - 1] : "";
+		const likelyOpeningQuote = immediateIndex === 0
+			|| beforeQuote === "="
+			|| beforeQuote === "("
+			|| beforeQuote === "["
+			|| beforeQuote === "{"
+			|| beforeQuote === ":"
+			|| beforeQuote === ","
+			|| /\s/.test(beforeQuote);
+		if (likelyOpeningQuote) return { kind: "quote", close: immediate };
+	}
+
+	let openerIndex = immediateIndex;
+	while (openerIndex >= 0 && (text[openerIndex] === " " || text[openerIndex] === "\t")) openerIndex--;
+	const opener = text[openerIndex];
+	if (opener === "(") return { kind: "parentheses" };
+	if (opener === "<") return { kind: "angle" };
+	return null;
+}
+
+function isBareDataUriTerminator(ch: string): boolean {
+	const code = ch.charCodeAt(0);
+	return code <= 32
+		|| code === 127
+		|| ch === "\""
+		|| ch === "`"
+		|| ch === "<"
+		|| ch === ">";
+}
+
+/** Scan one candidate exactly once. Enclosures consume malformed whitespace and
+ * balanced inner parentheses so invalid payload suffixes cannot escape. */
+function scanDataUriCandidate(text: string, start: number): ScannedDataUriCandidate {
+	const enclosure = dataUriEnclosure(text, start);
+	let comma = -1;
+	let depth = enclosure?.kind === "parentheses" ? 1 : 0;
+	let index = start + 5;
+
+	for (; index < text.length; index++) {
+		const ch = text[index];
+		if (enclosure?.kind === "quote") {
+			if (ch === enclosure.close) break;
+		} else if (enclosure?.kind === "parentheses") {
+			if (ch === "(") {
+				depth++;
+			} else if (ch === ")") {
+				depth--;
+				if (depth === 0) break;
+			}
+		} else if (enclosure?.kind === "angle") {
+			if (ch === ">") break;
+		} else if (isBareDataUriTerminator(ch)) {
+			break;
+		}
+		if (comma < 0 && ch === ",") comma = index;
+	}
+
+	return { end: index, comma, enclosure };
+}
+
+function headerEndsWithBase64(text: string, headerStart: number, comma: number): boolean {
+	let end = comma;
+	while (end > headerStart && (text[end - 1] === " " || text[end - 1] === "\t")) end--;
+	const token = "base64";
+	if (end - headerStart < token.length + 1) return false;
+	const tokenStart = end - token.length;
+	for (let i = 0; i < token.length; i++) {
+		if (asciiLowerCode(text.charCodeAt(tokenStart + i)) !== token.charCodeAt(i)) return false;
+	}
+	return tokenStart > headerStart && text[tokenStart - 1] === ";";
+}
+
+function isMimeTokenChar(code: number): boolean {
+	if (code < 33 || code > 126) return false;
+	// RFC 2045 token = printable ASCII excluding tspecials. Slash is handled
+	// separately as the single type/subtype separator.
+	switch (code) {
+		case 34: // "
+		case 40: // (
+		case 41: // )
+		case 44: // ,
+		case 47: // /
+		case 58: // :
+		case 59: // ;
+		case 60: // <
+		case 61: // =
+		case 62: // >
+		case 63: // ?
+		case 64: // @
+		case 91: // [
+		case 92: // backslash
+		case 93: // ]
+			return false;
+		default:
+			return true;
+	}
+}
+
+function normalizeMimeType(text: string, headerStart: number, comma: number): string {
+	let end = headerStart;
+	while (end < comma && text[end] !== ";") end++;
+	if (end === headerStart) return "text/plain";
+	if (end - headerStart > MAX_MIME_CHARS) return "application/octet-stream";
+
+	let slashCount = 0;
+	for (let i = headerStart; i < end; i++) {
+		const code = text.charCodeAt(i);
+		if (code === 47) {
+			slashCount++;
+			if (i === headerStart || i === end - 1) return "application/octet-stream";
+			continue;
+		}
+		if (!isMimeTokenChar(code)) return "application/octet-stream";
+	}
+	if (slashCount !== 1) return "application/octet-stream";
+	return text.slice(headerStart, end).toLowerCase();
+}
+
+function hexValue(code: number): number {
+	if (code >= 48 && code <= 57) return code - 48;
+	if (code >= 65 && code <= 70) return code - 55;
+	if (code >= 97 && code <= 102) return code - 87;
+	return -1;
+}
+
+function decodePercentEncoded(payload: string): { bytes: Buffer } | { error: string } {
+	const output = Buffer.allocUnsafe(Buffer.byteLength(payload, "utf8"));
+	let outputOffset = 0;
+	let cursor = 0;
+
+	while (cursor < payload.length) {
+		const percent = payload.indexOf("%", cursor);
+		const runEnd = percent < 0 ? payload.length : percent;
+		if (runEnd > cursor) {
+			const run = Buffer.from(payload.slice(cursor, runEnd), "utf8");
+			run.copy(output, outputOffset);
+			outputOffset += run.length;
+		}
+		if (percent < 0) break;
+		if (percent + 2 >= payload.length) return { error: "invalid-percent-escape" };
+		const high = hexValue(payload.charCodeAt(percent + 1));
+		const low = hexValue(payload.charCodeAt(percent + 2));
+		if (high < 0 || low < 0) return { error: "invalid-percent-escape" };
+		output[outputOffset++] = (high << 4) | low;
+		cursor = percent + 3;
+	}
+
+	return { bytes: output.subarray(0, outputOffset) };
+}
+
+function isBase64AlphabetByte(byte: number): boolean {
+	return (byte >= 65 && byte <= 90)
+		|| (byte >= 97 && byte <= 122)
+		|| (byte >= 48 && byte <= 57)
+		|| byte === 43
+		|| byte === 47;
+}
+
+function decodeBase64Payload(payload: string): { bytes: Buffer } | { error: string } {
+	const percentDecoded = decodePercentEncoded(payload);
+	if ("error" in percentDecoded) return percentDecoded;
+	const encoded = percentDecoded.bytes;
+	let paddingStart = encoded.length;
+	let paddingCount = 0;
+
+	for (let i = 0; i < encoded.length; i++) {
+		const byte = encoded[i];
+		if (byte > 127) return { error: "non-ascii-base64" };
+		if (byte === 61) {
+			if (paddingStart === encoded.length) paddingStart = i;
+			paddingCount++;
+			continue;
+		}
+		if (paddingStart !== encoded.length) return { error: "invalid-base64-padding" };
+		if (!isBase64AlphabetByte(byte)) return { error: "invalid-base64-character" };
+	}
+
+	if (paddingCount > 2) return { error: "invalid-base64-padding" };
+	if (paddingCount > 0 && encoded.length % 4 !== 0) return { error: "invalid-base64-padding" };
+	if (paddingCount === 0 && encoded.length % 4 === 1) return { error: "invalid-base64-length" };
+	if (paddingCount === 1 && paddingStart % 4 !== 3) return { error: "invalid-base64-padding" };
+	if (paddingCount === 2 && paddingStart % 4 !== 2) return { error: "invalid-base64-padding" };
+
+	return { bytes: Buffer.from(encoded.toString("ascii"), "base64") };
+}
+
+function safeMarkerSource(sourcePath: string): string {
+	const source = sourcePath || "value";
+	let safe = "";
+	for (const ch of source) {
+		const code = ch.charCodeAt(0);
+		const allowed = (code >= 48 && code <= 57)
+			|| (code >= 65 && code <= 90)
+			|| (code >= 97 && code <= 122)
+			|| ch === "."
+			|| ch === "_"
+			|| ch === "-"
+			|| ch === "["
+			|| ch === "]"
+			|| ch === "*"
+			|| ch === "$";
+		safe += allowed ? ch : "_";
+	}
+	if (safe.length <= MAX_MARKER_SOURCE_CHARS) return safe;
+	const suffix = sha256Bytes(source).slice(0, 12);
+	return `${safe.slice(0, MAX_MARKER_SOURCE_CHARS - suffix.length - 1)}~${suffix}`;
+}
+
+function buildDataUriMarker(omission: DataUriOmission): string {
+	const decoded = omission.decodedBytes === null ? "unknown" : String(omission.decodedBytes);
+	const decodeError = omission.decodeError ? `; decodeError=${omission.decodeError}` : "";
+	return `[pi-web-access inline data URI omitted; ordinal=${omission.ordinal}; source=${omission.sourcePath}; mime=${omission.mimeType}; encoding=${omission.encoding}; encodedBytes=${omission.encodedBytes}; decodedBytes=${decoded}${decodeError}; sha256=${omission.sha256}; digestBasis=${omission.digestBasis}; retrieval=not-retained]`;
+}
+
+function sanitizeTextInternal(text: string, sourcePath: string, state: SanitizationState): string {
+	let scanFrom = 0;
+	let retainedFrom = 0;
+	let outputLength = 0;
+	const pieces: string[] = [];
+
+	while (scanFrom < text.length) {
+		const start = findNextDataScheme(text, scanFrom);
+		if (start < 0) break;
+		const candidate = scanDataUriCandidate(text, start);
+		const end = candidate.end;
+		const headerStart = start + 5;
+		const missingComma = candidate.comma < 0;
+		// A bare prose label such as "data: value" is not an inline URI. Enclosed
+		// or non-empty comma-less candidates are malformed URIs and are removed.
+		if (missingComma && end === headerStart && candidate.enclosure === null) {
+			scanFrom = end;
+			continue;
+		}
+		const headerEnd = missingComma ? end : candidate.comma;
+		const headerLength = headerEnd - headerStart;
+		const encoding: DataUriEncoding = headerEndsWithBase64(text, headerStart, headerEnd)
+			? "base64"
+			: "percent-encoded";
+		const mimeType = normalizeMimeType(text, headerStart, headerEnd);
+		// Without the required comma, the post-scheme bytes are ambiguous. Count
+		// and digest the whole omitted segment on the encoded basis rather than
+		// retaining any header/payload-looking suffix.
+		const payload = missingComma
+			? text.slice(headerStart, end)
+			: text.slice(candidate.comma + 1, end);
+		const encodedBytes = Buffer.byteLength(payload, "utf8");
+
+		let decodedBytes: number | null = null;
+		let decodeError: string | undefined;
+		let digestBasis: DigestBasis = "encoded";
+		let digest = "";
+
+		if (missingComma) {
+			decodeError = "missing-comma";
+			digest = sha256Bytes(payload);
+		} else if (headerLength > MAX_DATA_URI_HEADER_CHARS) {
+			decodeError = "header-too-long";
+			digest = sha256Bytes(payload);
+		} else {
+			const decoded = encoding === "base64"
+				? decodeBase64Payload(payload)
+				: decodePercentEncoded(payload);
+			if ("error" in decoded) {
+				decodeError = decoded.error;
+				digest = sha256Bytes(payload);
+			} else {
+				decodedBytes = decoded.bytes.length;
+				digestBasis = "decoded";
+				digest = sha256Bytes(decoded.bytes);
+			}
+		}
+
+		const omission: DataUriOmission = {
+			ordinal: state.nextOrdinal++,
+			sourcePath: safeMarkerSource(sourcePath),
+			mimeType,
+			encoding,
+			encodedBytes,
+			decodedBytes,
+			...(decodeError ? { decodeError } : {}),
+			sha256: digest,
+			digestBasis,
+			retrieval: "not-retained",
+		};
+		const marker = buildDataUriMarker(omission);
+		const prefix = text.slice(retainedFrom, start);
+		pieces.push(prefix, marker);
+		outputLength += prefix.length;
+		const markerStart = outputLength;
+		outputLength += marker.length;
+		state.omissions.push({ ...omission, markerStart, markerEnd: outputLength });
+		retainedFrom = end;
+		scanFrom = end;
+	}
+
+	if (state.omissions.length === 0 && retainedFrom === 0) return text;
+	pieces.push(text.slice(retainedFrom));
+	return pieces.join("");
+}
+
+
+/** Replace every recognized RFC 2397-style inline data URI in one string. */
+export function sanitizeInlineDataUris(
+	text: string,
+	sourcePath: string,
+): { text: string; omissions: DataUriOmission[] } {
+	const state: SanitizationState = { nextOrdinal: 1, omissions: [] };
+	const sanitized = sanitizeTextInternal(text, sourcePath, state);
+	return {
+		text: sanitized,
+		omissions: state.omissions.map(({ markerStart: _start, markerEnd: _end, ...omission }) => omission),
+	};
+}
+
+/** Sanitize every string leaf in a JSON-compatible value with one ordinal sequence. */

--- a/extract.ts
+++ b/extract.ts
@@ -1256,7 +1256,7 @@ export async function fetchAllContent(
 	// results and the fetch cache as opaque base64; typed thumbnail/frame image
 	// blocks are deliberate outputs and are left untouched.
 	return results.map((result, index) => {
-		if (!result.content || !result.content.includes("data:")) return result;
+		if (!result.content) return result;
 		const sanitized = sanitizeInlineDataUris(result.content, `urls[${index}].content`);
 		return sanitized.omissions.length > 0 ? { ...result, content: sanitized.text } : result;
 	});

--- a/extract.ts
+++ b/extract.ts
@@ -1252,6 +1252,7 @@ export async function fetchAllContent(
 	options?: ExtractOptions,
 ): Promise<ExtractedContent[]> {
 	const results = await Promise.all(urls.map((url) => fetchLimit(() => extractContent(url, signal, options))));
+	if (options?.mode === "raw") return results;
 	// Inline data: URIs in extracted markdown would otherwise flow into tool
 	// results and the fetch cache as opaque base64; typed thumbnail/frame image
 	// blocks are deliberate outputs and are left untouched.

--- a/extract.ts
+++ b/extract.ts
@@ -27,6 +27,7 @@ import { formatSeconds, getWebSearchConfigPath } from "./utils.ts";
 import { isImageEnabled } from "./feature-config.ts";
 import { assertAuthFetchUrl, authFetchRedirectGuard, type AuthFetchProfile } from "./auth-fetch.ts";
 import { getBrowserCookiesForHosts, getLastBrowserCookieDiagnostic } from "./chrome-cookies.ts";
+import { sanitizeInlineDataUris } from "./data-uri-sanitize.ts";
 
 const DEFAULT_TIMEOUT_MS = 30000;
 const CONCURRENT_LIMIT = 3;
@@ -1250,5 +1251,13 @@ export async function fetchAllContent(
 	signal?: AbortSignal,
 	options?: ExtractOptions,
 ): Promise<ExtractedContent[]> {
-	return Promise.all(urls.map((url) => fetchLimit(() => extractContent(url, signal, options))));
+	const results = await Promise.all(urls.map((url) => fetchLimit(() => extractContent(url, signal, options))));
+	// Inline data: URIs in extracted markdown would otherwise flow into tool
+	// results and the fetch cache as opaque base64; typed thumbnail/frame image
+	// blocks are deliberate outputs and are left untouched.
+	return results.map((result, index) => {
+		if (!result.content || !result.content.includes("data:")) return result;
+		const sanitized = sanitizeInlineDataUris(result.content, `urls[${index}].content`);
+		return sanitized.omissions.length > 0 ? { ...result, content: sanitized.text } : result;
+	});
 }

--- a/test/data-uri-sanitize.test.mjs
+++ b/test/data-uri-sanitize.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import { test } from "node:test";
+
+import { sanitizeInlineDataUris } from "../data-uri-sanitize.ts";
+
+const DATA_URI_MARKER_PREFIX = "[pi-web-access inline data URI omitted;";
+
+function markerCount(text) {
+	return text.split(DATA_URI_MARKER_PREFIX).length - 1;
+}
+
+function assertRequiredMarkerFields(markerText, ordinal, sourcePath) {
+	assert.match(markerText, new RegExp(`ordinal=${ordinal}(?:;|\\])`));
+	assert.ok(markerText.includes(`source=${sourcePath};`));
+	assert.match(markerText, /mime=[a-z0-9!#$&^_.+\/-]+;/);
+	assert.match(markerText, /encoding=(?:base64|percent-encoded);/);
+	assert.match(markerText, /encodedBytes=\d+;/);
+	assert.match(markerText, /decodedBytes=(?:\d+|unknown)(?:;|\])/);
+	assert.match(markerText, /sha256=[a-f0-9]{64};/);
+	assert.match(markerText, /digestBasis=(?:decoded|encoded);/);
+	assert.match(markerText, /retrieval=not-retained\]/);
+}
+
+test("original 21-image failure shape collapses to bounded markers", { timeout: 20_000 }, () => {
+	const encoded = Buffer.alloc(240 * 1024, 0xa5).toString("base64");
+	const content = Array.from({ length: 21 }, (_, index) =>
+		`Prose ${index} before ![OSF screenshot ${index}](data:image/png;base64,${encoded}) prose ${index} after.`,
+	).join("\n\n");
+	assert.ok(Buffer.byteLength(content, "utf8") > 4 * 1024 * 1024);
+
+	const started = performance.now();
+	const { text, omissions } = sanitizeInlineDataUris(content, "urls[0].content");
+	const elapsedMs = performance.now() - started;
+
+	assert.equal(omissions.length, 21);
+	assert.equal(markerCount(text), 21);
+	assert.doesNotMatch(text, /data:image\/png;base64,/i);
+	for (let ordinal = 1; ordinal <= 21; ordinal++) {
+		assertRequiredMarkerFields(text, ordinal, "urls[0].content");
+	}
+	assert.ok(Buffer.byteLength(text, "utf8") < 32 * 1024);
+	assert.ok(elapsedMs < 15_000, `6-8 MiB sanitization took ${Math.round(elapsedMs)}ms`);
+});
+
+test("many individually small images have no per-payload exemption", { timeout: 20_000 }, () => {
+	const count = 4_300;
+	const encoded = Buffer.alloc(768, 0x5a).toString("base64");
+	const content = Array.from(
+		{ length: count },
+		(_, index) => `Paragraph ${index} ![small ${index}](data:image/png;base64,${encoded}) end ${index}.`,
+	).join("\n");
+
+	const { text, omissions } = sanitizeInlineDataUris(content, "urls[0].content");
+	assert.equal(omissions.length, count);
+	assert.equal(markerCount(text), count);
+	assert.doesNotMatch(text, /data:image\/png;base64,/i);
+});
+
+test("readable prose and Markdown alt text remain unchanged around replacements", () => {
+	const input = "Before ![architecture diagram](data:image/png;base64,SGk=) between <img src=\"data:text/plain,hello%20world\" alt=\"inline\"> after.";
+	const { text, omissions } = sanitizeInlineDataUris(input, "urls[0].content");
+	assert.equal(omissions.length, 2);
+	assert.ok(text.startsWith("Before ![architecture diagram]("));
+	assert.ok(text.includes(") between <img src=\""));
+	assert.ok(text.endsWith("\" alt=\"inline\"> after."));
+	assert.ok(text.includes("architecture diagram"));
+	assert.ok(text.includes("alt=\"inline\""));
+	assert.equal(markerCount(text), 2);
+	assert.doesNotMatch(text, /data:/i);
+});
+
+test("small legitimate SVG is explicitly omitted with decoded digest metadata", () => {
+	const decoded = "<svg xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M0 0\"/></svg>";
+	const payload = encodeURIComponent(decoded);
+	const { text, omissions } = sanitizeInlineDataUris(
+		`Diagram: ![tiny vector](data:image/svg+xml;charset=utf-8,${payload}) done`,
+		"urls[0].content",
+	);
+	assert.equal(omissions.length, 1);
+	const omission = omissions[0];
+	assert.equal(omission.mimeType, "image/svg+xml");
+	assert.equal(omission.encoding, "percent-encoded");
+	assert.equal(omission.encodedBytes, Buffer.byteLength(payload));
+	assert.equal(omission.decodedBytes, Buffer.byteLength(decoded));
+	assert.equal(omission.sha256, createHash("sha256").update(decoded).digest("hex"));
+	assert.equal(omission.digestBasis, "decoded");
+	assert.equal(omission.retrieval, "not-retained");
+	assert.ok(text.includes("![tiny vector]("));
+	assertRequiredMarkerFields(text, 1, "urls[0].content");
+	assert.doesNotMatch(text, /data:/i);
+});
+
+test("data URI variants are handled without payload-bearing errors", () => {
+	const fixtures = {
+		base64: "data:image/png;base64,SGVsbG8=",
+		percent: "data:text/plain,hello%20world",
+		missingMime: "data:;base64,SGk=",
+		parameters: "data:text/plain;charset=utf-8,hello%2Cworld",
+		quoted: "<img src='data:image/gif;base64,R0lGODlhAQABAIAAAAUEBA=='>",
+		quotedApostrophe: "<img src=\"data:text/plain,it's\">",
+		markdown: "![alt](data:application/octet-stream;base64,AAEC)",
+		invalidBase64: "data:image/png;base64,***not-base64***",
+		mixedCase: "DATA:IMAGE/PNG;BASE64,UE5H",
+	};
+	const byKey = new Map();
+	for (const [key, input] of Object.entries(fixtures)) {
+		const result = sanitizeInlineDataUris(input, key);
+		assert.equal(result.omissions.length, 1, `expected one omission for ${key}`);
+		assert.doesNotMatch(result.text, /data:/i);
+		byKey.set(key, { omission: result.omissions[0], text: result.text });
+	}
+	assert.equal(byKey.get("missingMime").omission.mimeType, "text/plain");
+	assert.equal(byKey.get("missingMime").omission.encoding, "base64");
+	assert.equal(byKey.get("parameters").omission.decodedBytes, 11);
+	assert.equal(byKey.get("mixedCase").omission.mimeType, "image/png");
+	const invalid = byKey.get("invalidBase64");
+	assert.equal(invalid.omission.decodedBytes, null);
+	assert.equal(invalid.omission.digestBasis, "encoded");
+	assert.equal(invalid.omission.decodeError, "invalid-base64-character");
+	assert.ok(invalid.text.includes("decodedBytes=unknown"));
+	assert.ok(invalid.text.includes("decodeError=invalid-base64-character"));
+	assert.ok(!invalid.text.includes("not-base64"));
+});
+
+test("malformed enclosed data URIs are wholly removed without payload suffix leakage", () => {
+	const cases = [
+		{
+			input: '<img src="data:image/png;base64,QUFB QkJC">',
+			forbidden: ["QUFB", "QkJC"],
+			error: "invalid-base64-character",
+		},
+		{
+			input: "![x](data:text/plain,abc(def)ghi)",
+			forbidden: ["abc(def)ghi", "ghi)"],
+			decodedBytes: 11,
+		},
+		{
+			input: "data:text/plain,abc(def)ghi",
+			forbidden: ["abc(def)ghi"],
+			decodedBytes: 11,
+		},
+		{
+			input: "![x](data:image/png;base64,SGVs\nbG8=)",
+			forbidden: ["SGVs", "bG8="],
+			error: "invalid-base64-character",
+		},
+		{
+			input: '<img src="data:image/png;base64">',
+			forbidden: ["data:image/png;base64"],
+			error: "missing-comma",
+			encodedBytes: Buffer.byteLength("image/png;base64"),
+		},
+	];
+
+	for (const fixture of cases) {
+		const result = sanitizeInlineDataUris(fixture.input, "urls[0].content");
+		assert.equal(result.omissions.length, 1);
+		assert.equal(markerCount(result.text), 1);
+		assert.doesNotMatch(result.text, /data:/i);
+		for (const fragment of fixture.forbidden) assert.ok(!result.text.includes(fragment));
+		if (fixture.error) assert.equal(result.omissions[0].decodeError, fixture.error);
+		if (fixture.encodedBytes !== undefined) assert.equal(result.omissions[0].encodedBytes, fixture.encodedBytes);
+		if (fixture.decodedBytes !== undefined) assert.equal(result.omissions[0].decodedBytes, fixture.decodedBytes);
+	}
+	assert.equal(
+		sanitizeInlineDataUris("ordinary data: value", "urls[0].content").text,
+		"ordinary data: value",
+	);
+});
+
+test("valid RFC MIME token characters are normalized without truncating the URI", () => {
+	for (const mimeType of ["application/x.foo~bar", "application/x.foo*bar", "application/x.foo'bar"]) {
+		const result = sanitizeInlineDataUris(`<img src=\"data:${mimeType},ok\">`, "urls[0].content");
+		assert.equal(result.omissions.length, 1);
+		assert.equal(result.omissions[0].mimeType, mimeType);
+		assert.equal(result.omissions[0].decodedBytes, 2);
+		assert.doesNotMatch(result.text, /data:/i);
+	}
+});
+
+test("malformed comma-less candidates scale linearly and are explicitly marked", { timeout: 15_000 }, () => {
+	function measure(count) {
+		const input = Array.from({ length: count }, () => "data:x;").join(" ");
+		const started = performance.now();
+		const result = sanitizeInlineDataUris(input, "urls[0].content");
+		const elapsedMs = performance.now() - started;
+		assert.equal(result.omissions.length, count);
+		assert.ok(result.omissions.every((item) => item.decodeError === "missing-comma"));
+		assert.doesNotMatch(result.text, /data:/i);
+		return elapsedMs;
+	}
+	const smallMs = measure(2_000);
+	const largeMs = measure(4_000);
+	assert.ok(largeMs < 10_000, `malformed scan took ${Math.round(largeMs)}ms`);
+	assert.ok(largeMs <= smallMs * 4 + 500, `nonlinear malformed scan: ${smallMs}ms -> ${largeMs}ms`);
+});
+
+test("overlong headers are bounded and classified without retaining header or payload", () => {
+	const header = `image/png;name=${"x".repeat(2_048)};base64`;
+	const result = sanitizeInlineDataUris(`![x](data:${header},SGVsbG8=)`, "urls[0].content");
+	assert.equal(result.omissions.length, 1);
+	assert.equal(result.omissions[0].decodedBytes, null);
+	assert.equal(result.omissions[0].decodeError, "header-too-long");
+	assert.equal(result.omissions[0].digestBasis, "encoded");
+	assert.ok(!result.text.includes("x".repeat(128)));
+	assert.doesNotMatch(result.text, /data:/i);
+});

--- a/test/fetch-modes.test.mjs
+++ b/test/fetch-modes.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { after, test } from "node:test";
 
-import { extractContent } from "../extract.ts";
+import { extractContent, fetchAllContent } from "../extract.ts";
 
 const originalFetch = globalThis.fetch;
 after(() => { globalThis.fetch = originalFetch; });
@@ -21,6 +21,14 @@ test("raw mode returns textual non-2xx bodies but rejects images", async () => {
 	const image = await extractContent("https://example.com/pixel.png", undefined, { mode: "raw", lookup });
 	assert.match(image.error, /Unsupported content type in raw mode: image\/png/);
 	assert.equal(image.thumbnail, undefined);
+});
+
+test("raw mode keeps data URIs in the exact HTTP body", async () => {
+	const body = "exact data:text/plain,hello%20world body";
+	globalThis.fetch = async () => new Response(body, { headers: { "content-type": "text/plain" } });
+
+	const [result] = await fetchAllContent(["https://example.com/data"], undefined, { mode: "raw", lookup });
+	assert.equal(result.content, body);
 });
 
 test("readable mode returns supported image content", async () => {


### PR DESCRIPTION
Fixes #281.

## Summary

- add `data-uri-sanitize.ts`: a byte-exact RFC 2397 scanner that replaces every inline
  `data:` URI in one string with an explicit omission marker
- apply it in `fetchAllContent` — the single choke point through which all
  `extractContent` results flow — on the markdown `content` field only
- typed thumbnail/frame image blocks and all other `ExtractedContent` fields are untouched

## Why

Extracted markdown keeps inline base64 images from page HTML. They are undecodable noise to
the model but consume the bounded model-visible windows (`maxInlineContentChars` slices,
`findText` context, direct display), crowding out the page's actual text. One observed
help-center page carried 21 embedded images totaling ~6.7 MB of base64 interleaved with the
article prose.

## Behavior

Every inline data URI is replaced, regardless of individual size. The marker records MIME
type, encoding, encoded and decoded byte counts (or a decode-error classification), source
ordinal/path, SHA-256 digest and its basis, and `retrieval=not-retained`. Readable prose
and Markdown image alt text are preserved. Malformed and comma-less candidates are removed
without leaking header or payload fragments. The scanner is single-pass, with a timing test
guarding pathological comma-less inputs.

## Validation

- `node --test test/data-uri-sanitize.test.mjs` — 9 tests pass
- `node --test test/*.test.mjs` (full suite, explicit file list) — 501 tests, 488 pass;
  the 11 failures are environment-dependent (keychain, local-server networking, load-time
  timeouts on a WSL2 host) and fail identically on unpatched v0.24.0 with this change
  stashed
- `npm run typecheck` — clean
- `git diff --check origin/main...HEAD` — clean
- live smoke: `fetchAllContent` on
  https://cran.r-project.org/web/packages/viridis/vignettes/intro-to-viridis.html
  (2.5 MB raw HTML, 98.9% base64) returns 12,125 chars of prose with 13 omission markers
  and zero residual data URIs

## Tests

`test/data-uri-sanitize.test.mjs`:

- original 21-image failure shape collapses to <32 KiB of marked-up prose
- many individually small images with no per-payload exemption
- prose and alt-text preservation around replacements
- decoded-digest metadata for small legitimate vectors
- data-URI variants (percent-encoding, missing MIME, parameters, quoting, mixed case,
  invalid base64) without payload-bearing errors
- malformed enclosed candidates removed without suffix leakage
- RFC MIME token normalization, overlong-header classification, timing bound on
  comma-less inputs

## Notes

- Sanitization runs before content reaches the fetch cache, so the payload is genuinely
  not retained (the marker says so). If you'd rather this be opt-out, I'm happy to add a
  config flag (e.g. `sanitizeDataUris: false`) in this PR.
- Known trade-off: `data:` URIs appearing as *examples* in technical articles (data-URI
  tutorials, CSS-inlining docs) are also replaced. The marker preserves MIME type, sizes,
  and digest, and short examples are cheap to reconstruct from surrounding prose; a size
  threshold was deliberately rejected because many-small-images pages are a real failure
  shape (see the second test).
- Markers are bounded at ~250 bytes each, so pathological many-image pages trade base64
  spam for a bounded amount of marker text. Happy to shorten the digest or coalesce runs
  of consecutive markers if you'd prefer smaller output there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
