### PR TITLE
fix: detach Linux curator browser launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Replaced inline RFC 2397 `data:` URIs in extracted page content with explicit bounded omission markers (MIME type, encoding, encoded/decoded byte counts, SHA-256 digest, `retrieval=not-retained`) before content reaches tool results, the fetch cache, or session persistence. Readable prose and Markdown image alt text are preserved; typed thumbnail/frame image blocks are unaffected. Thanks to [@bbbRye007](https://github.com/bbbRye007) for #281 and #282.
+- Detached Linux curator browser launches so `xdg-open` cannot block `web_search` until the browser exits. Thanks to [@nguyenphivn](https://github.com/nguyenphivn) for issue #279.
 
 ## [0.24.0] - 2026-08-18
 

--- a/index.ts
+++ b/index.ts
@@ -34,7 +34,7 @@ import {
 	type SummaryMeta,
 } from "./summary-review.ts";
 import { randomUUID } from "node:crypto";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import { platform } from "node:os";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
@@ -744,11 +744,26 @@ function closeCurator(callId?: string): void {
 
 async function openInBrowser(pi: ExtensionAPI, url: string): Promise<void> {
 	const plat = platform();
+	if (plat !== "darwin" && plat !== "win32") {
+		await new Promise<void>((resolve, reject) => {
+			const child = spawn("xdg-open", [url], { detached: true, stdio: "ignore" });
+			const timer = setTimeout(resolve, 100);
+			child.once("error", (err) => {
+				clearTimeout(timer);
+				reject(err);
+			});
+			child.once("exit", (code) => {
+				clearTimeout(timer);
+				if (code === 0) resolve();
+				else reject(new Error(`Failed to open browser (exit code ${code ?? "unknown"})`));
+			});
+			child.unref();
+		});
+		return;
+	}
 	const result = plat === "darwin"
 		? await pi.exec("open", [url])
-		: plat === "win32"
-			? await pi.exec("cmd", ["/c", "start", "", url])
-			: await pi.exec("xdg-open", [url]);
+		: await pi.exec("cmd", ["/c", "start", "", url]);
 	if (result.code !== 0) {
 		throw new Error(result.stderr || `Failed to open browser (exit code ${result.code})`);
 	}

--- a/test/curator-fallback.test.mjs
+++ b/test/curator-fallback.test.mjs
@@ -53,6 +53,14 @@ test("remote curator mode prints the manual URL unless auto-open is explicit", (
 	assert.ok(indexSrc.includes('ctx.ui.notify(`Search curator is running. Open manually: ${handle.url}`, "info")'));
 });
 
+test("Linux curator browser launch detaches xdg-open but keeps immediate failures", () => {
+	assert.match(indexSrc, /spawn\("xdg-open", \[url\], \{ detached: true, stdio: "ignore" \}\)/);
+	assert.match(indexSrc, /child\.once\("error", \(err\) => \{/);
+	assert.match(indexSrc, /child\.once\("exit", \(code\) => \{/);
+	assert.match(indexSrc, /setTimeout\(resolve, 100\)/);
+	assert.match(indexSrc, /child\.unref\(\);/);
+});
+
 test("README documents manual browser fallback", () => {
 	assert.match(readmeSrc, /Docker, WSL, SSH, or headless environments/);
 	assert.match(readmeSrc, /Copy it into a browser that can reach the Pi host/);


### PR DESCRIPTION
Fixes #279.

This keeps the curator URL open path from hanging on Linux when `xdg-open` stays attached to the browser. The Linux branch now uses a detached spawn with a short startup window, while immediate launch errors still flow into the existing manual URL fallback paths.

Validation:
- `npm test -- --test-name-pattern="Linux curator browser launch detaches xdg-open but keeps immediate failures|web_search curator auto-open failures keep the curator alive with a manual URL|manual websearch command reports browser-open fallback without closing curator"`
- `npm run typecheck`
- fresh follow-up review: no issues found

Credit: Thanks to [@nguyenphivn](https://github.com/nguyenphivn) for #279.