### PR TITLE
feat: add configurable PDF page limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added `pdf.maxPages` to limit Datalab, Gemini, and local PDF extraction to the first N pages. Thanks to [@jaudiger](https://github.com/jaudiger) for issue #277.
+
 ## [0.24.0] - 2026-08-18
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Configure Datalab via the web-search config:
   "datalabApiKey": "$DATALAB_API_KEY",
   "pdf": {
     "maxSizeMB": 20,
+    "maxPages": 100,
     "provider": "auto",      // "auto" | "gemini" | "datalab" | "unpdf"
     "datalabMode": "balanced", // "fast" | "balanced" | "accurate"
     "datalabTimeoutMs": 120000
@@ -810,7 +811,7 @@ Values use the same format as pi keybindings (e.g. `ctrl+s`, `ctrl+shift+s`, `al
 
 Set `"enabled": false` under `tools`, `commands`, `image`, or `pdf` to disable that feature. Tool-specific settings override the legacy `webSearch.enabled` shorthand; without an override, it still disables `web_search` and `source_check`. `image.enabled: false` blocks direct image fetches and video frame extraction, and prevents video thumbnails. `pdf.enabled: false` blocks PDF extraction. For GitHub specifically, `githubClone.enabled: false` only skips clone/API specialization; it does not unregister `fetch_content` or block generic URL extraction. Pi restart is required for tool and command registration changes.
 
-Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Search, TinyFish, Search1API, and Searchinfinity apply the plan limits documented by their APIs. Querit Search and Contents subscriptions are independent. Content fetches run 3 concurrent with a 30s timeout for the direct HTTP fetch of each URL. Remote extraction fallbacks carry their own budgets and are not covered by that number: Jina Reader 30s, Firecrawl 60s, Kagi Extract 60s, Ollama Web Fetch 60s, Bright Data Web Unlocker 60s, TinyFish up to 150s, Gemini 120s, Datalab 120s (capped at 300s, rate-limited to 25 requests/minute on the free tier). `pdf.maxSizeMB` defaults to 20 and is capped at 50.
+Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Search, TinyFish, Search1API, and Searchinfinity apply the plan limits documented by their APIs. Querit Search and Contents subscriptions are independent. Content fetches run 3 concurrent with a 30s timeout for the direct HTTP fetch of each URL. Remote extraction fallbacks carry their own budgets and are not covered by that number: Jina Reader 30s, Firecrawl 60s, Kagi Extract 60s, Ollama Web Fetch 60s, Bright Data Web Unlocker 60s, TinyFish up to 150s, Gemini 120s, Datalab 120s (capped at 300s, rate-limited to 25 requests/minute on the free tier). `pdf.maxSizeMB` defaults to 20 and is capped at 50. `pdf.maxPages` defaults to 100 and limits every PDF provider to the first N pages.
 
 ## Limitations
 

--- a/pdf-extract.ts
+++ b/pdf-extract.ts
@@ -51,6 +51,7 @@ export const PDF_PROVIDER_VALUES = new Set<PDFProvider>([
 export interface PDFConfig {
 	enabled: boolean;
 	maxSizeMB: number;
+	maxPages: number;
 	provider: PDFProvider;
 	datalabMode: DatalabMode;
 	datalabTimeoutMs: number;
@@ -69,6 +70,7 @@ export function loadPDFConfig(): PDFConfig {
 		return {
 			enabled: true,
 			maxSizeMB: DEFAULT_PDF_MAX_SIZE_MB,
+			maxPages: DEFAULT_MAX_PAGES,
 			provider: "auto",
 			datalabMode: normalizeDatalabMode(process.env.DATALAB_MODE),
 			datalabTimeoutMs: DEFAULT_DATALAB_TIMEOUT_MS,
@@ -98,6 +100,13 @@ export function loadPDFConfig(): PDFConfig {
 		configured > 0
 			? Math.min(configured, MAX_PDF_MAX_SIZE_MB)
 			: DEFAULT_PDF_MAX_SIZE_MB;
+	const configuredMaxPages = pdf.maxPages;
+	const maxPages =
+		typeof configuredMaxPages === "number" &&
+		Number.isFinite(configuredMaxPages) &&
+		configuredMaxPages > 0
+			? Math.max(1, Math.floor(configuredMaxPages))
+			: DEFAULT_MAX_PAGES;
 
 	const provider =
 		typeof pdf.provider === "string" &&
@@ -120,6 +129,7 @@ export function loadPDFConfig(): PDFConfig {
 	return {
 		enabled,
 		maxSizeMB: normalized,
+		maxPages,
 		provider,
 		datalabMode,
 		datalabTimeoutMs,
@@ -155,18 +165,21 @@ export async function extractPDFToMarkdown(
 	options: PDFExtractOptions = {},
 ): Promise<PDFExtractResult> {
 	const {
-		maxPages = DEFAULT_MAX_PAGES,
+		maxPages,
 		outputDir = DEFAULT_OUTPUT_DIR,
 		filename,
 		signal,
 		geminiTimeoutMs,
 	} = options;
 
-	const safeMaxPages = Number.isFinite(maxPages)
-		? Math.max(1, Math.floor(maxPages))
-		: DEFAULT_MAX_PAGES;
-	const urlTitle = extractTitleFromURL(url);
 	const pdfConfig = loadPDFConfig();
+	const safeMaxPages =
+		maxPages === undefined
+			? pdfConfig.maxPages
+			: Number.isFinite(maxPages)
+				? Math.max(1, Math.floor(maxPages))
+				: DEFAULT_MAX_PAGES;
+	const urlTitle = extractTitleFromURL(url);
 	const provider = pdfConfig.provider;
 
 	if (provider === "auto" || provider === "datalab") {

--- a/test/pdf-config.test.mjs
+++ b/test/pdf-config.test.mjs
@@ -31,6 +31,15 @@ test("pdf.maxSizeMB caps values above 50 and rejects invalid values", () => {
 	assert.equal(readConfig({ pdf: { maxSizeMB: "50" } }).maxSizeMB, 20);
 });
 
+test("pdf.maxPages defaults to 100 and accepts positive integer values", () => {
+	assert.equal(readConfig(undefined).maxPages, 100);
+	assert.equal(readConfig({ pdf: { maxPages: 25 } }).maxPages, 25);
+	assert.equal(readConfig({ pdf: { maxPages: 2.8 } }).maxPages, 2);
+	assert.equal(readConfig({ pdf: { maxPages: 0 } }).maxPages, 100);
+	assert.equal(readConfig({ pdf: { maxPages: -1 } }).maxPages, 100);
+	assert.equal(readConfig({ pdf: { maxPages: "25" } }).maxPages, 100);
+});
+
 test("pdf.provider defaults to auto and validates explicit providers", () => {
 	assert.equal(readConfig(undefined).provider, "auto");
 	assert.equal(readConfig({ pdf: { provider: "gemini" } }).provider, "gemini");


### PR DESCRIPTION
Fixes #277.

This adds `pdf.maxPages` with the existing default of 100 pages. The configured value becomes the shared default for Datalab, Gemini, and local `unpdf` extraction while explicit caller `maxPages` still takes precedence.

Validation:
- `node --test test/pdf-config.test.mjs`
- `npm run typecheck`
- fresh read-only review: no issues found

Credit: Thanks to [@jaudiger](https://github.com/jaudiger) for #277.