### PR TITLE
fix: repair Windows cookie extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Prefer Codex-backed OpenAI search in `auto` mode when the active Pi model is `openai-codex`; otherwise prefer Exa before OpenAI.
 
+### Fixed
+- Fixed Windows Chromium cookie extraction for large cookie expiry timestamps and DPAPI key unprotect calls. Thanks to [@laixuanthoi](https://github.com/laixuanthoi) for issue #290.
+
 ## [0.24.1] - 2026-08-21
 
 ### Added

--- a/chrome-cookies.ts
+++ b/chrome-cookies.ts
@@ -375,8 +375,9 @@ async function readWindowsEncryptionKey(config: BrowserConfig, home: string): Pr
 
 function unprotectWindowsData(protectedData: Buffer): Promise<Buffer | null> {
 	return new Promise((resolve) => {
-		const script = "$data=[Convert]::FromBase64String($args[0]);$clear=[Security.Cryptography.ProtectedData]::Unprotect($data,$null,[Security.Cryptography.DataProtectionScope]::CurrentUser);[Console]::Write([Convert]::ToBase64String($clear))";
-		execFile("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script, protectedData.toString("base64")], { timeout: 5000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
+		const script = "Add-Type -AssemblyName System.Security;$data=[Convert]::FromBase64String($env:PIWA_PROTECTED);$clear=[System.Security.Cryptography.ProtectedData]::Unprotect($data,$null,[System.Security.Cryptography.DataProtectionScope]::CurrentUser);[Console]::Write([Convert]::ToBase64String($clear))";
+		const encoded = Buffer.from(script, "utf16le").toString("base64");
+		execFile("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded], { timeout: 5000, maxBuffer: 1024 * 1024, env: { ...process.env, PIWA_PROTECTED: protectedData.toString("base64") } }, (err, stdout) => {
 			if (err) { resolve(null); return; }
 			try {
 				resolve(Buffer.from(stdout.trim(), "base64"));
@@ -509,10 +510,10 @@ async function queryCookieRows(dbPath: string, hosts: string[], names: Iterable<
 	const columns = await readCookieColumns(dbPath);
 	if (columns.status === "failure") return columns;
 	const pathExpr = columns.columns.has("path") ? "path" : "'/' AS path";
-	const expiresExpr = columns.columns.has("expires_utc") ? "expires_utc" : "0 AS expires_utc";
-	const expiryFilter = filterExpired && columns.columns.has("expires_utc") ? ` AND (expires_utc = 0 OR expires_utc > ${chromeExpiryNowMicros()})` : "";
+	const expiresExpr = columns.columns.has("expires_utc") ? chromeExpiryMillisExpr() : "0";
+	const expiryFilter = filterExpired && columns.columns.has("expires_utc") ? ` AND (${expiresExpr} = 0 OR ${expiresExpr} > ${chromeExpiryNowMillis()})` : "";
 	const partitionFilter = filterExpired ? unpartitionedCookieFilter(columns.columns) : "";
-	return runSqliteQuery(dbPath, `SELECT name, value, host_key, ${pathExpr}, ${expiresExpr}, hex(encrypted_value) AS encrypted_value_hex FROM cookies WHERE ${buildCookieWhere(hosts, names ?? undefined)}${expiryFilter}${partitionFilter} ORDER BY length(path) DESC, expires_utc ASC`);
+	return runSqliteQuery(dbPath, `SELECT name, value, host_key, ${pathExpr}, ${expiresExpr} AS expires_utc, hex(encrypted_value) AS encrypted_value_hex FROM cookies WHERE ${buildCookieWhere(hosts, names ?? undefined)}${expiryFilter}${partitionFilter} ORDER BY length(path) DESC, ${expiresExpr} ASC`);
 }
 
 async function readCookieColumns(dbPath: string): Promise<{ status: "success"; columns: Set<string> } | { status: "failure"; failure: SqliteFailure }> {
@@ -521,8 +522,12 @@ async function readCookieColumns(dbPath: string): Promise<{ status: "success"; c
 	return { status: "success", columns: new Set(result.rows.map(row => typeof row.name === "string" ? row.name : "")) };
 }
 
-function chromeExpiryNowMicros(): number {
-	return (Date.now() + 11644473600000) * 1000;
+function chromeExpiryMillisExpr(): string {
+	return "CASE WHEN expires_utc = 0 THEN 0 ELSE CAST(expires_utc / 1000 AS INTEGER) + CASE WHEN expires_utc % 1000 = 0 THEN 0 ELSE 1 END END";
+}
+
+function chromeExpiryNowMillis(): number {
+	return Date.now() + 11644473600000;
 }
 
 function unpartitionedCookieFilter(columns: Set<string>): string {

--- a/test/chrome-cookie-extraction.test.mjs
+++ b/test/chrome-cookie-extraction.test.mjs
@@ -47,10 +47,11 @@ function encryptWindowsCookie(value, key, version = "v10", hostKey) {
 	return Buffer.concat([Buffer.from(version), nonce, cipher.update(plaintext), cipher.final(), cipher.getAuthTag()]).toString("hex");
 }
 
-function writeWindowsDpapiCommand(bin) {
-	const script = "#!/bin/sh\nlast=\nfor arg do last=$arg; done\n[ \"$last\" = \"$DPAPI_PROTECTED\" ] || exit 1\nprintf '%s' \"$DPAPI_KEY\"\n";
+function writeWindowsDpapiCommand(bin, argsPath) {
+	const script = "#!/bin/sh\n[ -n \"$ARGS_FILE\" ] && printf '%s\\n' \"$@\" > \"$ARGS_FILE\"\nencoded=0\nfor arg do [ \"$arg\" = \"-EncodedCommand\" ] && encoded=1; [ \"$arg\" = \"$DPAPI_PROTECTED\" ] && exit 1; done\n[ \"$encoded\" = 1 ] || exit 1\n[ \"$PIWA_PROTECTED\" = \"$DPAPI_PROTECTED\" ] || exit 1\nprintf '%s' \"$DPAPI_KEY\"\n";
 	writeFileSync(join(bin, "powershell.exe"), script);
 	chmodSync(join(bin, "powershell.exe"), 0o755);
+	return argsPath ? { ARGS_FILE: argsPath } : {};
 }
 
 function makeEnvironment(home, bin, extra = {}) {
@@ -84,13 +85,17 @@ function writeFailThenSucceedPasswordCommand(bin, countPath) {
 }
 
 function runCookies(home, env, options = "{ requiredCookies: ['__Secure-1PSID', '__Secure-1PSIDTS'] }", platformOverride) {
+	return runCookieScript(env, `const r = await m.getGoogleCookies(${options}); console.log(JSON.stringify({ result: r, diagnostic: m.getLastGoogleCookieDiagnostic() }));`, platformOverride);
+}
+
+function runCookieScript(env, body, platformOverride) {
 	const override = platformOverride
 		? `Object.defineProperty(process, "platform", { value: ${JSON.stringify(platformOverride)} }); `
 		: "";
 	const child = spawnSync(process.execPath, ["--experimental-strip-types", "--input-type=module"], {
 		encoding: "utf8",
 		env,
-		input: `${override}const m = await import(${JSON.stringify(moduleUrl)}); const r = await m.getGoogleCookies(${options}); console.log(JSON.stringify({ result: r, diagnostic: m.getLastGoogleCookieDiagnostic() }));`,
+		input: `${override}const m = await import(${JSON.stringify(moduleUrl)}); ${body}`,
 	});
 	assert.equal(child.status, 0, child.stderr);
 	return JSON.parse(child.stdout);
@@ -154,15 +159,54 @@ test("Windows Chrome profiles decrypt v10 cookies with DPAPI keys", (t) => {
 	skipWithoutPython(t);
 	const home = mkdtempSync(join(tmpdir(), "pi-cookie-windows-"));
 	const bin = mkdtempSync(join(tmpdir(), "pi-cookie-bin-"));
+	const argsPath = join(home, "powershell-args");
 	const key = Buffer.alloc(32, 3);
 	createFixture(home, "Default", [
 		["__Secure-1PSID", "", ".google.com", `hex:${encryptWindowsCookie("one", key, "v10", ".google.com")}`, 1],
 		["__Secure-1PSIDTS", "", ".google.com", `hex:${encryptWindowsCookie("two", key, "v10", ".google.com")}`, 2],
 	], { targetPlatform: "win32", windowsKey: key });
-	const env = makeEnvironment(home, bin, { LOCALAPPDATA: join(home, "AppData", "Local"), DPAPI_KEY: key.toString("base64"), DPAPI_PROTECTED: Buffer.from("protected").toString("base64"), TEMP: tmpdir(), TMP: tmpdir() });
-	writeWindowsDpapiCommand(bin);
+	const protectedValue = Buffer.from("protected").toString("base64");
+	const env = makeEnvironment(home, bin, { LOCALAPPDATA: join(home, "AppData", "Local"), DPAPI_KEY: key.toString("base64"), DPAPI_PROTECTED: protectedValue, TEMP: tmpdir(), TMP: tmpdir(), ...writeWindowsDpapiCommand(bin, argsPath) });
 	const result = runCookies(home, env, undefined, "win32");
 	assert.deepEqual(result.result.cookies, { "__Secure-1PSIDTS": "two", "__Secure-1PSID": "one" });
+	const args = readFileSync(argsPath, "utf8").trim().split("\n");
+	assert.equal(args.includes("-EncodedCommand"), true);
+	assert.equal(args.includes(protectedValue), false);
+	rmSync(home, { recursive: true, force: true });
+	rmSync(bin, { recursive: true, force: true });
+});
+
+test("cookie queries keep high Chromium expiry values safe", (t) => {
+	skipWithoutPython(t);
+	const home = mkdtempSync(join(tmpdir(), "pi-cookie-high-expiry-"));
+	const bin = mkdtempSync(join(tmpdir(), "pi-cookie-bin-"));
+	createFixture(home, "Profile 2", [
+		["__Secure-1PSID", "expired", ".google.com", null, 1],
+		["__Secure-1PSID", "future", ".google.com", null, "9223372036854775807"],
+		["__Secure-1PSIDTS", "session", ".google.com", null, 0],
+	]);
+	const env = makeEnvironment(home, bin);
+	Object.assign(env, writePasswordCommand(bin, join(home, "password-count")));
+	const result = runCookieScript(env, "const r = await m.getBrowserCookiesForHosts({ hosts: ['www.google.com'], requestUrl: new URL('https://www.google.com/'), requiredCookies: ['__Secure-1PSID', '__Secure-1PSIDTS'] }); console.log(JSON.stringify({ result: r, diagnostic: m.getLastBrowserCookieDiagnostic() }));");
+	assert.deepEqual(result.result.cookies, { "__Secure-1PSID": "future", "__Secure-1PSIDTS": "session" });
+	rmSync(home, { recursive: true, force: true });
+	rmSync(bin, { recursive: true, force: true });
+});
+
+test("cookie expiry filtering preserves same-second validity", (t) => {
+	skipWithoutPython(t);
+	const home = mkdtempSync(join(tmpdir(), "pi-cookie-subsecond-expiry-"));
+	const bin = mkdtempSync(join(tmpdir(), "pi-cookie-bin-"));
+	const nowMs = 1_700_000_000_500;
+	const sameSecondFutureChromeMicros = (nowMs + 400 + 11644473600000) * 1000;
+	createFixture(home, "Profile 2", [
+		["__Secure-1PSID", "future", ".google.com", null, sameSecondFutureChromeMicros],
+		["__Secure-1PSIDTS", "session", ".google.com", null, 0],
+	]);
+	const env = makeEnvironment(home, bin);
+	Object.assign(env, writePasswordCommand(bin, join(home, "password-count")));
+	const result = runCookieScript(env, `Date.now = () => ${nowMs}; const r = await m.getBrowserCookiesForHosts({ hosts: ['www.google.com'], requestUrl: new URL('https://www.google.com/'), requiredCookies: ['__Secure-1PSID', '__Secure-1PSIDTS'] }); console.log(JSON.stringify({ result: r, diagnostic: m.getLastBrowserCookieDiagnostic() }));`);
+	assert.deepEqual(result.result.cookies, { "__Secure-1PSID": "future", "__Secure-1PSIDTS": "session" });
 	rmSync(home, { recursive: true, force: true });
 	rmSync(bin, { recursive: true, force: true });
 });


### PR DESCRIPTION
Fixes #290.

This fixes the Windows Gemini Web cookie extraction path by projecting Chromium cookie expiry values to safe Unix seconds before Node reads them, and by switching the Windows DPAPI unwrap call to PowerShell `-EncodedCommand` with the protected blob passed through the environment.

Validation:
- `node --test test/chrome-cookie-extraction.test.mjs`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh review: No issues found.
