### PR TITLE
fix(get_search_content): tolerate bridge defaults with findText

### DIFF
--- a/get-search-content-params.ts
+++ b/get-search-content-params.ts
@@ -1,0 +1,26 @@
+export interface GetSearchContentParams {
+	responseId: string;
+	query?: string;
+	queryIndex?: number;
+	url?: string;
+	urlIndex?: number;
+	offset?: number;
+	limit?: number;
+	findText?: string | string[];
+	findMode?: string;
+}
+
+export function normalizeGetSearchContentParams(params: GetSearchContentParams): GetSearchContentParams {
+	// Tool bridges may serialize optional selectors and slice defaults even when unset.
+	const normalized = { ...params };
+
+	if (normalized.query?.trim() === "") delete normalized.query;
+	if (normalized.url?.trim() === "") delete normalized.url;
+
+	if (normalized.findText !== undefined) {
+		delete normalized.offset;
+		delete normalized.limit;
+	}
+
+	return normalized;
+}

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import { Type } from "typebox";
 import { StringEnum, type ImageContent, type TextContent } from "@earendil-works/pi-ai/compat";
 import type { ExtractedContent, ExtractOptions } from "./extract.ts";
 import { normalizeFetchContentParams } from "./fetch-params.ts";
+import { normalizeGetSearchContentParams } from "./get-search-content-params.ts";
 import { resolveAuthFetchProfile, type AuthFetchProfile } from "./auth-fetch.ts";
 import { findContent, type FindMode } from "./content-find.ts";
 import { answerFromPage } from "./page-query.ts";
@@ -2689,24 +2690,17 @@ export default function (pi: ExtensionAPI) {
 			queryIndex: Type.Optional(Type.Integer({ minimum: 0, description: "Get content for query at index" })),
 			url: Type.Optional(Type.String({ description: "Get content for this URL" })),
 			urlIndex: Type.Optional(Type.Integer({ minimum: 0, description: "Get content for URL at index" })),
-			offset: Type.Optional(Type.Integer({ minimum: 0, description: "Character offset for fetched URL content slices (default 0). Cannot be combined with findText." })),
-			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: maxInlineContentChars, description: "Maximum characters to return for fetched URL content slices (default and max are set by maxInlineContentChars). Cannot be combined with findText." })),
+			offset: Type.Optional(Type.Integer({ minimum: 0, description: "Character offset for fetched URL content slices (default 0). Ignored when findText is supplied." })),
+			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: maxInlineContentChars, description: "Maximum characters to return for fetched URL content slices (default and max are set by maxInlineContentChars). Ignored when findText is supplied." })),
 			findText: Type.Optional(Type.Union([
 				Type.String({ minLength: 1, maxLength: 500 }),
 				Type.Array(Type.String({ minLength: 1, maxLength: 500 }), { minItems: 1, maxItems: 10 }),
-			], { description: "Text or texts to find in the selected stored content. Cannot be combined with offset or limit." })),
+			], { description: "Text or texts to find in the selected stored content. When supplied, offset and limit are ignored." })),
 			findMode: Type.Optional(StringEnum(["exact", "case-insensitive", "fuzzy"], { description: "Matching mode for findText (default: case-insensitive). Requires findText." })),
 		}),
 
 		async execute(_toolCallId, params): Promise<AgentToolResult<Record<string, unknown>>> {
-			if (params.findText !== undefined && (params.offset !== undefined || params.limit !== undefined)) {
-				const offset = formatInputValue(params.offset);
-				const limit = formatInputValue(params.limit);
-				return {
-					content: [{ type: "text", text: `findText cannot be combined with offset or limit. Received offset=${offset}, limit=${limit}; omit offset and limit when using findText.` }],
-					details: { error: "Incompatible find options" },
-				};
-			}
+			params = normalizeGetSearchContentParams(params);
 			if (params.findMode !== undefined && params.findText === undefined) {
 				return {
 					content: [{ type: "text", text: `findMode ${formatInputValue(params.findMode)} requires findText; provide findText or omit findMode.` }],

--- a/test/get-search-content.test.mjs
+++ b/test/get-search-content.test.mjs
@@ -34,6 +34,24 @@ function storeFetchedContent(content) {
 	});
 }
 
+function storeSearchContent() {
+	storeResult("search-result", {
+		id: "search-result",
+		type: "search",
+		timestamp: Date.now(),
+		queries: [{
+			query: "CotEditor scripts",
+			answer: "",
+			results: [
+				{ title: "ScriptManager.swift", url: "https://example.com/script-manager", snippet: "UNIX script support" },
+				{ title: "UNIX script", url: "https://example.com/unix-script", snippet: "Script support" },
+				{ title: "ScriptMenu", url: "https://example.com/script-menu", snippet: "Menu integration" },
+			],
+			error: null,
+		}],
+	});
+}
+
 test("get_search_content schemas constrain numeric parameters", () => {
 	const properties = getContentTool().parameters.properties;
 
@@ -114,10 +132,6 @@ test("get_search_content rejects unsafe fetched content ranges", async () => {
 	assert.match(outOfRange.content[0].text, /Received offset 99/);
 	assert.match(outOfRange.content[0].text, /valid range is 0-13/);
 
-	const incompatible = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, findText: "content", offset: 1 });
-	assert.equal(incompatible.details.error, "Incompatible find options");
-	assert.match(incompatible.content[0].text, /Received offset=1, limit=undefined/);
-
 	const missingFindText = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, findMode: "fuzzy" });
 	assert.equal(missingFindText.details.error, "findMode requires findText");
 	assert.match(missingFindText.content[0].text, /findMode "fuzzy" requires findText/);
@@ -134,6 +148,28 @@ test("get_search_content rejects unsafe fetched content ranges", async () => {
 	assert.equal(researchOutOfRange.details.error, "Offset out of range");
 	assert.match(researchOutOfRange.content[0].text, /responseId "stored-research"/);
 	assert.match(researchOutOfRange.content[0].text, /valid range is 0-/);
+});
+
+test("get_search_content normalizes bridge defaults for search matches", async () => {
+	const tool = getContentTool();
+	storeSearchContent();
+
+	const result = await tool.execute("call", {
+		responseId: "search-result",
+		query: "",
+		queryIndex: 0,
+		url: "",
+		urlIndex: 0,
+		offset: 0,
+		limit: 10_000,
+		findText: ["ScriptManager.swift", "UNIX script", "ScriptMenu"],
+		findMode: "case-insensitive",
+	});
+
+	assert.equal(result.details.findMode, "case-insensitive");
+	assert.equal(result.details.matchCount, 3);
+	assert.match(result.content[0].text, /ScriptManager\.swift/);
+	assert.match(result.content[0].text, /ScriptMenu/);
 });
 
 test("get_search_content returns small fetched content without continuation noise", async () => {
@@ -155,7 +191,12 @@ test("get_search_content finds bounded passages in stored fetched content", asyn
 
 	const result = await tool.execute("call", {
 		responseId: "large-fetch",
+		query: "",
+		queryIndex: 0,
+		url: "",
 		urlIndex: 0,
+		offset: 0,
+		limit: 10_000,
 		findText: "installation",
 	});
 


### PR DESCRIPTION
## Summary

Make `get_search_content` tolerate default fields injected by tool-call bridges when using `findText`.

## Problem

When an agent requests text matching from stored search or fetch content, the tool-call bridge may include:

- `offset: 0`
- `limit: 1`, `10000`, or `20000`
- `query: ""`
- `url: ""`

The current implementation rejects `findText` whenever `offset` or `limit` is present. Empty selectors can also take precedence over `queryIndex` or `urlIndex`.

As a result, valid stored content cannot be searched and the agent may repeatedly retry the same invalid call.

## Root Cause

The tool schema marks `offset`, `limit`, `query`, and `url` as optional, but the caller may serialize them as empty or default values. The runtime treats those fields as intentional input instead of normalizing bridge defaults.

## Changes

- Normalize empty `query` and `url` to `undefined`.
- Give `findText` precedence over `offset` and `limit`.
- Ignore `offset` and `limit` when `findText` is present.
- Preserve existing pagination behavior when `findText` is absent.
- Update the tool schema descriptions to document this behavior.
- Add regression coverage for polluted search and fetch calls.

## Compatibility

- Existing `get_search_content` slice requests continue to use `offset` and `limit`.
- Existing `queryIndex` and `urlIndex` requests continue to work when the corresponding selector string is empty.
- Calls that provide `findText` together with `offset` or `limit` now return matching passages instead of an incompatibility error.

## Validation

Focused regression test:

```bash
node --experimental-strip-types --test test/get-search-content.test.mjs
```

Result:

```text
7 pass 0 fail
```

Type check:

```bash
npm run typecheck
```

Result: passed.

Also verified the registered tool with local search and fetch fixtures:

- `findText` search result lookup: passed
- `findText` fetched-content lookup: passed
- polluted empty-selector and pagination defaults: passed
- normal paginated slice lookup: passed

The full local suite was also run with `NODE_OPTIONS=--experimental-strip-types`: `504 pass / 16 fail`. The remaining failures are environment-dependent existing tests involving browser-cookie fixtures, temporary process fixtures, package-install network access, and Node child-process loading under the local Node `22.17.0` runtime.

## Risks

`offset` and `limit` are ignored when `findText` is present. This avoids ambiguity because matching mode returns bounded matching passages rather than a positional content slice.

## References

- PR #233: document `get_search_content` parameter constraints
- PR #251: numeric parameter validation
- PR #205: fix the related `fetch (no URL)` display issue
