### PR TITLE
feat: support Windows Gemini Web cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Added `pdf.maxPages` to limit Datalab, Gemini, and local PDF extraction to the first N pages. Thanks to [@jaudiger](https://github.com/jaudiger) for issue #277.
 - Added optional `openaiSearchProviders` config to choose which Pi model providers fund OpenAI `web_search`, in priority order. Thanks to [@hank-warren](https://github.com/hank-warren) for PR #276.
+- Added Windows Chrome and Edge browser-cookie support for Gemini Web. Thanks to [@laixuanthoi](https://github.com/laixuanthoi) for issue #286.
 
 ### Fixed
 - Replaced inline RFC 2397 `data:` URIs in extracted page content with explicit bounded omission markers (MIME type, encoding, encoded/decoded byte counts, SHA-256 digest, `retrieval=not-retained`) before content reaches tool results, the fetch cache, or session persistence. Readable prose and Markdown image alt text are preserved; typed thumbnail/frame image blocks are unaffected. Thanks to [@bbbRye007](https://github.com/bbbRye007) for #281 and #282.

--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Sear
 ## Limitations
 
 - If the curator cannot open a browser automatically, such as in Docker, WSL, SSH, or headless environments, the running curator URL is shown in the tool output. Copy it into a browser that can reach the Pi host, or use a tunnel/port-forward when needed.
-- Chromium cookie extraction for Gemini Web is opt-in via `allowBrowserCookies: true` or `PI_ALLOW_BROWSER_COOKIES=1`; no browser data or password store is touched while it is disabled. On macOS, enabling it may trigger a Keychain dialog. Required cookie names are checked before password-store access, and browser encryption passwords are cached only in-process. If `node:sqlite` is unavailable, the reader falls back to the `sqlite3` CLI or Python stdlib; `/google-account` reports a sanitized SQLite/profile/password diagnostic when extraction fails.
+- Chromium cookie extraction for Gemini Web is opt-in via `allowBrowserCookies: true` or `PI_ALLOW_BROWSER_COOKIES=1`; no browser data or password store is touched while it is disabled. On macOS, enabling it may trigger a Keychain dialog. On Windows, Chrome and Edge v10 cookies use the current user's DPAPI key; v20 app-bound cookies are not supported. Required cookie names are checked before password-store access, and browser encryption passwords are cached only in-process. If `node:sqlite` is unavailable, the reader falls back to the `sqlite3` CLI or Python stdlib; `/google-account` reports a sanitized SQLite/profile/password diagnostic when extraction fails.
 - YouTube private/age-restricted videos may fail on all extraction paths.
 - Gemini can process videos up to ~1 hour; longer videos may be truncated.
 - PDFs are text-extracted only (no OCR for scanned documents).
@@ -863,7 +863,7 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Sear
 | `gemini-web.ts` | Gemini Web client (cookie auth, StreamGenerate) |
 | `gemini-web-config.ts` | Gemini Web profile and browser-cookie opt-in config |
 | `gemini-api.ts` | Gemini REST API client (generateContent) |
-| `chrome-cookies.ts` | macOS/Linux Chromium-based cookie extraction (Keychain/secret-tool + SQLite) |
+| `chrome-cookies.ts` | Chromium-based cookie extraction (macOS Keychain, Linux secret-tool, Windows DPAPI + SQLite) |
 | `youtube-extract.ts` | YouTube detection, three-tier extraction, frame extraction |
 | `video-extract.ts` | Local video detection, Files API upload, Gemini analysis |
 | `github-extract.ts` | GitHub URL parsing, clone cache, content generation |

--- a/chrome-cookies.ts
+++ b/chrome-cookies.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { pbkdf2Sync, createDecipheriv } from "node:crypto";
-import { copyFileSync, existsSync, mkdtempSync, readdirSync, realpathSync, rmSync } from "node:fs";
+import { copyFileSync, existsSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
 import { isAbsolute, join, sep } from "node:path";
 import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
@@ -10,6 +10,7 @@ export type CookieMap = Record<string, string>;
 interface BrowserConfig {
 	name: string;
 	baseDir: string;
+	usesLocalAppData?: boolean;
 	keychainService?: string;
 	keychainAccount?: string;
 	secretToolApp?: string;
@@ -48,6 +49,11 @@ const LINUX_BROWSER_CONFIGS: BrowserConfig[] = [
 	{ name: "Chrome", baseDir: ".config/google-chrome", secretToolApp: "chrome" },
 ];
 
+const WINDOWS_BROWSER_CONFIGS: BrowserConfig[] = [
+	{ name: "Chrome", baseDir: "Google/Chrome/User Data", usesLocalAppData: true },
+	{ name: "Edge", baseDir: "Microsoft/Edge/User Data", usesLocalAppData: true },
+];
+
 const browserPasswordCache = new Map<string, Promise<string | null>>();
 let lastCookieDiagnostic: string | null = null;
 let sqliteModule: typeof import("node:sqlite") | null = null;
@@ -83,7 +89,7 @@ export async function getBrowserCookiesForHosts(
 	}
 
 	const currentPlatform = process.platform;
-	const configs = currentPlatform === "darwin" ? MACOS_BROWSER_CONFIGS : currentPlatform === "linux" ? LINUX_BROWSER_CONFIGS : [];
+	const configs = currentPlatform === "darwin" ? MACOS_BROWSER_CONFIGS : currentPlatform === "linux" ? LINUX_BROWSER_CONFIGS : currentPlatform === "win32" ? WINDOWS_BROWSER_CONFIGS : [];
 	if (configs.length === 0) {
 		lastCookieDiagnostic = "Chromium cookie extraction is unsupported on this platform.";
 		return null;
@@ -103,12 +109,13 @@ export async function getBrowserCookiesForHosts(
 		lastCookieDiagnostic = "No valid cookie hosts were requested.";
 		return null;
 	}
-	const home = homedir();
+	const home = currentPlatform === "win32" ? process.env.USERPROFILE || homedir() : homedir();
 	let sawCookieDatabase = false;
 	let sawRequiredCookies = false;
 	let sawAnyHostCookie = false;
 	let sawBackendFailure: SqliteFailure | undefined;
 	let sawUnsafeProfilePath = false;
+	let sawWindowsAppBoundCookie = false;
 
 	for (const config of configs) {
 		const profiles = requestedProfile ? [requestedProfile] : listBrowserProfiles(home, config);
@@ -119,7 +126,8 @@ export async function getBrowserCookiesForHosts(
 				continue;
 			}
 			if (!profilePath) continue;
-			const cookiesPath = join(profilePath, "Cookies");
+			const cookiesPath = cookieDatabasePath(profilePath, config);
+			if (!cookiesPath) continue;
 			sawCookieDatabase = true;
 
 			const tempDir = mkdtempSync(join(tmpdir(), "pi-chrome-cookies-"));
@@ -136,13 +144,15 @@ export async function getBrowserCookiesForHosts(
 					sawRequiredCookies = true;
 				}
 
-				const password = await readBrowserPassword(config, currentPlatform);
-				if (!password) {
-					warningSet.add(`Could not read ${config.name} cookie encryption password`);
+				const key = currentPlatform === "win32"
+					? await readWindowsEncryptionKey(config, home)
+					: await readBrowserPassword(config, currentPlatform).then((password) => password ? pbkdf2Sync(password, "saltysalt", currentPlatform === "darwin" ? 1003 : 1, 16, "sha1") : null);
+				if (!key) {
+					warningSet.add(currentPlatform === "win32"
+						? `Could not read ${config.name} Windows cookie encryption key`
+						: `Could not read ${config.name} cookie encryption password`);
 					continue;
 				}
-
-				const key = pbkdf2Sync(password, "saltysalt", currentPlatform === "darwin" ? 1003 : 1, 16, "sha1");
 				const metaVersion = await readMetaVersion(tempDb);
 				if (metaVersion.failure) sawBackendFailure = metaVersion.failure;
 				if (metaVersion.value === null) continue;
@@ -159,7 +169,11 @@ export async function getBrowserCookiesForHosts(
 					if (!name) continue;
 					let value = typeof row.value === "string" && row.value.length > 0 ? row.value : null;
 					if (!value && typeof row.encrypted_value_hex === "string" && /^[0-9a-f]*$/i.test(row.encrypted_value_hex)) {
-						value = decryptCookieValue(Buffer.from(row.encrypted_value_hex, "hex"), key, metaVersion.value >= 24);
+						const encrypted = Buffer.from(row.encrypted_value_hex, "hex");
+						if (currentPlatform === "win32" && encrypted.subarray(0, 3).toString("utf8") === "v20") sawWindowsAppBoundCookie = true;
+						value = currentPlatform === "win32"
+							? decryptWindowsCookieValue(encrypted, key, metaVersion.value >= 24)
+							: decryptCookieValue(encrypted, key, metaVersion.value >= 24);
 					}
 					if (!value) continue;
 					const path = typeof row.path === "string" && row.path.startsWith("/") ? row.path : "/";
@@ -194,6 +208,8 @@ export async function getBrowserCookiesForHosts(
 			: "No detected Chromium profile contains a cookie database.";
 	} else if (requiredCookies?.length && !sawRequiredCookies) {
 		lastCookieDiagnostic = `No detected Chromium profile contains the required ${options.requiredLabel ?? "browser"} cookies.`;
+	} else if (sawWindowsAppBoundCookie) {
+		lastCookieDiagnostic = "Windows Chromium v20 app-bound cookies are not supported.";
 	} else if (!sawAnyHostCookie) {
 		lastCookieDiagnostic = options.requestUrl
 			? "No detected Chromium profile contains cookies for the requested URL."
@@ -217,10 +233,9 @@ function normalizeProfileName(value: string | undefined): string | undefined {
 }
 
 function resolveProfilePath(home: string, config: BrowserConfig, profile: string): string | "outside-root" | null {
-	const basePath = join(home, config.baseDir);
+	const basePath = browserBasePath(home, config);
 	const profilePath = join(basePath, profile);
-	const cookiesPath = join(profilePath, "Cookies");
-	if (!existsSync(cookiesPath)) return null;
+	if (!cookieDatabasePath(profilePath, config)) return null;
 	try {
 		const baseRealPath = realpathSync(basePath);
 		const profileRealPath = realpathSync(profilePath);
@@ -229,6 +244,19 @@ function resolveProfilePath(home: string, config: BrowserConfig, profile: string
 	} catch {
 		return null;
 	}
+}
+
+function cookieDatabasePath(profilePath: string, config: BrowserConfig): string | null {
+	const networkCookies = join(profilePath, "Network", "Cookies");
+	if (config.usesLocalAppData && existsSync(networkCookies)) return networkCookies;
+	const legacyCookies = join(profilePath, "Cookies");
+	return existsSync(legacyCookies) ? legacyCookies : null;
+}
+
+function browserBasePath(home: string, config: BrowserConfig): string {
+	return config.usesLocalAppData
+		? join(process.env.LOCALAPPDATA || join(home, "AppData", "Local"), config.baseDir)
+		: join(home, config.baseDir);
 }
 
 function normalizeCookieNames(names: string[] | undefined): string[] | undefined {
@@ -242,12 +270,12 @@ function normalizeHosts(hosts: string[]): string[] {
 }
 
 function listBrowserProfiles(home: string, config: BrowserConfig): string[] {
-	const basePath = join(home, config.baseDir);
+	const basePath = browserBasePath(home, config);
 	if (!existsSync(basePath)) return ["Default"];
 	const profiles = new Set<string>();
 	try {
 		for (const entry of readdirSync(basePath, { withFileTypes: true })) {
-			if (entry.isDirectory() && existsSync(join(basePath, entry.name, "Cookies"))) profiles.add(entry.name);
+			if (entry.isDirectory() && cookieDatabasePath(join(basePath, entry.name), config)) profiles.add(entry.name);
 		}
 	} catch {
 	}
@@ -288,6 +316,21 @@ function decryptCookieValue(encrypted: Uint8Array, key: Buffer, stripHash: boole
 	}
 }
 
+function decryptWindowsCookieValue(encrypted: Uint8Array, key: Buffer, stripHash: boolean): string | null {
+	const buf = Buffer.from(encrypted);
+	if (buf.subarray(0, 3).toString("utf8") !== "v10" || buf.length < 3 + 12 + 16) return null;
+	try {
+		const nonce = buf.subarray(3, 15);
+		const ciphertext = buf.subarray(15, -16);
+		const decipher = createDecipheriv("aes-256-gcm", key, nonce);
+		decipher.setAuthTag(buf.subarray(-16));
+		const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+		return new TextDecoder("utf-8", { fatal: true }).decode(stripHash && plaintext.length >= 32 ? plaintext.subarray(32) : plaintext);
+	} catch {
+		return null;
+	}
+}
+
 function removePkcs7Padding(buf: Buffer): Buffer {
 	if (!buf.length) return buf;
 	const padding = buf[buf.length - 1];
@@ -314,6 +357,34 @@ function readBrowserPassword(config: BrowserConfig, currentPlatform: typeof proc
 	});
 	browserPasswordCache.set(cacheKey, passwordPromise);
 	return passwordPromise;
+}
+
+async function readWindowsEncryptionKey(config: BrowserConfig, home: string): Promise<Buffer | null> {
+	try {
+		const localState = JSON.parse(readFileSync(join(browserBasePath(home, config), "Local State"), "utf8")) as { os_crypt?: { encrypted_key?: unknown } };
+		const encodedKey = localState.os_crypt?.encrypted_key;
+		if (typeof encodedKey !== "string") return null;
+		const protectedKey = Buffer.from(encodedKey, "base64");
+		if (protectedKey.subarray(0, 5).toString("utf8") !== "DPAPI") return null;
+		const decrypted = await unprotectWindowsData(protectedKey.subarray(5));
+		return decrypted?.length === 32 ? decrypted : null;
+	} catch {
+		return null;
+	}
+}
+
+function unprotectWindowsData(protectedData: Buffer): Promise<Buffer | null> {
+	return new Promise((resolve) => {
+		const script = "$data=[Convert]::FromBase64String($args[0]);$clear=[Security.Cryptography.ProtectedData]::Unprotect($data,$null,[Security.Cryptography.DataProtectionScope]::CurrentUser);[Console]::Write([Convert]::ToBase64String($clear))";
+		execFile("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script, protectedData.toString("base64")], { timeout: 5000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
+			if (err) { resolve(null); return; }
+			try {
+				resolve(Buffer.from(stdout.trim(), "base64"));
+			} catch {
+				resolve(null);
+			}
+		});
+	});
 }
 
 function readKeychainPassword(account: string, service: string): Promise<string | null> {

--- a/test/chrome-cookie-extraction.test.mjs
+++ b/test/chrome-cookie-extraction.test.mjs
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
+import { createCipheriv, createHash } from "node:crypto";
 import { chmodSync, existsSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, symlinkSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
 
 const moduleUrl = new URL("../chrome-cookies.ts", import.meta.url).href;
@@ -15,9 +16,13 @@ function createFixture(home, profile, rows = [], options = {}) {
 		? browser === "Brave"
 			? join(home, "Library", "Application Support", "BraveSoftware", "Brave-Browser")
 			: join(home, "Library", "Application Support", "Google", "Chrome")
+		: targetPlatform === "win32"
+			? browser === "Edge"
+				? join(home, "AppData", "Local", "Microsoft", "Edge", "User Data")
+				: join(home, "AppData", "Local", "Google", "Chrome", "User Data")
 		: join(home, ".config", "google-chrome");
-	const dbPath = join(base, profile, "Cookies");
-	mkdirSync(join(base, profile), { recursive: true });
+	const dbPath = targetPlatform === "win32" ? join(base, profile, "Network", "Cookies") : join(base, profile, "Cookies");
+	mkdirSync(dirname(dbPath), { recursive: true });
 	execFileSync(python, ["-c", `
 import json, sqlite3, sys
 c = sqlite3.connect(sys.argv[1])
@@ -25,10 +30,27 @@ c.execute("create table meta (key text, value integer)")
 c.execute("insert into meta values ('version', 24)")
 c.execute("create table cookies (name text, value text, host_key text, encrypted_value blob, expires_utc integer)")
 for row in json.loads(sys.argv[2]):
-    c.execute("insert into cookies values (?, ?, ?, ?, ?)", row)
+    encrypted = bytes.fromhex(row[3][4:]) if isinstance(row[3], str) and row[3].startswith('hex:') else row[3]
+    c.execute("insert into cookies values (?, ?, ?, ?, ?)", [row[0], row[1], row[2], encrypted, row[4]])
 c.commit()
 c.close()
 `, dbPath, JSON.stringify(rows)], { stdio: "ignore" });
+	if (options.windowsKey) {
+		writeFileSync(join(base, "Local State"), JSON.stringify({ os_crypt: { encrypted_key: Buffer.concat([Buffer.from("DPAPI"), Buffer.from("protected")]).toString("base64") } }));
+	}
+}
+
+function encryptWindowsCookie(value, key, version = "v10", hostKey) {
+	const nonce = Buffer.alloc(12, 7);
+	const cipher = createCipheriv("aes-256-gcm", key, nonce);
+	const plaintext = hostKey ? Buffer.concat([createHash("sha256").update(hostKey).digest(), Buffer.from(value)]) : Buffer.from(value);
+	return Buffer.concat([Buffer.from(version), nonce, cipher.update(plaintext), cipher.final(), cipher.getAuthTag()]).toString("hex");
+}
+
+function writeWindowsDpapiCommand(bin) {
+	const script = "#!/bin/sh\nlast=\nfor arg do last=$arg; done\n[ \"$last\" = \"$DPAPI_PROTECTED\" ] || exit 1\nprintf '%s' \"$DPAPI_KEY\"\n";
+	writeFileSync(join(bin, "powershell.exe"), script);
+	chmodSync(join(bin, "powershell.exe"), 0o755);
 }
 
 function makeEnvironment(home, bin, extra = {}) {
@@ -124,6 +146,42 @@ test("auto-discovery finds a Brave profile on macOS", (t) => {
 	assert.deepEqual(readFileSync(argsPath, "utf8").trim().split("\n"), [
 		"find-generic-password", "-w", "-a", "Brave", "-s", "Brave Safe Storage",
 	]);
+	rmSync(home, { recursive: true, force: true });
+	rmSync(bin, { recursive: true, force: true });
+});
+
+test("Windows Chrome profiles decrypt v10 cookies with DPAPI keys", (t) => {
+	skipWithoutPython(t);
+	const home = mkdtempSync(join(tmpdir(), "pi-cookie-windows-"));
+	const bin = mkdtempSync(join(tmpdir(), "pi-cookie-bin-"));
+	const key = Buffer.alloc(32, 3);
+	createFixture(home, "Default", [
+		["__Secure-1PSID", "", ".google.com", `hex:${encryptWindowsCookie("one", key, "v10", ".google.com")}`, 1],
+		["__Secure-1PSIDTS", "", ".google.com", `hex:${encryptWindowsCookie("two", key, "v10", ".google.com")}`, 2],
+	], { targetPlatform: "win32", windowsKey: key });
+	const env = makeEnvironment(home, bin, { LOCALAPPDATA: join(home, "AppData", "Local"), DPAPI_KEY: key.toString("base64"), DPAPI_PROTECTED: Buffer.from("protected").toString("base64"), TEMP: tmpdir(), TMP: tmpdir() });
+	writeWindowsDpapiCommand(bin);
+	const result = runCookies(home, env, undefined, "win32");
+	assert.deepEqual(result.result.cookies, { "__Secure-1PSIDTS": "two", "__Secure-1PSID": "one" });
+	rmSync(home, { recursive: true, force: true });
+	rmSync(bin, { recursive: true, force: true });
+});
+
+test("Windows Edge uses the USERPROFILE AppData fallback and reports unsupported v20 cookies", (t) => {
+	skipWithoutPython(t);
+	const home = mkdtempSync(join(tmpdir(), "pi-cookie-windows-edge-"));
+	const bin = mkdtempSync(join(tmpdir(), "pi-cookie-bin-"));
+	const key = Buffer.alloc(32, 4);
+	createFixture(home, "Default", [
+		["__Secure-1PSID", "", ".google.com", `hex:${encryptWindowsCookie("one", key, "v20")}`, 1],
+		["__Secure-1PSIDTS", "", ".google.com", `hex:${encryptWindowsCookie("two", key, "v20")}`, 2],
+	], { browser: "Edge", targetPlatform: "win32", windowsKey: key });
+	const env = makeEnvironment(home, bin, { DPAPI_KEY: key.toString("base64"), DPAPI_PROTECTED: Buffer.from("protected").toString("base64"), TEMP: tmpdir(), TMP: tmpdir() });
+	delete env.LOCALAPPDATA;
+	writeWindowsDpapiCommand(bin);
+	const result = runCookies(home, env, undefined, "win32");
+	assert.equal(result.result, null);
+	assert.match(result.diagnostic, /v20 app-bound cookies are not supported/);
 	rmSync(home, { recursive: true, force: true });
 	rmSync(bin, { recursive: true, force: true });
 });


### PR DESCRIPTION
Fixes #286.

This adds opt-in Windows browser-cookie extraction for Gemini Web. Chrome and Edge profiles are discovered under `LOCALAPPDATA`, with a `USERPROFILE/AppData/Local` fallback for environments where `LOCALAPPDATA` is absent. Supported Windows `v10` cookie values decrypt through the current user DPAPI key from Chromium `Local State`; `v20` app-bound cookies are not faked and return a sanitized diagnostic.

Browser-cookie access remains disabled unless `allowBrowserCookies: true` or `PI_ALLOW_BROWSER_COOKIES=1` is set. Existing macOS/Linux behavior and authFetch redirect/host protections are unchanged.

Validation:
- `node --test test/chrome-cookie-extraction.test.mjs`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh review: no issues found on exact head `961845446ef31ddf56b3f7426bd309aefcac8e31`.

Credit: Thanks to [@laixuanthoi](https://github.com/laixuanthoi) for issue #286.