### PR TITLE
feat: specialize GitHub PR and issue fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Auto-specialize GitHub pull request and issue URLs in `fetch_content`, with `gh`-first metadata, bounded REST fallback, comment-anchor inclusion, truncation markers, and the `githubPrIssue.enabled` opt-out (#294).
+
 ### Fixed
 - Improved Gemini Web browser-cookie diagnostics so `/google-account` shows sanitized attempted browser/profile entries and distinguishes missing required cookies, password-store access, and decryption failures. Thanks to [@lmilojevicc](https://github.com/lmilojevicc) for issue #296.
 

--- a/README.md
+++ b/README.md
@@ -123,12 +123,13 @@ web_search({ queries: ["query 1", "query 2"], workflow: "auto-summary" })
 
 ### fetch_content
 
-Fetch URL(s) as readable markdown, exact textual HTTP bodies, direct images, or page-grounded answers. Automatically detects and handles GitHub repos, YouTube videos, PDFs, local video files, images, and regular web pages.
+Fetch URL(s) as readable markdown, exact textual HTTP bodies, direct images, or page-grounded answers. Automatically detects and handles GitHub repos, GitHub PRs and issues, YouTube videos, PDFs, local video files, images, and regular web pages.
 
 ```typescript
 fetch_content({ url: "https://example.com/article" })
 fetch_content({ urls: ["url1", "url2", "url3"] })
 fetch_content({ url: "https://github.com/owner/repo" })
+fetch_content({ url: "https://github.com/owner/repo/pull/123#discussion_r456" })
 fetch_content({ url: "https://youtube.com/watch?v=abc", prompt: "What libraries are shown?" })
 fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on screen?" })
 fetch_content({ url: "https://youtube.com/watch?v=abc", timestamp: "23:41-25:00", frames: 4 })
@@ -185,6 +186,10 @@ The artifact includes `supported`, `contradicted`, `unclear`, or `missing-eviden
 GitHub URLs are cloned locally instead of scraped. The agent gets real file contents and a local path to explore with `read` and `bash`. Root URLs return the repo tree + README, `/tree/` paths return directory listings, `/blob/` paths return file contents.
 
 Repos over 350MB get a lightweight API-based view instead of a full clone (override with `forceClone: true`). Commit SHA URLs are handled via the API. Clones are cached for the session and wiped on session change. Private repos require the `gh` CLI. Set `githubClone.enabled` to `false` to skip this GitHub-specific clone/API handling; `fetch_content` remains available, so the URL can continue through the normal HTTP extraction path.
+
+Pull request and issue URLs are rendered as one priority-ordered markdown document instead of scraped HTML. PR views include status, body, checks when `gh` supports them, review verdicts, linked references, files, commits, conversation comments, review thread comments, truncation markers, and escalation commands. Issue views include state, metadata, body, linked closing PRs when available, and comments. Comment anchors such as `#issuecomment-...` and `#discussion_r...` are forced inline. The full rendered document is stored for `get_search_content` offsets and `findText`.
+
+`fetch_content` uses `gh pr view` or `gh issue view` first with prompts disabled. It retries with a smaller field set when an older `gh` does not know a requested field. Public unauthenticated REST is used as a bounded fallback under the same `fetchContent.domainPolicy` and SSRF rules; REST cannot include checks. Set `githubPrIssue.enabled` to `false` to skip PR/issue specialization and keep normal HTTP extraction.
 
 ### YouTube videos
 
@@ -400,6 +405,9 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
     "maxRepoSizeMB": 350,
     "cloneTimeoutSeconds": 30,
     "clonePath": "/tmp/pi-github-repos"
+  },
+  "githubPrIssue": {
+    "enabled": true
   },
   "youtube": {
     "enabled": true,
@@ -809,7 +817,7 @@ Both shortcuts are configurable via `~/.pi/web-search.json`:
 
 Values use the same format as pi keybindings (e.g. `ctrl+s`, `ctrl+shift+s`, `alt+r`). Changes take effect on next pi restart.
 
-Set `"enabled": false` under `tools`, `commands`, `image`, or `pdf` to disable that feature. Tool-specific settings override the legacy `webSearch.enabled` shorthand; without an override, it still disables `web_search` and `source_check`. `image.enabled: false` blocks direct image fetches and video frame extraction, and prevents video thumbnails. `pdf.enabled: false` blocks PDF extraction. For GitHub specifically, `githubClone.enabled: false` only skips clone/API specialization; it does not unregister `fetch_content` or block generic URL extraction. Pi restart is required for tool and command registration changes.
+Set `"enabled": false` under `tools`, `commands`, `image`, or `pdf` to disable that feature. Tool-specific settings override the legacy `webSearch.enabled` shorthand; without an override, it still disables `web_search` and `source_check`. `image.enabled: false` blocks direct image fetches and video frame extraction, and prevents video thumbnails. `pdf.enabled: false` blocks PDF extraction. For GitHub specifically, `githubClone.enabled: false` only skips clone/API specialization, and `githubPrIssue.enabled: false` only skips PR/issue specialization; neither setting unregisters `fetch_content` or blocks generic URL extraction. Pi restart is required for tool and command registration changes.
 
 Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Search, TinyFish, Search1API, and Searchinfinity apply the plan limits documented by their APIs. Querit Search and Contents subscriptions are independent. Content fetches run 3 concurrent with a 30s timeout for the direct HTTP fetch of each URL. Remote extraction fallbacks carry their own budgets and are not covered by that number: Jina Reader 30s, Firecrawl 60s, Kagi Extract 60s, Ollama Web Fetch 60s, Bright Data Web Unlocker 60s, TinyFish up to 150s, Gemini 120s, Datalab 120s (capped at 300s, rate-limited to 25 requests/minute on the free tier). `pdf.maxSizeMB` defaults to 20 and is capped at 50. `pdf.maxPages` defaults to 100 and limits every PDF provider to the first N pages.
 
@@ -821,7 +829,7 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Sear
 - Gemini can process videos up to ~1 hour; longer videos may be truncated.
 - PDFs are text-extracted only (no OCR for scanned documents).
 - GitHub branch names with slashes may misresolve file paths; the clone still works and the agent can navigate manually.
-- Non-code GitHub URLs (issues, PRs, wiki) fall through to normal web extraction.
+- GitHub wiki, discussion, and other non-code pages still fall through to normal web extraction. PR review-thread resolution state is unknown in the specialized PR view, and REST fallback omits checks.
 
 <details>
 <summary>Files</summary>
@@ -868,6 +876,7 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Sear
 | `video-extract.ts` | Local video detection, Files API upload, Gemini analysis |
 | `github-extract.ts` | GitHub URL parsing, clone cache, content generation |
 | `github-api.ts` | GitHub API fallback for large repos and commit SHAs |
+| `github-issue-pr.ts` | GitHub PR and issue URL parsing, gh/REST fetch, markdown rendering |
 | `perplexity.ts` | Perplexity API client with rate limiting |
 | `datalab-pdf-extract.ts` | Datalab hosted PDF-to-Markdown conversion client (upload → convert → poll) |
 | `pdf-extract.ts` | PDF text extraction, saves to markdown |

--- a/extract.ts
+++ b/extract.ts
@@ -8,6 +8,7 @@ import { activityMonitor } from "./activity.ts";
 import { extractRSCContent } from "./rsc-extract.ts";
 import { extractPDFToMarkdown, isPDF, loadPDFConfig } from "./pdf-extract.ts";
 import { extractGitHub } from "./github-extract.ts";
+import { extractGitHubIssuePr } from "./github-issue-pr.ts";
 import { isYouTubeURL, isYouTubeEnabled, extractYouTube, extractYouTubeFrame, extractYouTubeFrames, getYouTubeStreamInfo } from "./youtube-extract.ts";
 import { CredentialResolutionError } from "./credential-source.ts";
 import { extractWithUrlContext, extractWithGeminiWeb } from "./gemini-url-context.ts";
@@ -583,6 +584,18 @@ export async function extractContent(
 		if (!remoteUrl) new URL(url);
 	} catch (err) {
 		return { url, title: "", content: "", error: errorMessage(err) };
+	}
+
+	try {
+		const ghIssuePrResult = await extractGitHubIssuePr(url, signal, options);
+		if (ghIssuePrResult) return ghIssuePrResult;
+		if (signal?.aborted) return abortedResult(url);
+	} catch (err) {
+		const message = errorMessage(err);
+		if (isAbortError(err)) return abortedResult(url);
+		if (isConfigParseError(err)) {
+			return { url, title: "", content: "", error: message };
+		}
 	}
 
 	try {

--- a/github-api.ts
+++ b/github-api.ts
@@ -8,13 +8,14 @@ const MAX_INLINE_FILE_CHARS = 100_000;
 let ghAvailable: boolean | null = null;
 let ghHintShown = false;
 
-export async function checkGhAvailable(): Promise<boolean> {
+export async function checkGhAvailable(signal?: AbortSignal): Promise<boolean> {
 	if (ghAvailable !== null) return ghAvailable;
 
 	return new Promise((resolve) => {
-		execFile("gh", ["--version"], { timeout: 5000 }, (err) => {
-			ghAvailable = !err;
-			resolve(ghAvailable);
+		execFile("gh", ["--version"], { timeout: 5000, ...(signal ? { signal } : {}) }, (err) => {
+			const available = !err;
+			if (!signal?.aborted) ghAvailable = available;
+			resolve(available);
 		});
 	});
 }

--- a/github-issue-pr.ts
+++ b/github-issue-pr.ts
@@ -1,0 +1,690 @@
+import { execFile } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import type { ExtractedContent, ExtractOptions } from "./extract.ts";
+import { checkGhAvailable, showGhHint } from "./github-api.ts";
+import { fetchRemoteUrl, loadFetchContentDomainPolicy, loadSsrfConfig } from "./ssrf-protection.ts";
+import { getWebSearchConfigPath } from "./utils.ts";
+
+const CONFIG_PATH = getWebSearchConfigPath();
+const GH_TIMEOUT_MS = 10_000;
+const GH_TOTAL_TIMEOUT_MS = 20_000;
+const MAX_DOC_CHARS = 150_000;
+const BODY_INLINE_CHARS = 4_000;
+const COMMENT_INLINE_CHARS = 700;
+const MAX_INLINE_COMMENTS = 15;
+const MAX_INLINE_REVIEWS = 10;
+const MAX_INLINE_CHECKS = 15;
+const MAX_INLINE_FILES = 50;
+const MAX_INLINE_COMMITS = 20;
+const MAX_INLINE_REVIEW_THREADS = 30;
+const REST_HEADERS = { "Accept": "application/vnd.github+json", "User-Agent": "pi-web-access" };
+const PR_SUBPATHS = new Set(["files", "commits", "checks", "conversation"]);
+
+const PR_FIELDS = [
+	"title", "number", "state", "isDraft", "author", "baseRefName", "headRefName", "headRepositoryOwner",
+	"createdAt", "mergedAt", "closedAt", "labels", "milestone", "additions", "deletions", "changedFiles",
+	"files", "commits", "reviews", "statusCheckRollup", "comments", "body", "closingIssuesReferences", "url",
+];
+const PR_CORE_FIELDS = [
+	"title", "number", "state", "isDraft", "author", "baseRefName", "headRefName", "headRepositoryOwner",
+	"createdAt", "mergedAt", "closedAt", "labels", "milestone", "additions", "deletions", "changedFiles",
+	"files", "commits", "reviews", "comments", "body", "url",
+];
+const ISSUE_FIELDS = [
+	"title", "number", "state", "stateReason", "author", "createdAt", "closedAt", "labels", "assignees", "milestone",
+	"comments", "body", "closedByPullRequestsReferences", "url",
+];
+const ISSUE_CORE_FIELDS = ["title", "number", "state", "author", "createdAt", "closedAt", "labels", "assignees", "milestone", "comments", "body", "url"];
+
+type Kind = "pull" | "issue";
+
+export interface GitHubIssuePrUrlInfo {
+	owner: string;
+	repo: string;
+	kind: Kind;
+	number: number;
+	anchor?: string;
+}
+
+interface GitHubPrIssueConfig {
+	enabled: boolean;
+}
+
+interface GhResult {
+	ok: boolean;
+	stdout: string;
+	stderr: string;
+	code: number | null;
+	error?: string;
+}
+
+interface RenderData {
+	url: string;
+	owner: string;
+	repo: string;
+	kind: Kind;
+	number: number;
+	anchor?: string;
+	view: Record<string, unknown>;
+	reviewThreads: Record<string, unknown>[];
+	reviewThreadsBounded?: boolean;
+	reviewThreadsUnavailable?: boolean;
+	fallbackNotes: string[];
+}
+
+let cachedConfig: GitHubPrIssueConfig | null = null;
+
+function loadConfig(): GitHubPrIssueConfig {
+	if (cachedConfig) return cachedConfig;
+	const defaults = { enabled: true };
+	if (!existsSync(CONFIG_PATH)) {
+		cachedConfig = defaults;
+		return cachedConfig;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+	const root = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+	const value = root.githubPrIssue;
+	if (value !== undefined && (typeof value !== "object" || value === null || Array.isArray(value))) {
+		throw new Error(`githubPrIssue in ${CONFIG_PATH} must be an object`);
+	}
+	const enabled = typeof (value as { enabled?: unknown } | undefined)?.enabled === "boolean"
+		? (value as { enabled: boolean }).enabled
+		: true;
+	cachedConfig = { enabled };
+	return cachedConfig;
+}
+
+function validOwner(owner: string): boolean {
+	return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(owner) && !owner.includes("--");
+}
+
+function validRepo(repo: string): boolean {
+	return /^[A-Za-z0-9._-]{1,100}$/.test(repo) && repo !== "." && repo !== "..";
+}
+
+export function parseGitHubIssuePrUrl(url: string): GitHubIssuePrUrlInfo | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+	const host = parsed.hostname.toLowerCase();
+	if (host !== "github.com" && host !== "www.github.com") return null;
+	const segments: string[] = [];
+	for (const segment of parsed.pathname.split("/").filter(Boolean)) {
+		try {
+			segments.push(decodeURIComponent(segment));
+		} catch {
+			return null;
+		}
+	}
+	if (segments.length < 4) return null;
+	const owner = segments[0];
+	const repo = segments[1].replace(/\.git$/, "");
+	if (!validOwner(owner) || !validRepo(repo)) return null;
+	const route = segments[2].toLowerCase();
+	if (route !== "pull" && route !== "issues") return null;
+	if (!/^\d+$/.test(segments[3])) return null;
+	const subpath = segments[4]?.toLowerCase();
+	if (route === "pull" && subpath && !PR_SUBPATHS.has(subpath)) return null;
+	if (route === "issues" && subpath) return null;
+	const number = Number.parseInt(segments[3], 10);
+	if (!Number.isSafeInteger(number) || number <= 0) return null;
+	const fragment = parsed.hash.slice(1);
+	const anchorPattern = route === "pull" ? /^(?:issuecomment-\d+|discussion_r\d+)$/i : /^issuecomment-\d+$/i;
+	const anchor = anchorPattern.test(fragment) ? fragment : undefined;
+	return { owner, repo, kind: route === "pull" ? "pull" : "issue", number, ...(anchor ? { anchor } : {}) };
+}
+
+function runGh(args: string[], timeoutMs = GH_TIMEOUT_MS, signal?: AbortSignal): Promise<GhResult> {
+	return new Promise((resolve) => {
+		execFile("gh", args, {
+			timeout: timeoutMs,
+			maxBuffer: 10 * 1024 * 1024,
+			...(signal ? { signal } : {}),
+			env: { ...process.env, GH_PROMPT_DISABLED: "1", GIT_TERMINAL_PROMPT: "0" },
+		}, (err, stdout, stderr) => {
+			const nodeErr = err as NodeJS.ErrnoException | null;
+			resolve({
+				ok: !err,
+				stdout,
+				stderr,
+				code: typeof nodeErr?.code === "number" ? nodeErr.code : null,
+				...(err ? { error: nodeErr?.message ?? String(err) } : {}),
+			});
+		});
+	});
+}
+
+function remainingGhTimeout(deadlineMs: number): number {
+	return Math.max(1, Math.min(GH_TIMEOUT_MS, deadlineMs - Date.now()));
+}
+
+function unknownJsonField(result: GhResult): boolean {
+	return /unknown (?:json )?field|UnknownField|Unknown JSON field/i.test(`${result.stderr}\n${result.error ?? ""}`);
+}
+
+async function ghView(info: GitHubIssuePrUrlInfo, deadlineMs: number, signal?: AbortSignal): Promise<{ view: Record<string, unknown>; notes: string[] } | null> {
+	const repoArg = `${info.owner}/${info.repo}`;
+	const command = info.kind === "pull" ? "pr" : "issue";
+	const fields = info.kind === "pull" ? PR_FIELDS : ISSUE_FIELDS;
+	const coreFields = info.kind === "pull" ? PR_CORE_FIELDS : ISSUE_CORE_FIELDS;
+	let result = await runGh([command, "view", String(info.number), "--repo", repoArg, "--json", fields.join(",")], remainingGhTimeout(deadlineMs), signal);
+	const notes: string[] = [];
+	let linkedReferencesUnavailable = false;
+	if (!result.ok && unknownJsonField(result)) {
+		result = await runGh([command, "view", String(info.number), "--repo", repoArg, "--json", coreFields.join(",")], remainingGhTimeout(deadlineMs), signal);
+		notes.push("Some GitHub fields were unavailable from this gh version; retried with the core field set.");
+		linkedReferencesUnavailable = true;
+	}
+	if (!result.ok) return null;
+	try {
+		const parsed = JSON.parse(result.stdout) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		const view = parsed as Record<string, unknown>;
+		if (linkedReferencesUnavailable) view.linkedReferencesUnavailable = true;
+		return { view, notes };
+	} catch {
+		return null;
+	}
+}
+
+async function ghReviewThreads(info: GitHubIssuePrUrlInfo, deadlineMs: number, signal?: AbortSignal): Promise<{ comments: Record<string, unknown>[]; note?: string; bounded?: boolean; unavailable?: boolean; anchorUnavailable?: boolean }> {
+	if (info.kind !== "pull") return { comments: [] };
+	const comments: Record<string, unknown>[] = [];
+	let bounded = false;
+	let pageFailed = false;
+	for (let page = 1; page <= 3; page++) {
+		const result = await runGh(["api", `repos/${info.owner}/${info.repo}/pulls/${info.number}/comments?per_page=100&page=${page}`], remainingGhTimeout(deadlineMs), signal);
+		if (!result.ok) {
+			pageFailed = true;
+			break;
+		}
+		let pageItems: unknown;
+		try {
+			pageItems = JSON.parse(result.stdout);
+		} catch {
+			pageFailed = true;
+			break;
+		}
+		if (!Array.isArray(pageItems) || pageItems.length === 0) break;
+		comments.push(...pageItems.filter((item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item)));
+		if (pageItems.length < 100) break;
+		if (page === 3) bounded = true;
+	}
+	const discussionId = anchorId(info.anchor, "discussion_r");
+	if (discussionId && !hasCommentId(comments, discussionId)) {
+		const result = await runGh(["api", `repos/${info.owner}/${info.repo}/pulls/comments/${discussionId}`], remainingGhTimeout(deadlineMs), signal);
+		if (result.ok) {
+			try {
+				const comment = JSON.parse(result.stdout) as unknown;
+				if (comment && typeof comment === "object" && !Array.isArray(comment) && belongsToPull(comment as Record<string, unknown>, discussionId, info)) comments.push(comment as Record<string, unknown>);
+				else return { comments, bounded: bounded || (pageFailed && comments.length > 0), unavailable: pageFailed && comments.length === 0, anchorUnavailable: true };
+			} catch {
+				return { comments, bounded: bounded || (pageFailed && comments.length > 0), unavailable: pageFailed && comments.length === 0, note: "Anchored review thread comment unavailable from gh." };
+			}
+		} else {
+			return { comments, bounded: bounded || (pageFailed && comments.length > 0), unavailable: pageFailed && comments.length === 0, anchorUnavailable: true };
+		}
+	}
+	return { comments, bounded: bounded || (pageFailed && comments.length > 0), unavailable: pageFailed && comments.length === 0 };
+}
+
+function isRateLimited(response: Response): boolean {
+	return response.status === 403 && response.headers.get("x-ratelimit-remaining") === "0";
+}
+
+function anchorId(anchor: string | undefined, prefix: "issuecomment" | "discussion_r"): string | null {
+	const match = anchor?.match(prefix === "issuecomment" ? /^issuecomment-(\d+)$/i : /^discussion_r(\d+)$/i);
+	return match?.[1] ?? null;
+}
+
+function hasCommentId(comments: Record<string, unknown>[], id: string): boolean {
+	return comments.some(comment => commentId(comment) === id);
+}
+
+function belongsToIssue(comment: Record<string, unknown>, id: string, info: GitHubIssuePrUrlInfo): boolean {
+	return commentId(comment) === id && associationMatches(comment.issue_url, info, "issues");
+}
+
+function belongsToPull(comment: Record<string, unknown>, id: string, info: GitHubIssuePrUrlInfo): boolean {
+	return commentId(comment) === id && associationMatches(comment.pull_request_url, info, "pulls");
+}
+
+function associationMatches(value: unknown, info: GitHubIssuePrUrlInfo, route: "issues" | "pulls"): boolean {
+	if (typeof value !== "string") return false;
+	try {
+		const parsed = new URL(value);
+		if (parsed.protocol !== "https:" || parsed.hostname.toLowerCase() !== "api.github.com") return false;
+		return parsed.pathname.toLowerCase() === `/repos/${info.owner}/${info.repo}/${route}/${info.number}`.toLowerCase();
+	} catch {
+		return false;
+	}
+}
+
+function rateLimitResult(url: string, info: GitHubIssuePrUrlInfo, response: Response): ExtractedContent {
+	const reset = response.headers.get("x-ratelimit-reset");
+	const resetNote = reset ? ` Rate limit resets at Unix time ${reset}.` : "";
+	return {
+		url,
+		title: `${info.owner}/${info.repo}#${info.number}`,
+		content: `GitHub API rate limit reached for ${info.owner}/${info.repo} ${info.kind} #${info.number}.${resetNote}\n\nAuthenticate the gh CLI and retry:\n\n\`gh auth login\`\n\nThen fetch this URL again.`,
+		error: "GitHub API rate limit reached; authenticate gh to fetch this PR or issue.",
+		status: response.status,
+	};
+}
+
+async function restJson(url: string, options?: ExtractOptions, signal?: AbortSignal): Promise<{ value: unknown; response: Response } | null> {
+	const ssrf = loadSsrfConfig();
+	const domainPolicy = loadFetchContentDomainPolicy();
+	const response = await fetchRemoteUrl(url, { headers: REST_HEADERS, ...(signal ? { signal } : {}) }, {
+		allowRanges: ssrf.allowRanges,
+		trustEnvProxy: ssrf.trustEnvProxy,
+		domainPolicy,
+		...(options?.lookup ? { lookup: options.lookup } : {}),
+	});
+	if (!response.ok) return { value: null, response };
+	return { value: await response.json(), response };
+}
+
+async function restFallback(url: string, info: GitHubIssuePrUrlInfo, options?: ExtractOptions, signal?: AbortSignal): Promise<ExtractedContent | { data: RenderData } | null> {
+	try {
+		const base = `https://api.github.com/repos/${info.owner}/${info.repo}`;
+		const mainPath = info.kind === "pull" ? `${base}/pulls/${info.number}` : `${base}/issues/${info.number}`;
+		const main = await restJson(mainPath, options, signal);
+		if (!main) return null;
+		if (isRateLimited(main.response)) return rateLimitResult(url, info, main.response);
+		if (!main.response.ok) return null;
+		const view = mapRestView(info, main.value);
+		view.linkedReferencesUnavailable = true;
+		const comments = await restJson(`${base}/issues/${info.number}/comments?per_page=50`, options, signal);
+		if (comments && isRateLimited(comments.response)) return rateLimitResult(url, info, comments.response);
+		const conversationComments = comments?.response.ok && Array.isArray(comments.value)
+			? comments.value.filter((item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item))
+			: [];
+		const issueCommentId = anchorId(info.anchor, "issuecomment");
+		if (issueCommentId && !hasCommentId(conversationComments, issueCommentId)) {
+			const anchoredComment = await restJson(`${base}/issues/comments/${issueCommentId}`, options, signal);
+			if (anchoredComment && isRateLimited(anchoredComment.response)) return rateLimitResult(url, info, anchoredComment.response);
+			if (anchoredComment?.response.ok && anchoredComment.value && typeof anchoredComment.value === "object" && !Array.isArray(anchoredComment.value)) {
+				const comment = anchoredComment.value as Record<string, unknown>;
+				if (belongsToIssue(comment, issueCommentId, info)) conversationComments.push(comment);
+				else view.anchorUnavailable = true;
+			} else {
+				view.anchorUnavailable = true;
+			}
+		}
+		view.comments = conversationComments;
+		const reviewThreads: Record<string, unknown>[] = [];
+		const notes = [info.kind === "pull" ? "Checks unavailable in REST fallback; install or authenticate gh for check status." : "REST fallback used; gh fields unavailable."];
+		if (info.kind === "pull") {
+			view.reviewsUnavailable = true;
+			view.commitsUnavailable = true;
+			const files = await restJson(`${base}/pulls/${info.number}/files?per_page=50`, options, signal);
+			if (files && isRateLimited(files.response)) return rateLimitResult(url, info, files.response);
+			if (files?.response.ok && Array.isArray(files.value)) view.files = files.value;
+			const threads = await restJson(`${base}/pulls/${info.number}/comments?per_page=50`, options, signal);
+			if (threads && isRateLimited(threads.response)) return rateLimitResult(url, info, threads.response);
+			if (threads?.response.ok && Array.isArray(threads.value)) {
+				reviewThreads.push(...threads.value.filter((item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item)));
+			}
+			const discussionId = anchorId(info.anchor, "discussion_r");
+			if (discussionId && !hasCommentId(reviewThreads, discussionId)) {
+				const anchoredThread = await restJson(`${base}/pulls/comments/${discussionId}`, options, signal);
+				if (anchoredThread && isRateLimited(anchoredThread.response)) return rateLimitResult(url, info, anchoredThread.response);
+				if (anchoredThread?.response.ok && anchoredThread.value && typeof anchoredThread.value === "object" && !Array.isArray(anchoredThread.value)) {
+					const comment = anchoredThread.value as Record<string, unknown>;
+					if (belongsToPull(comment, discussionId, info)) reviewThreads.push(comment);
+					else view.anchorUnavailable = true;
+				} else {
+					view.anchorUnavailable = true;
+				}
+			}
+		}
+		return { data: { url, owner: info.owner, repo: info.repo, kind: info.kind, number: info.number, anchor: info.anchor, view, reviewThreads, fallbackNotes: notes } };
+	} catch {
+		return null;
+	}
+}
+
+function mapRestView(info: GitHubIssuePrUrlInfo, value: unknown): Record<string, unknown> {
+	const source = value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+	const user = source.user && typeof source.user === "object" ? source.user as Record<string, unknown> : undefined;
+	const base = source.base && typeof source.base === "object" ? source.base as Record<string, unknown> : undefined;
+	const head = source.head && typeof source.head === "object" ? source.head as Record<string, unknown> : undefined;
+	return {
+		title: stringValue(source.title),
+		number: numberValue(source.number) ?? info.number,
+		state: stringValue(source.state),
+		stateReason: stringValue(source.state_reason),
+		isDraft: Boolean(source.draft),
+		author: { login: user ? stringValue(user.login) : "" },
+		baseRefName: base ? stringValue(base.ref) : "",
+		headRefName: head ? stringValue(head.ref) : "",
+		headRepositoryOwner: { login: head && typeof head.repo === "object" && head.repo && typeof (head.repo as Record<string, unknown>).owner === "object" ? stringValue(((head.repo as Record<string, unknown>).owner as Record<string, unknown>).login) : "" },
+		createdAt: stringValue(source.created_at),
+		mergedAt: stringValue(source.merged_at),
+		closedAt: stringValue(source.closed_at),
+		labels: source.labels,
+		assignees: source.assignees,
+		milestone: source.milestone,
+		additions: source.additions,
+		deletions: source.deletions,
+		changedFiles: source.changed_files,
+		body: stringValue(source.body),
+		url: stringValue(source.html_url),
+		commentsCount: source.comments,
+		reviewCommentsCount: source.review_comments,
+	};
+}
+
+function stringValue(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+function numberValue(value: unknown): number | null {
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function authorLogin(value: unknown): string {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return "unknown";
+	const login = (value as Record<string, unknown>).login;
+	return typeof login === "string" && login ? login : "unknown";
+}
+
+function listNames(value: unknown): string {
+	if (!Array.isArray(value) || value.length === 0) return "none";
+	const names = value.map((item) => {
+		if (!item || typeof item !== "object" || Array.isArray(item)) return "";
+		const record = item as Record<string, unknown>;
+		return stringValue(record.name) || stringValue(record.login) || stringValue(record.title);
+	}).filter(Boolean);
+	return names.length > 0 ? names.join(", ") : "none";
+}
+
+function milestoneTitle(value: unknown): string {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return "none";
+	return stringValue((value as Record<string, unknown>).title) || "none";
+}
+
+function truncateText(text: string, limit: number, label: string, appendix: string[]): string {
+	if (text.length <= limit) return text;
+	appendix.push(`## Full ${label}\n\n${text}`);
+	return `${text.slice(0, limit)}\n\n[${label} truncated; use get_search_content findText or offset for the full text]`;
+}
+
+function appendLimitedSection(lines: string[], title: string, items: string[], max: number, marker: string): void {
+	lines.push(`## ${title}`);
+	if (items.length === 0) {
+		lines.push("none", "");
+		return;
+	}
+	lines.push(...items.slice(0, max));
+	if (items.length > max) lines.push(`[${max} of ${items.length} ${marker} shown; use get_search_content offset or the gh command below for more]`);
+	lines.push("");
+}
+
+function objectArray(value: unknown): Record<string, unknown>[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item));
+}
+
+function commentId(comment: Record<string, unknown>): string {
+	return String(comment.id ?? comment.databaseId ?? "");
+}
+
+function anchorMatches(anchor: string | undefined, comment: Record<string, unknown>): boolean {
+	if (!anchor) return false;
+	const id = commentId(comment);
+	return anchor === `issuecomment-${id}` || anchor === `discussion_r${id}`;
+}
+
+function renderComments(comments: Record<string, unknown>[], anchor: string | undefined, appendix: string[]): string[] {
+	const forced = anchor ? comments.find(comment => anchorMatches(anchor, comment)) : undefined;
+	const selected = comments.slice(0, MAX_INLINE_COMMENTS);
+	if (forced && !selected.includes(forced)) selected.push(forced);
+	const lines = selected.map((comment) => {
+		const body = stringValue(comment.body);
+		const label = `comment ${commentId(comment) || selected.indexOf(comment) + 1}`;
+		return `- ${authorLogin(comment.author ?? comment.user)} at ${stringValue(comment.createdAt) || stringValue(comment.created_at)}${forced === comment ? " [anchored]" : ""}:\n  ${truncateText(body, COMMENT_INLINE_CHARS, label, appendix).replace(/\n/g, "\n  ")}`;
+	});
+	return lines;
+}
+
+function renderCommentMarker(comments: Record<string, unknown>[], renderedCount: number, total: unknown): string | null {
+	const knownTotal = numberValue(total);
+	if (knownTotal !== null && knownTotal > comments.length) {
+		return `[${renderedCount} comments shown from at least ${knownTotal}; use get_search_content findText or offset, or gh issue view -c]`;
+	}
+	if (comments.length > renderedCount) return `[${renderedCount} of ${comments.length} comments shown; use get_search_content findText or offset, or gh issue view -c]`;
+	return null;
+}
+
+function commentCountText(view: Record<string, unknown>): string {
+	const comments = objectArray(view.comments).length;
+	const total = numberValue(view.commentsCount);
+	if (total !== null && total > comments) return `at least ${total}`;
+	return String(comments || total || 0);
+}
+
+function reviewThreadCountText(comments: Record<string, unknown>[], total: unknown, bounded?: boolean, unavailable?: boolean): string {
+	if (unavailable) return "unavailable";
+	const knownTotal = numberValue(total);
+	if (bounded) return `at least ${comments.length}`;
+	if (knownTotal !== null && knownTotal > comments.length) return `at least ${knownTotal}`;
+	return String(comments.length || knownTotal || 0);
+}
+
+function renderChecks(value: unknown): string[] {
+	const checks = objectArray(value);
+	if (checks.length === 0) return ["No check rollup data available."];
+	const rows = checks.map((check) => {
+		const name = stringValue(check.name) || stringValue(check.context) || stringValue(check.workflowName) || "check";
+		const state = stringValue(check.conclusion) || stringValue(check.status) || stringValue(check.state) || "unknown";
+		return `- ${name}: ${state}`;
+	});
+	const failing = rows.filter(row => !/(success|neutral|skipped|completed)$/i.test(row));
+	return [`Rollup: ${failing.length === 0 ? "no failing checks in shown data" : `${failing.length} non-passing checks in shown data`}`, ...rows.slice(0, MAX_INLINE_CHECKS), ...(rows.length > MAX_INLINE_CHECKS ? [`[${MAX_INLINE_CHECKS} of ${rows.length} checks shown]`] : [])];
+}
+
+function renderReviewVerdicts(value: unknown, appendix: string[]): string[] {
+	const latest = new Map<string, Record<string, unknown>>();
+	for (const review of objectArray(value)) latest.set(authorLogin(review.author ?? review.user), review);
+	return [...latest.entries()].map(([author, review]) => {
+		const state = stringValue(review.state) || "COMMENTED";
+		const body = truncateText(stringValue(review.body), 300, `review by ${author}`, appendix);
+		return `- ${author}: ${state}${body ? ` — ${body.replace(/\n/g, " ")}` : ""}`;
+	});
+}
+
+function renderReviewVerdictsOrUnavailable(view: Record<string, unknown>, appendix: string[]): string[] {
+	const rendered = renderReviewVerdicts(view.reviews, appendix);
+	if (rendered.length > 0) return rendered;
+	return view.reviewsUnavailable === true ? ["Unavailable in this GitHub fetch path; use gh for review verdicts."] : [];
+}
+
+function renderFiles(value: unknown): string[] {
+	return objectArray(value).map((file) => {
+		const path = stringValue(file.path) || stringValue(file.filename) || "file";
+		const additions = numberValue(file.additions) ?? 0;
+		const deletions = numberValue(file.deletions) ?? 0;
+		return `- ${path} (+${additions}/−${deletions})`;
+	});
+}
+
+function appendFilesSection(lines: string[], view: Record<string, unknown>): void {
+	lines.push("## Files");
+	const files = renderFiles(view.files);
+	if (files.length === 0) {
+		const total = numberValue(view.changedFiles);
+		if (total !== null && total > 0) {
+			lines.push(`[0 files shown from at least ${total}; use get_search_content offset or the gh command below for more]`, "");
+			return;
+		}
+		lines.push("none", "");
+		return;
+	}
+	lines.push(...files.slice(0, MAX_INLINE_FILES));
+	const total = numberValue(view.changedFiles);
+	if (total !== null && total > files.length) {
+		lines.push(`[${Math.min(files.length, MAX_INLINE_FILES)} files shown from at least ${total}; use get_search_content offset or the gh command below for more]`);
+	} else if (files.length > MAX_INLINE_FILES) {
+		lines.push(`[${MAX_INLINE_FILES} of ${files.length} files shown; use get_search_content offset or the gh command below for more]`);
+	}
+	lines.push("");
+}
+
+function renderCommits(value: unknown): string[] {
+	return objectArray(value).map((commit) => {
+		const oid = stringValue(commit.oid) || stringValue(commit.sha);
+		const message = stringValue(commit.messageHeadline) || (commit.commit && typeof commit.commit === "object" ? stringValue((commit.commit as Record<string, unknown>).message).split("\n")[0] : "");
+		return `- ${oid.slice(0, 7)} ${message}`.trim();
+	});
+}
+
+function renderCommitsOrUnavailable(view: Record<string, unknown>): string[] {
+	const rendered = renderCommits(view.commits);
+	if (rendered.length > 0) return rendered;
+	return view.commitsUnavailable === true ? ["Unavailable in this GitHub fetch path; use gh for commits."] : [];
+}
+
+function renderLinked(value: unknown, kind: "closing" | "closedBy"): string[] {
+	return objectArray(value).map((item) => `- #${numberValue(item.number) ?? "?"} ${stringValue(item.title)}${kind === "closedBy" ? ` (${stringValue(item.url)})` : ""}`);
+}
+
+function renderLinkedOrUnavailable(view: Record<string, unknown>, field: "closingIssuesReferences" | "closedByPullRequestsReferences", kind: "closing" | "closedBy"): string[] {
+	const linked = renderLinked(view[field], kind);
+	if (linked.length > 0) return linked;
+	return view.linkedReferencesUnavailable === true ? ["Unavailable in this GitHub fetch path; use gh for linked references."] : [];
+}
+
+function renderReviewThreads(comments: Record<string, unknown>[], anchor: string | undefined, appendix: string[], total?: unknown, bounded?: boolean, unavailable?: boolean): string[] {
+	if (unavailable) return ["Unavailable in this GitHub fetch path; use gh for review thread comments."];
+	const forced = anchor ? comments.find(comment => anchorMatches(anchor, comment)) : undefined;
+	const selected = comments.slice(0, MAX_INLINE_REVIEW_THREADS);
+	if (forced && !selected.includes(forced)) selected.push(forced);
+	const lines = selected.map((comment) => {
+		const path = stringValue(comment.path) || "unknown path";
+		const line = numberValue(comment.line) ?? numberValue(comment.original_line) ?? numberValue(comment.position) ?? "?";
+		const body = truncateText(stringValue(comment.body), COMMENT_INLINE_CHARS, `review thread comment ${commentId(comment) || selected.indexOf(comment) + 1}`, appendix);
+		return `- ${path}:${line} — ${authorLogin(comment.user ?? comment.author)}${forced === comment ? " [anchored]" : ""} (resolution state unknown):\n  ${body.replace(/\n/g, "\n  ")}`;
+	});
+	const knownTotal = numberValue(total);
+	if (bounded) {
+		lines.push(`[${selected.length} review thread comments shown from at least ${comments.length}; use get_search_content offset, or gh api repos/<owner>/<repo>/pulls/<number>/comments]`);
+	} else if (knownTotal !== null && knownTotal > comments.length) {
+		lines.push(`[${selected.length} review thread comments shown from at least ${knownTotal}; use get_search_content offset, or gh api repos/<owner>/<repo>/pulls/<number>/comments]`);
+	} else if (comments.length > selected.length) {
+		lines.push(`[${selected.length} of ${comments.length} review thread comments shown; use get_search_content offset, or gh api repos/<owner>/<repo>/pulls/<number>/comments]`);
+	}
+	return lines;
+}
+
+export function renderGitHubPrIssue(data: RenderData): ExtractedContent {
+	const { view } = data;
+	const appendix: string[] = [];
+	const title = stringValue(view.title) || `${data.owner}/${data.repo}#${data.number}`;
+	const number = numberValue(view.number) ?? data.number;
+	const stateParts = [stringValue(view.state) || "unknown"];
+	if (view.isDraft === true) stateParts.push("draft");
+	const lines: string[] = [`#${number} ${title}`, ""];
+	lines.push(`- type: ${data.kind}`);
+	lines.push(`- state: ${stateParts.join(" ")}${stringValue(view.stateReason) ? ` (${stringValue(view.stateReason)})` : ""}`);
+	lines.push(`- author: ${authorLogin(view.author)}`);
+	if (data.kind === "pull") {
+		const headOwner = authorLogin(view.headRepositoryOwner);
+		const headRef = stringValue(view.headRefName);
+		const head = headOwner !== "unknown" && headOwner !== data.owner ? `${headOwner}:${headRef}` : headRef;
+		lines.push(`- branch: ${stringValue(view.baseRefName)} ← ${head}`);
+		const commitSummary = view.commitsUnavailable === true ? "commits unavailable" : `${objectArray(view.commits).length} commits`;
+		lines.push(`- changes: +${numberValue(view.additions) ?? 0} −${numberValue(view.deletions) ?? 0}, ${numberValue(view.changedFiles) ?? objectArray(view.files).length} files, ${commitSummary}`);
+	} else {
+		lines.push(`- assignees: ${listNames(view.assignees)}`);
+	}
+	lines.push(`- created: ${stringValue(view.createdAt) || "unknown"}`);
+	if (stringValue(view.mergedAt)) lines.push(`- merged: ${stringValue(view.mergedAt)}`);
+	if (stringValue(view.closedAt)) lines.push(`- closed: ${stringValue(view.closedAt)}`);
+	lines.push(`- labels: ${listNames(view.labels)}`);
+	lines.push(`- milestone: ${milestoneTitle(view.milestone)}`);
+	lines.push(`- comments: ${commentCountText(view)}; review threads: ${reviewThreadCountText(data.reviewThreads, view.reviewCommentsCount, data.reviewThreadsBounded, data.reviewThreadsUnavailable)}`);
+	if (data.anchor) lines.push(`- requested anchor: #${data.anchor}`);
+	lines.push("");
+
+	lines.push("## Body");
+	lines.push(truncateText(stringValue(view.body) || "(empty)", BODY_INLINE_CHARS, "body", appendix), "");
+
+	if (data.kind === "pull") {
+		lines.push("## Checks");
+		lines.push(...renderChecks(view.statusCheckRollup), "");
+		appendLimitedSection(lines, "Review verdicts", renderReviewVerdictsOrUnavailable(view, appendix), MAX_INLINE_REVIEWS, "review verdicts");
+		appendLimitedSection(lines, "Linked references", renderLinkedOrUnavailable(view, "closingIssuesReferences", "closing"), 20, "linked references");
+		appendFilesSection(lines, view);
+		appendLimitedSection(lines, "Commits", renderCommitsOrUnavailable(view), MAX_INLINE_COMMITS, "commits");
+	} else {
+		appendLimitedSection(lines, "Closed by pull requests", renderLinkedOrUnavailable(view, "closedByPullRequestsReferences", "closedBy"), 20, "pull requests");
+	}
+	lines.push("## Conversation comments");
+	const commentLines = renderComments(objectArray(view.comments), data.anchor, appendix);
+	const commentMarker = renderCommentMarker(objectArray(view.comments), commentLines.length, view.commentsCount);
+	if (commentMarker) commentLines.push(commentMarker);
+	if (view.anchorUnavailable === true && data.anchor?.startsWith("issuecomment-")) commentLines.push("[anchored comment unavailable for this issue or pull request]");
+	lines.push(...(commentLines.length > 0 ? commentLines : ["none"]), "");
+	if (data.kind === "pull") {
+		lines.push("## Review thread comments");
+		const threadLines = renderReviewThreads(data.reviewThreads, data.anchor, appendix, view.reviewCommentsCount, data.reviewThreadsBounded, data.reviewThreadsUnavailable);
+		if (view.anchorUnavailable === true && data.anchor?.startsWith("discussion_r")) threadLines.push("[anchored review thread comment unavailable for this pull request]");
+		lines.push(...(threadLines.length > 0 ? threadLines : ["none"]), "");
+	}
+	if (data.fallbackNotes.length > 0) {
+		lines.push("## Availability notes", ...data.fallbackNotes.map(note => `- ${note}`), "");
+	}
+	if (appendix.length > 0) lines.push("## Appendix", ...appendix, "");
+	const viewCommand = data.kind === "pull" ? `gh pr view ${data.number} --repo ${data.owner}/${data.repo}` : `gh issue view ${data.number} --repo ${data.owner}/${data.repo} -c`;
+	lines.push("## Escalation commands");
+	lines.push(`- Full view: \`${viewCommand}\``);
+	if (data.kind === "pull") lines.push(`- Complete diff: \`gh pr diff ${data.number} --repo ${data.owner}/${data.repo}\``);
+	lines.push("- Stored full document: use `get_search_content` with `offset` or `findText`.");
+	const content = lines.join("\n");
+	return {
+		url: data.url,
+		title: `${data.owner}/${data.repo} ${data.kind} #${data.number}: ${title}`,
+		content: content.length > MAX_DOC_CHARS ? `${content.slice(0, MAX_DOC_CHARS)}\n\n[GitHub document truncated at ${MAX_DOC_CHARS} chars; use the gh escalation commands for complete data]` : content,
+		error: null,
+	};
+}
+
+export async function extractGitHubIssuePr(url: string, signal?: AbortSignal, options?: ExtractOptions): Promise<ExtractedContent | null> {
+	const info = parseGitHubIssuePrUrl(url);
+	if (!info) return null;
+	if (!loadConfig().enabled) return null;
+	if (signal?.aborted) return { url, title: "", content: "", error: "Aborted" };
+
+	const ghAvailable = await checkGhAvailable(signal);
+	if (signal?.aborted) return { url, title: "", content: "", error: "Aborted" };
+	if (ghAvailable) {
+		const ghDeadlineMs = Date.now() + GH_TOTAL_TIMEOUT_MS;
+		const viewed = await ghView(info, ghDeadlineMs, signal);
+		if (signal?.aborted) return { url, title: "", content: "", error: "Aborted" };
+		if (viewed) {
+			const threads = await ghReviewThreads(info, ghDeadlineMs, signal);
+			if (signal?.aborted) return { url, title: "", content: "", error: "Aborted" };
+			if (threads.anchorUnavailable) viewed.view.anchorUnavailable = true;
+			const notes = [...viewed.notes, ...(threads.note ? [threads.note] : [])];
+			return renderGitHubPrIssue({ url, owner: info.owner, repo: info.repo, kind: info.kind, number: info.number, anchor: info.anchor, view: viewed.view, reviewThreads: threads.comments, reviewThreadsBounded: threads.bounded, reviewThreadsUnavailable: threads.unavailable, fallbackNotes: notes });
+		}
+	} else {
+		showGhHint();
+	}
+
+	const fallback = await restFallback(url, info, options, signal);
+	if (!fallback) return null;
+	if ("data" in fallback) return renderGitHubPrIssue(fallback.data);
+	return fallback;
+}

--- a/test/github-issue-pr.test.mjs
+++ b/test/github-issue-pr.test.mjs
@@ -1,0 +1,518 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { test } from "node:test";
+
+const moduleUrl = new URL("../github-issue-pr.ts", import.meta.url).href;
+const extractUrl = new URL("../extract.ts", import.meta.url).href;
+const publicLookup = async () => [{ address: "140.82.112.6", family: 4 }];
+
+async function writeFakeExecutable(binDir, name, source) {
+	const executable = join(binDir, name);
+	await writeFile(executable, `#!/usr/bin/env node\n${source}\n`, { mode: 0o755 });
+	return executable;
+}
+
+test("parseGitHubIssuePrUrl accepts PR and issue variants without changing repo parsing", async () => {
+	const { parseGitHubIssuePrUrl } = await import(moduleUrl);
+	assert.deepEqual(parseGitHubIssuePrUrl("https://github.com/owner/repo/pull/123/files#discussion_r42"), {
+		owner: "owner", repo: "repo", kind: "pull", number: 123, anchor: "discussion_r42",
+	});
+	assert.deepEqual(parseGitHubIssuePrUrl("https://www.github.com/owner/repo/issues/5#issuecomment-99"), {
+		owner: "owner", repo: "repo", kind: "issue", number: 5, anchor: "issuecomment-99",
+	});
+	assert.deepEqual(parseGitHubIssuePrUrl("https://www.github.com/owner/repo/issues/5#discussion_r99"), {
+		owner: "owner", repo: "repo", kind: "issue", number: 5,
+	});
+	assert.equal(parseGitHubIssuePrUrl("https://github.com/owner/repo/pulls"), null);
+	assert.equal(parseGitHubIssuePrUrl("https://github.com/owner/repo/issues/new"), null);
+	assert.equal(parseGitHubIssuePrUrl("https://github.com/owner/repo/pull/123/unknown"), null);
+	assert.equal(parseGitHubIssuePrUrl("https://github.com/owner/repo/issues/5/edit"), null);
+	assert.equal(parseGitHubIssuePrUrl("https://github.com/owner%2Frepo/repo/issues/1"), null);
+});
+
+test("renderer orders sections, marks truncation, and forces anchored comments inline", async () => {
+	const { renderGitHubPrIssue } = await import(moduleUrl);
+	const comments = Array.from({ length: 20 }, (_, index) => ({
+		id: index + 1,
+		user: { login: `user${index + 1}` },
+		created_at: "2026-01-01T00:00:00Z",
+		body: index === 18 ? "anchored comment body" : `comment ${index + 1}`,
+	}));
+	const result = renderGitHubPrIssue({
+		url: "https://github.com/owner/repo/pull/7#issuecomment-19",
+		owner: "owner",
+		repo: "repo",
+		kind: "pull",
+		number: 7,
+		anchor: "issuecomment-19",
+		reviewThreads: [],
+		fallbackNotes: [],
+		view: {
+			number: 7,
+			title: "Improve fetch",
+			state: "OPEN",
+			isDraft: false,
+			author: { login: "alice" },
+			baseRefName: "main",
+			headRefName: "feature",
+			headRepositoryOwner: { login: "fork" },
+			createdAt: "2026-01-01T00:00:00Z",
+			labels: [{ name: "bug" }],
+			additions: 5,
+			deletions: 1,
+			changedFiles: 1,
+			body: "x".repeat(4100),
+			files: [{ path: "a.ts", additions: 5, deletions: 1 }],
+			commits: [{ oid: "abcdef123456", messageHeadline: "commit subject" }],
+			comments,
+			statusCheckRollup: [{ name: "test", conclusion: "SUCCESS" }],
+		},
+	});
+
+	assert.equal(result.error, null);
+	assert.match(result.content, /#7 Improve fetch/);
+	assert.ok(result.content.indexOf("## Body") < result.content.indexOf("## Checks"));
+	assert.match(result.content, /\[body truncated; use get_search_content/);
+	assert.match(result.content, /user19.*\[anchored\]/s);
+	assert.match(result.content, /15 of 20 comments shown|16 of 20 comments shown/);
+	assert.match(result.content, /gh pr diff 7 --repo owner\/repo/);
+});
+
+test("renderer marks truncated review verdicts", async () => {
+	const { renderGitHubPrIssue } = await import(moduleUrl);
+	const reviews = Array.from({ length: 11 }, (_, index) => ({
+		author: { login: `reviewer${index}` },
+		state: "COMMENTED",
+		body: `review ${index}`,
+	}));
+	const result = renderGitHubPrIssue({
+		url: "https://github.com/owner/repo/pull/7",
+		owner: "owner",
+		repo: "repo",
+		kind: "pull",
+		number: 7,
+		reviewThreads: [],
+		fallbackNotes: [],
+		view: { number: 7, title: "Reviews", state: "OPEN", author: { login: "alice" }, body: "body", reviews },
+	});
+
+	assert.match(result.content, /10 of 11 review verdicts shown/);
+});
+
+test("extractGitHubIssuePr retries gh view with core fields on unknown --json field", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-pr-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `
+		const args = process.argv.slice(2);
+		if (args[0] === "--version") { console.log("gh version 2.0.0"); process.exit(0); }
+		if (args[0] === "pr" && args[1] === "view") {
+			const fields = args[args.indexOf("--json") + 1] || "";
+			if (fields.includes("statusCheckRollup")) { console.error("Unknown JSON field: statusCheckRollup"); process.exit(1); }
+			console.log(JSON.stringify({ number: 12, title: "Fallback fields", state: "OPEN", author: { login: "alice" }, body: "body", comments: [] }));
+			process.exit(0);
+		}
+		if (args[0] === "api") { console.log("[]"); process.exit(0); }
+		process.exit(1);
+	`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { extractGitHubIssuePr } = await import(${JSON.stringify(moduleUrl)});
+			const result = await extractGitHubIssuePr("https://github.com/owner/repo/pull/12");
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout);
+	assert.match(result.content, /Fallback fields/);
+	assert.match(result.content, /retried with the core field set/);
+	assert.match(result.content, /Linked references\nUnavailable in this GitHub fetch path/);
+});
+
+test("gh path fetches an anchored review comment beyond fetched pages", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-deep-review-anchor-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `
+		const args = process.argv.slice(2);
+		if (args[0] === "--version") { console.log("gh version 2.0.0"); process.exit(0); }
+		if (args[0] === "pr" && args[1] === "view") {
+			console.log(JSON.stringify({ number: 7, title: "Deep anchor", state: "OPEN", author: { login: "alice" }, body: "body", comments: [] }));
+			process.exit(0);
+		}
+		if (args[0] === "api" && args[1].includes("/pulls/7/comments?")) {
+			const comments = Array.from({ length: 100 }, (_, index) => ({ id: index + 1, user: { login: "page" }, path: "a.ts", line: 1, body: "paged" }));
+			console.log(JSON.stringify(comments));
+			process.exit(0);
+		}
+		if (args[0] === "api" && args[1].endsWith("/pulls/comments/999")) {
+			console.log(JSON.stringify({ id: 999, pull_request_url: "https://api.github.com/repos/owner/repo/pulls/7", user: { login: "reviewer" }, path: "deep.ts", line: 44, body: "deep anchor" }));
+			process.exit(0);
+		}
+		process.exit(1);
+	`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { extractGitHubIssuePr } = await import(${JSON.stringify(moduleUrl)});
+			const result = await extractGitHubIssuePr("https://github.com/owner/repo/pull/7#discussion_r999");
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout);
+	assert.match(result.content, /reviewer.*\[anchored\]/s);
+	assert.match(result.content, /deep anchor/);
+	assert.match(result.content, /review threads: at least 301/);
+	assert.match(result.content, /review thread comments shown from at least 301/);
+});
+
+test("gh path rejects anchored review comments from another pull request", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-cross-review-anchor-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `
+		const args = process.argv.slice(2);
+		if (args[0] === "--version") { console.log("gh version 2.0.0"); process.exit(0); }
+		if (args[0] === "pr" && args[1] === "view") {
+			console.log(JSON.stringify({ number: 7, title: "Cross anchor", state: "OPEN", author: { login: "alice" }, body: "body", comments: [] }));
+			process.exit(0);
+		}
+		if (args[0] === "api" && args[1].includes("/pulls/7/comments?")) { console.log(JSON.stringify([])); process.exit(0); }
+		if (args[0] === "api" && args[1].endsWith("/pulls/comments/999")) {
+			console.log(JSON.stringify({ id: 999, pull_request_url: "https://api.github.com/repos/other/repo/pulls/7", user: { login: "wrong" }, path: "wrong.ts", line: 1, body: "wrong pull" }));
+			process.exit(0);
+		}
+		process.exit(1);
+	`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { extractGitHubIssuePr } = await import(${JSON.stringify(moduleUrl)});
+			const result = await extractGitHubIssuePr("https://github.com/owner/repo/pull/7#discussion_r999");
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout);
+	assert.doesNotMatch(result.content, /wrong pull/);
+	assert.match(result.content, /anchored review thread comment unavailable for this pull request/);
+});
+
+test("gh path still attempts an anchored review comment after page failure", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-page-fail-anchor-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `
+		const args = process.argv.slice(2);
+		if (args[0] === "--version") { console.log("gh version 2.0.0"); process.exit(0); }
+		if (args[0] === "pr" && args[1] === "view") {
+			console.log(JSON.stringify({ number: 7, title: "Page fail anchor", state: "OPEN", author: { login: "alice" }, body: "body", comments: [] }));
+			process.exit(0);
+		}
+		if (args[0] === "api" && args[1].includes("/pulls/7/comments?")) { process.exit(1); }
+		if (args[0] === "api" && args[1].endsWith("/pulls/comments/999")) {
+			console.log(JSON.stringify({ id: 999, pull_request_url: "https://api.github.com/repos/owner/repo/pulls/7", user: { login: "reviewer" }, path: "deep.ts", line: 44, body: "deep after page failure" }));
+			process.exit(0);
+		}
+		process.exit(1);
+	`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { extractGitHubIssuePr } = await import(${JSON.stringify(moduleUrl)});
+			const result = await extractGitHubIssuePr("https://github.com/owner/repo/pull/7#discussion_r999");
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout);
+	assert.match(result.content, /reviewer.*\[anchored\]/s);
+	assert.match(result.content, /deep after page failure/);
+});
+
+test("gh review thread page failure renders unavailable instead of none", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-review-unavailable-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `
+		const args = process.argv.slice(2);
+		if (args[0] === "--version") { console.log("gh version 2.0.0"); process.exit(0); }
+		if (args[0] === "pr" && args[1] === "view") {
+			console.log(JSON.stringify({ number: 7, title: "Unavailable reviews", state: "OPEN", author: { login: "alice" }, body: "body", comments: [] }));
+			process.exit(0);
+		}
+		if (args[0] === "api" && args[1].includes("/pulls/7/comments?")) { process.exit(1); }
+		process.exit(1);
+	`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { extractGitHubIssuePr } = await import(${JSON.stringify(moduleUrl)});
+			const result = await extractGitHubIssuePr("https://github.com/owner/repo/pull/7");
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout);
+	assert.match(result.content, /review threads: unavailable/);
+	assert.match(result.content, /Review thread comments\nUnavailable in this GitHub fetch path/);
+});
+
+test("extractGitHubIssuePr aborts active gh work with the caller signal", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-abort-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `
+		const args = process.argv.slice(2);
+		if (args[0] === "--version") { console.log("gh version 2.0.0"); process.exit(0); }
+		setTimeout(() => {}, 30000);
+	`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			globalThis.fetch = async (_input, init = {}) => {
+				if (!init.signal?.aborted) throw new Error("fallback fetch did not receive aborted signal");
+				throw new Error("aborted fallback fetch");
+			};
+			const { extractGitHubIssuePr } = await import(${JSON.stringify(moduleUrl)});
+			const controller = new AbortController();
+			setTimeout(() => controller.abort(), 50);
+			const started = Date.now();
+			const result = await extractGitHubIssuePr("https://github.com/owner/repo/pull/7", controller.signal, { lookup: async () => [{ address: "140.82.112.6", family: 4 }] });
+			console.log(JSON.stringify({ elapsed: Date.now() - started, result }));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout);
+	assert.equal(output.result.error, "Aborted");
+	assert.ok(output.elapsed < 1000, `expected abort before gh timeout, got ${output.elapsed}ms`);
+});
+
+test("extractGitHubIssuePr aborts a hung gh availability probe", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-probe-abort-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `setTimeout(() => {}, 30000);`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { extractGitHubIssuePr } = await import(${JSON.stringify(moduleUrl)});
+			const controller = new AbortController();
+			setTimeout(() => controller.abort(), 50);
+			const started = Date.now();
+			const result = await extractGitHubIssuePr("https://github.com/owner/repo/pull/7", controller.signal);
+			console.log(JSON.stringify({ elapsed: Date.now() - started, result }));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout);
+	assert.equal(output.result.error, "Aborted");
+	assert.ok(output.elapsed < 1000, `expected abort before gh probe timeout, got ${output.elapsed}ms`);
+});
+
+test("extractContent returns an actionable GitHub rate-limit result instead of HTML fall-through", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-rate-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `process.exit(1);`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			globalThis.fetch = async () => new Response("rate limited", { status: 403, headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "1800000000" } });
+			const { extractContent } = await import(${JSON.stringify(extractUrl)});
+			const lookup = ${publicLookup.toString()};
+			const result = await extractContent("https://github.com/owner/repo/issues/12", undefined, { lookup });
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout.split("\n").at(-2));
+	assert.equal(result.status, 403);
+	assert.match(result.error, /rate limit/i);
+	assert.match(result.content, /gh auth login/);
+});
+
+test("REST fallback fetches an anchored issue comment outside the first page", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-issue-anchor-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `process.exit(1);`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			globalThis.fetch = async (input) => {
+				const url = String(input);
+				if (url.endsWith("/issues/12")) return new Response(JSON.stringify({ number: 12, title: "Issue", state: "open", user: { login: "owner" }, body: "body", comments: 75 }), { status: 200 });
+				if (url.endsWith("/issues/12/comments?per_page=50")) return new Response(JSON.stringify([{ id: 1, user: { login: "first" }, created_at: "2026-01-01T00:00:00Z", body: "first page" }]), { status: 200 });
+				if (url.endsWith("/issues/comments/99")) return new Response(JSON.stringify({ id: 99, issue_url: "https://api.github.com/repos/owner/repo/issues/12", user: { login: "anchored" }, created_at: "2026-01-02T00:00:00Z", body: "outside first page" }), { status: 200 });
+				throw new Error("unexpected URL " + url);
+			};
+			const { extractContent } = await import(${JSON.stringify(extractUrl)});
+			const lookup = ${publicLookup.toString()};
+			const result = await extractContent("https://github.com/owner/repo/issues/12#issuecomment-99", undefined, { lookup });
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout.split("\n").at(-2));
+	assert.match(result.content, /anchored.*\[anchored\]/s);
+	assert.match(result.content, /outside first page/);
+	assert.match(result.content, /comments: at least 75/);
+	assert.match(result.content, /comments shown from at least 75/);
+});
+
+test("REST fallback rejects anchored issue comments from another work item", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-cross-issue-anchor-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `process.exit(1);`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			globalThis.fetch = async (input) => {
+				const url = String(input);
+				if (url.endsWith("/issues/12")) return new Response(JSON.stringify({ number: 12, title: "Issue", state: "open", user: { login: "owner" }, body: "body", comments: 1 }), { status: 200 });
+				if (url.endsWith("/issues/12/comments?per_page=50")) return new Response(JSON.stringify([]), { status: 200 });
+				if (url.endsWith("/issues/comments/99")) return new Response(JSON.stringify({ id: 98, issue_url: "https://api.github.com/repos/other/repo/issues/12", user: { login: "wrong" }, created_at: "2026-01-02T00:00:00Z", body: "wrong issue" }), { status: 200 });
+				throw new Error("unexpected URL " + url);
+			};
+			const { extractContent } = await import(${JSON.stringify(extractUrl)});
+			const lookup = ${publicLookup.toString()};
+			const result = await extractContent("https://github.com/owner/repo/issues/12#issuecomment-99", undefined, { lookup });
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout.split("\n").at(-2));
+	assert.doesNotMatch(result.content, /wrong issue/);
+	assert.match(result.content, /anchored comment unavailable for this issue or pull request/);
+});
+
+test("REST fallback fetches an anchored PR review comment outside the first page", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-review-anchor-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `process.exit(1);`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			globalThis.fetch = async (input) => {
+				const url = String(input);
+				if (url.endsWith("/pulls/7")) return new Response(JSON.stringify({ number: 7, title: "PR", state: "open", user: { login: "owner" }, body: "body", draft: false, base: { ref: "main" }, head: { ref: "feature", repo: { owner: { login: "owner" } } }, additions: 1, deletions: 0, changed_files: 75, review_comments: 12 }), { status: 200 });
+				if (url.endsWith("/issues/7/comments?per_page=50")) return new Response(JSON.stringify([]), { status: 200 });
+				if (url.endsWith("/pulls/7/files?per_page=50")) return new Response(JSON.stringify(Array.from({ length: 50 }, (_, index) => ({ filename: "file" + index + ".ts", additions: 1, deletions: 0 }))), { status: 200 });
+				if (url.endsWith("/pulls/7/comments?per_page=50")) return new Response(JSON.stringify([{ id: 1, user: { login: "first" }, path: "a.ts", line: 1, body: "first review" }]), { status: 200 });
+				if (url.endsWith("/pulls/comments/42")) return new Response(JSON.stringify({ id: 42, pull_request_url: "https://api.github.com/repos/owner/repo/pulls/7", user: { login: "reviewer" }, path: "b.ts", line: 9, body: "outside review page" }), { status: 200 });
+				throw new Error("unexpected URL " + url);
+			};
+			const { extractContent } = await import(${JSON.stringify(extractUrl)});
+			const lookup = ${publicLookup.toString()};
+			const result = await extractContent("https://github.com/owner/repo/pull/7#discussion_r42", undefined, { lookup });
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout.split("\n").at(-2));
+	assert.match(result.content, /reviewer.*\[anchored\]/s);
+	assert.match(result.content, /outside review page/);
+	assert.match(result.content, /commits unavailable/);
+	assert.match(result.content, /Review verdicts\nUnavailable in this GitHub fetch path/);
+	assert.match(result.content, /50 files shown from at least 75/);
+	assert.match(result.content, /Commits\nUnavailable in this GitHub fetch path/);
+	assert.match(result.content, /review threads: at least 12/);
+	assert.match(result.content, /review thread comments shown from at least 12/);
+	assert.match(result.content, /Linked references\nUnavailable in this GitHub fetch path/);
+});
+
+test("REST fallback does not render positive changedFiles as none when files are missing", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-gh-files-unavailable-"));
+	const binDir = join(root, "bin");
+	const agentDir = join(root, "agent");
+	await mkdir(binDir, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFakeExecutable(binDir, "gh", `process.exit(1);`);
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			globalThis.fetch = async (input) => {
+				const url = String(input);
+				if (url.endsWith("/pulls/7")) return new Response(JSON.stringify({ number: 7, title: "PR", state: "open", user: { login: "owner" }, body: "body", draft: false, base: { ref: "main" }, head: { ref: "feature", repo: { owner: { login: "owner" } } }, additions: 1, deletions: 0, changed_files: 3 }), { status: 200 });
+				if (url.endsWith("/issues/7/comments?per_page=50")) return new Response(JSON.stringify([]), { status: 200 });
+				if (url.endsWith("/pulls/7/files?per_page=50")) return new Response(JSON.stringify([]), { status: 200 });
+				if (url.endsWith("/pulls/7/comments?per_page=50")) return new Response(JSON.stringify([]), { status: 200 });
+				throw new Error("unexpected URL " + url);
+			};
+			const { extractContent } = await import(${JSON.stringify(extractUrl)});
+			const lookup = ${publicLookup.toString()};
+			const result = await extractContent("https://github.com/owner/repo/pull/7", undefined, { lookup });
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH || ""}`, PI_CODING_AGENT_DIR: agentDir },
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const result = JSON.parse(child.stdout.split("\n").at(-2));
+	assert.match(result.content, /0 files shown from at least 3/);
+	assert.doesNotMatch(result.content, /Files\nnone/);
+});


### PR DESCRIPTION
## Summary

Implements first-class GitHub PR and issue URL handling inside `fetch_content`.

GitHub work-item URLs now route before the generic web extractor and return a compact API-backed markdown view with metadata, body, checks/reviews where available, files/commits for PRs, comments, truncation markers, and escalation commands.

Closes #294.

## Validation

- `node --test test/github-issue-pr.test.mjs`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh review found no issues after the REST anchor fallback fix.
