### PR TITLE
fix: update fetch_content HTTP user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Added Windows Chrome and Edge browser-cookie support for Gemini Web. Thanks to [@laixuanthoi](https://github.com/laixuanthoi) for issue #286.
 
 ### Fixed
+- Updated the local `fetch_content` HTTP User-Agent for wider compatible content retrieval.
 - Replaced inline RFC 2397 `data:` URIs in extracted page content with explicit bounded omission markers (MIME type, encoding, encoded/decoded byte counts, SHA-256 digest, `retrieval=not-retained`) before content reaches tool results, the fetch cache, or session persistence. Readable prose and Markdown image alt text are preserved; typed thumbnail/frame image blocks are unaffected. Thanks to [@bbbRye007](https://github.com/bbbRye007) for #281 and #282.
 - Detached Linux curator browser launches so `xdg-open` cannot block `web_search` until the browser exits. Thanks to [@nguyenphivn](https://github.com/nguyenphivn) for issue #279.
 - Allowed configured Firecrawl API base URLs to use loopback addresses without opening loopback for submitted fetch targets. Thanks to [@ackalker](https://github.com/ackalker) for issue #280.

--- a/extract.ts
+++ b/extract.ts
@@ -1002,7 +1002,7 @@ async function extractViaHttp(
 		const requestInit = {
 			signal: controller.signal,
 			headers: {
-				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+				"User-Agent": "OpenAI File Downloader, XaiImageApiFetch/1.0",
 				"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
 				"Accept-Language": "en-US,en;q=0.9",
 				"Cache-Control": "no-cache",

--- a/test/fetch-modes.test.mjs
+++ b/test/fetch-modes.test.mjs
@@ -8,6 +8,17 @@ after(() => { globalThis.fetch = originalFetch; });
 const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
 const png = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=", "base64");
 
+test("local HTTP fetch sends the compatible User-Agent", async () => {
+	let userAgent;
+	globalThis.fetch = async (_url, init) => {
+		userAgent = new Headers(init.headers).get("user-agent");
+		return new Response("body", { headers: { "content-type": "text/plain" } });
+	};
+
+	await extractContent("https://example.com/article", undefined, { mode: "raw", lookup });
+	assert.equal(userAgent, "OpenAI File Downloader, XaiImageApiFetch/1.0");
+});
+
 test("raw mode returns textual non-2xx bodies but rejects images", async () => {
 	globalThis.fetch = async (url) => String(url).endsWith(".png")
 		? new Response(png, { status: 200, headers: { "content-type": "image/png" } })


### PR DESCRIPTION
Updates the local fetch_content HTTP User-Agent so more public pages return readable content.

This applies only to the direct HTTP extraction path.