### PR TITLE
fix: prefer Codex search for Codex models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Prefer Codex-backed OpenAI search in `auto` mode when the active Pi model is `openai-codex`; otherwise prefer Exa before OpenAI.
+
 ## [0.24.1] - 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **Video Understanding** — Point it at a YouTube video or local screen recording and ask questions about what's on screen. Full transcripts, visual descriptions, and frame extraction at exact timestamps.
 
-**Smart Fallbacks** — Every capability has a fallback chain. Search tries configured SearXNG first for local/private search, then OpenAI when suitable and available, Exa, Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Kagi, Bocha, Ollama, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. With no SearXNG configured, the existing zero-config order is unchanged. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages try configured self-hosted Firecrawl first. Third-party hosted page fetchers require explicit `fetchRouting.allowRemoteHostedProviders` opt-in for remote HTTP(S) targets.
+**Smart Fallbacks** — Every capability has a fallback chain. Search tries configured SearXNG first for local/private search. When the active Pi model is `openai-codex`, it then tries Codex-backed OpenAI search. Otherwise it tries Exa before OpenAI, then Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Kagi, Bocha, Ollama, Perplexity, Gemini API, and Gemini Web when browser cookies are enabled. YouTube tries Gemini Web when enabled, then API, then Perplexity. Blocked pages try configured self-hosted Firecrawl first. Third-party hosted page fetchers require explicit `fetchRouting.allowRemoteHostedProviders` opt-in for remote HTTP(S) targets.
 
 **GitHub Cloning** — GitHub URLs are cloned locally instead of scraped. The agent gets real file contents and a local path to explore, not rendered HTML.
 
@@ -46,7 +46,7 @@ Works immediately with no API keys — Exa MCP provides zero-config search. If P
 }
 ```
 
-In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first for local/private search, then OpenAI when suitable and available, Exa (direct API if keyed, MCP if not), Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Perplexity, Gemini API, and Gemini Web when browser-cookie access is enabled. With no SearXNG configured, the existing zero-config order is unchanged. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model, defaulting to Claude Haiku, Codex Luna, Codex Terra, Gemini 3.6 Flash, GPT-5 mini, then DeepSeek V4 Flash when available. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
+In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first for local/private search. When the active Pi model is `openai-codex`, it then tries Codex-backed OpenAI search. Otherwise it tries Exa (direct API if keyed, MCP if not) before OpenAI, then Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Perplexity, Gemini API, and Gemini Web when browser-cookie access is enabled. Exa handles search; curator summary drafts are generated separately by the configured Pi summary model, defaulting to Claude Haiku, Codex Luna, Codex Terra, Gemini 3.6 Flash, GPT-5 mini, then DeepSeek V4 Flash when available. Slow summary drafts fall back to a deterministic result summary after a bounded deadline.
 
 If your OpenAI key belongs to a third-party Responses-compatible gateway, set `openaiResponsesUrl` to that gateway's full Responses endpoint. The default remains `https://api.openai.com/v1/responses`.
 

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -216,6 +216,24 @@ function shouldTryOpenAIInAuto(options: SearchOptions): boolean {
 	return true;
 }
 
+function isOpenAICodexSelected(ctx?: ExtensionContext): boolean {
+	return ctx?.model?.provider === "openai-codex";
+}
+
+async function tryOpenAIInAuto(query: string, options: FullSearchOptions, fallbackErrors: string[]): Promise<AttributedSearchResponse | null> {
+	if (!shouldTryOpenAIInAuto(options)) return null;
+	try {
+		if (await isOpenAISearchAvailable(options.extensionContext)) {
+			const result = await searchWithOpenAI(query, options, options.extensionContext);
+			return { ...result, provider: "openai" };
+		}
+	} catch (err) {
+		if (isAbortError(err)) throw err;
+		fallbackErrors.push(`OpenAI: ${errorMessage(err)}`);
+	}
+	return null;
+}
+
 async function searchWithGemini(
 	query: string,
 	options: SearchOptions,
@@ -524,16 +542,11 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 		}
 	}
 
-	if (shouldTryOpenAIInAuto(options)) {
-		try {
-			if (await isOpenAISearchAvailable(options.extensionContext)) {
-				const result = await searchWithOpenAI(query, options, options.extensionContext);
-				return { ...result, provider: "openai" };
-			}
-		} catch (err) {
-			if (isAbortError(err)) throw err;
-			fallbackErrors.push(`OpenAI: ${errorMessage(err)}`);
-		}
+	let triedOpenAI = false;
+	if (!options.extensionContext || isOpenAICodexSelected(options.extensionContext)) {
+		triedOpenAI = true;
+		const result = await tryOpenAIInAuto(query, options, fallbackErrors);
+		if (result) return result;
 	}
 
 	if (isExaAvailable()) {
@@ -544,6 +557,11 @@ export async function search(query: string, options: FullSearchOptions = {}): Pr
 			if (err instanceof CredentialResolutionError || isAbortError(err)) throw err;
 			fallbackErrors.push(`Exa: ${errorMessage(err)}`);
 		}
+	}
+
+	if (!triedOpenAI) {
+		const result = await tryOpenAIInAuto(query, options, fallbackErrors);
+		if (result) return result;
 	}
 
 	if (isBraveAvailable()) {

--- a/index.ts
+++ b/index.ts
@@ -152,7 +152,7 @@ interface WebSearchConfig {
 	};
 }
 
-interface ProviderAvailability {
+export interface ProviderAvailability {
 	all: boolean;
 	openai: boolean;
 	brave: boolean;
@@ -184,7 +184,7 @@ interface ProviderAvailability {
 
 type WebSearchWorkflow = "none" | "summary-review" | "auto-summary";
 type CuratorWorkflow = "summary-review";
-type CuratorProvider = Exclude<SearchProvider, "auto">;
+export type CuratorProvider = Exclude<SearchProvider, "auto">;
 type SummaryWorkflow = "summary-review" | "auto-summary";
 
 interface CuratorBootstrap {
@@ -420,13 +420,16 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 	};
 }
 
-function shouldPreferOpenAI(options?: Pick<PendingCurate, "numResults" | "recencyFilter">): boolean {
-	if (!options) return true;
-	if (options.recencyFilter) return false;
-	if (typeof options.numResults === "number" && Number.isFinite(options.numResults) && Math.floor(options.numResults) !== 5) {
+function shouldUseOpenAICodexDefault(ctx?: Pick<ExtensionContext, "model">): boolean {
+	return ctx?.model?.provider === "openai-codex";
+}
+
+function shouldPreferOpenAI(options: Pick<PendingCurate, "numResults" | "recencyFilter"> | undefined, preferOpenAICodexDefault: boolean): boolean {
+	if (options?.recencyFilter) return false;
+	if (typeof options?.numResults === "number" && Number.isFinite(options.numResults) && Math.floor(options.numResults) !== 5) {
 		return false;
 	}
-	return true;
+	return preferOpenAICodexDefault;
 }
 
 async function loadCuratorBootstrap(
@@ -439,15 +442,25 @@ async function loadCuratorBootstrap(
 	if (Array.isArray(provider)) availableProviders.all = true;
 	return {
 		availableProviders,
-		defaultProvider: resolveProvider(provider, availableProviders, options),
+		defaultProvider: resolveCuratorDefaultProvider(provider, availableProviders, ctx, options),
 		timeoutSeconds: getCuratorTimeoutSeconds(),
 	};
+}
+
+export function resolveCuratorDefaultProvider(
+	provider: SearchProviderSelection,
+	available: ProviderAvailability,
+	ctx?: Pick<ExtensionContext, "model">,
+	options?: Pick<PendingCurate, "numResults" | "recencyFilter">,
+): CuratorProvider {
+	return resolveProvider(provider, available, options, shouldUseOpenAICodexDefault(ctx));
 }
 
 function firstAvailableProvider(available: ProviderAvailability, preferOpenAI: boolean, fallback: ResolvedSearchProvider): ResolvedSearchProvider {
 	if (available.searxng) return "searxng";
 	if (preferOpenAI && available.openai) return "openai";
 	if (available.exa) return "exa";
+	if (available.openai) return "openai";
 	if (available.brave) return "brave";
 	if (available.parallel) return "parallel";
 	if (available.tinyfish) return "tinyfish";
@@ -470,9 +483,10 @@ function resolveProvider(
 	provider: SearchProviderSelection,
 	available: ProviderAvailability,
 	options?: Pick<PendingCurate, "numResults" | "recencyFilter">,
+	preferOpenAICodexDefault = false,
 ): CuratorProvider {
 	if (Array.isArray(provider)) return "all";
-	const preferOpenAI = shouldPreferOpenAI(options);
+	const preferOpenAI = shouldPreferOpenAI(options, preferOpenAICodexDefault);
 
 	if (provider === "auto") {
 		const routing = getConfiguredSearchRouting();
@@ -1660,7 +1674,7 @@ export default function (pi: ExtensionAPI) {
 		name: toolNames.webSearch,
 		label: "Web Search",
 		description:
-			`Search the web using OpenAI, Brave, Parallel, Parallel MCP, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Kagi, Bocha, Ollama, SearXNG, DuckDuckGo, Exa, Perplexity, Gemini, AnySearch, Valyu, xAI, Bright Data, SerpBase, or Serper. Pass a provider array to search only those providers simultaneously, or use provider "all" to search every eligible provider except Parallel MCP, DuckDuckGo, AnySearch, Valyu, xAI, Bright Data, SerpBase, and Serper. Returns an AI-synthesized answer with source citations. OpenAI search uses a Codex subscription or OpenAI API key; xAI search uses a SuperGrok/X Premium subscription or xAI API key. Parallel MCP, DuckDuckGo, AnySearch, Valyu, xAI, Bright Data, SerpBase, and Serper are available only when explicitly selected. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation or "auto-summary" for a model-generated summary without the browser curator. The configured provider is used when provider is omitted or set to auto; omit provider unless explicitly overriding it. Without a configured provider, auto-selects OpenAI when suitable and available, then Exa, Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Kagi, Bocha, Ollama, Perplexity, Gemini API, or Gemini Web. When SearXNG is configured, it is preferred first for local/private search.`,
+			`Search the web using OpenAI, Brave, Parallel, Parallel MCP, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Kagi, Bocha, Ollama, SearXNG, DuckDuckGo, Exa, Perplexity, Gemini, AnySearch, Valyu, xAI, Bright Data, SerpBase, or Serper. Pass a provider array to search only those providers simultaneously, or use provider "all" to search every eligible provider except Parallel MCP, DuckDuckGo, AnySearch, Valyu, xAI, Bright Data, SerpBase, and Serper. Returns an AI-synthesized answer with source citations. OpenAI search uses a Codex subscription or OpenAI API key; xAI search uses a SuperGrok/X Premium subscription or xAI API key. Parallel MCP, DuckDuckGo, AnySearch, Valyu, xAI, Bright Data, SerpBase, and Serper are available only when explicitly selected. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation or "auto-summary" for a model-generated summary without the browser curator. The configured provider is used when provider is omitted or set to auto; omit provider unless explicitly overriding it. Without a configured provider, SearXNG is preferred first for local/private search. When the active Pi model is openai-codex, Codex-backed OpenAI search is preferred next. Otherwise Exa is preferred before OpenAI, then Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Kagi, Bocha, Ollama, Perplexity, Gemini API, or Gemini Web.`,
 		promptSnippet:
 			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage. Omit provider unless explicitly overriding the configured default.",
 		parameters: Type.Object({

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -12,6 +12,7 @@ const perplexityModuleUrl = new URL("../perplexity.ts", import.meta.url).href;
 const tavilyModuleUrl = new URL("../tavily.ts", import.meta.url).href;
 const searxngModuleUrl = new URL("../searxng.ts", import.meta.url).href;
 const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
+const indexModuleUrl = new URL("../index.ts", import.meta.url).href;
 
 function runChild(script, env) {
 	const childEnv = { ...process.env };
@@ -908,6 +909,120 @@ test("OpenAI search uses configured Responses endpoint", async () => {
 	assert.equal(output.capturedUrl, "https://gateway.example.com/v1/responses");
 	assert.equal(output.capturedAuthorization, "Bearer sk-config-key");
 	assert.equal(output.answer, "gateway answer");
+});
+
+test("curator auto default follows the active model provider", async () => {
+	const { resolveCuratorDefaultProvider } = await import(indexModuleUrl);
+	const available = {
+		all: true,
+		openai: true,
+		brave: false,
+		parallel: false,
+		"parallel-mcp": false,
+		tinyfish: false,
+		search1api: false,
+		searchinfinity: false,
+		querit: false,
+		tavily: false,
+		firecrawl: false,
+		jina: false,
+		serpdive: false,
+		searxng: false,
+		duckduckgo: false,
+		perplexity: false,
+		exa: true,
+		gemini: false,
+		kagi: false,
+		bocha: false,
+		ollama: false,
+		anysearch: false,
+		xai: false,
+		brightdata: false,
+		serpbase: false,
+		serper: false,
+		valyu: false,
+	};
+
+	assert.equal(resolveCuratorDefaultProvider("auto", available, { model: { provider: "openai-codex" } }), "openai");
+	assert.equal(resolveCuratorDefaultProvider("auto", available, { model: { provider: "openai" } }), "exa");
+	assert.equal(resolveCuratorDefaultProvider("auto", { ...available, exa: false }, { model: { provider: "openai" } }), "openai");
+});
+
+test("auto search prefers Codex-backed OpenAI search when the selected model is openai-codex", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-auto-codex-selected-"));
+	const child = runChild(`
+		let capturedUrl = "";
+		globalThis.fetch = async (url) => {
+			capturedUrl = String(url);
+			if (capturedUrl !== "https://chatgpt.com/backend-api/codex/responses") {
+				throw new Error("Expected Codex search first, got " + capturedUrl);
+			}
+			return new Response(JSON.stringify({
+				output: [{ type: "message", content: [{ type: "output_text", text: "codex search answer" }] }],
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+
+		const ctx = {
+			model: { provider: "openai-codex", id: "gpt-5.6-terra" },
+			modelRegistry: {
+				getAll: () => [{ provider: "openai-codex", id: "gpt-5.6-terra" }],
+				getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "codex-token", headers: {} }),
+			},
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("current model search", { provider: "auto", extensionContext: ctx });
+		console.log(JSON.stringify({ provider: result.provider, answer: result.answer, capturedUrl }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.provider, "openai");
+	assert.equal(output.answer, "codex search answer");
+	assert.equal(output.capturedUrl, "https://chatgpt.com/backend-api/codex/responses");
+});
+
+test("auto search uses Exa before OpenAI when the selected model is not openai-codex", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-auto-non-codex-selected-"));
+	const child = runChild(`
+		let capturedUrl = "";
+		globalThis.fetch = async (url) => {
+			capturedUrl = String(url);
+			if (capturedUrl.startsWith("https://api.openai.com/") || capturedUrl.startsWith("https://chatgpt.com/")) {
+				throw new Error("OpenAI must not run before Exa for a non-Codex selected model");
+			}
+			if (!capturedUrl.startsWith("https://mcp.exa.ai/mcp")) throw new Error("Unexpected fetch " + capturedUrl);
+			const event = { result: { content: [{ type: "text", text: "Title: Exa Source\\nURL: https://exa.example/source\\nText: Exa selected first" }] } };
+			return new Response("data: " + JSON.stringify(event) + "\\n\\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		};
+
+		const ctx = {
+			model: { provider: "openai", id: "gpt-5.6-terra" },
+			modelRegistry: {
+				getAll: () => [{ provider: "openai-codex", id: "gpt-5.6-terra" }],
+				getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "codex-token", headers: {} }),
+			},
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("current model search", { provider: "auto", extensionContext: ctx });
+		console.log(JSON.stringify({ provider: result.provider, answer: result.answer, capturedUrl }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.provider, "exa");
+	assert.match(output.answer, /Exa selected first/);
+	assert.match(output.capturedUrl, /^https:\/\/mcp\.exa\.ai\/mcp/);
 });
 
 test("OpenAI search falls back to API key when model registry cannot enumerate", async () => {


### PR DESCRIPTION
## Summary

This changes `web_search` auto routing so Codex-backed OpenAI search is preferred when the active Pi model provider is `openai-codex`. Otherwise, Exa remains ahead of OpenAI, with OpenAI still available as fallback after Exa. The curator default provider follows the same rule.

## Validation

- `node --test test/search-providers.test.mjs test/provider-precedence.test.mjs test/search-routing.test.mjs`
- `npm run typecheck`
- `npm test`
- Fresh review found one curator fallback blocker, fixed in this PR.
- Targeted follow-up review found no issues.