### PR TITLE
fix: improve Gemini cookie diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Improved Gemini Web browser-cookie diagnostics so `/google-account` shows sanitized attempted browser/profile entries and distinguishes missing required cookies, password-store access, and decryption failures. Thanks to [@lmilojevicc](https://github.com/lmilojevicc) for issue #296.
+
 ## [0.24.2] - 2026-08-22
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Browse stored search results interactively. Lists all results from the current s
 
 ### /google-account
 
-Show the active Google account currently authenticated for Gemini Web. Useful when multiple Chromium profiles exist or `chromeProfile` is set in config.
+Show the active Google account currently authenticated for Gemini Web. If cookie extraction fails, it reports sanitized attempted browser/profile entries and whether the failure was missing required cookies, password-store access, decryption, SQLite, or profile lookup.
 
 ## Activity Monitor
 
@@ -816,7 +816,7 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Sear
 ## Limitations
 
 - If the curator cannot open a browser automatically, such as in Docker, WSL, SSH, or headless environments, the running curator URL is shown in the tool output. Copy it into a browser that can reach the Pi host, or use a tunnel/port-forward when needed.
-- Chromium cookie extraction for Gemini Web is opt-in via `allowBrowserCookies: true` or `PI_ALLOW_BROWSER_COOKIES=1`; no browser data or password store is touched while it is disabled. On macOS, enabling it may trigger a Keychain dialog. On Windows, Chrome and Edge v10 cookies use the current user's DPAPI key; v20 app-bound cookies are not supported. Required cookie names are checked before password-store access, and browser encryption passwords are cached only in-process. If `node:sqlite` is unavailable, the reader falls back to the `sqlite3` CLI or Python stdlib; `/google-account` reports a sanitized SQLite/profile/password diagnostic when extraction fails.
+- Chromium cookie extraction for Gemini Web is opt-in via `allowBrowserCookies: true` or `PI_ALLOW_BROWSER_COOKIES=1`; no browser data or password store is touched while it is disabled. On macOS, enabling it may trigger a Keychain dialog. On Windows, Chrome and Edge v10 cookies use the current user's DPAPI key; v20 app-bound cookies are not supported. Required cookie names are checked before password-store access, and browser encryption passwords are cached only in-process. If `node:sqlite` is unavailable, the reader falls back to the `sqlite3` CLI or Python stdlib; `/google-account` reports sanitized browser/profile attempts and classifies SQLite, profile, missing-cookie, password-store, and decryption failures.
 - YouTube private/age-restricted videos may fail on all extraction paths.
 - Gemini can process videos up to ~1 hour; longer videos may be truncated.
 - PDFs are text-extracted only (no OCR for scanned documents).

--- a/chrome-cookies.ts
+++ b/chrome-cookies.ts
@@ -19,6 +19,27 @@ interface BrowserConfig {
 type SqliteRow = Record<string, unknown>;
 type SqliteFailure = "unavailable" | "query";
 
+export type BrowserCookieAttemptStatus =
+	| "missing-database"
+	| "missing-required-cookies"
+	| "password-read-failed"
+	| "decryption-failed"
+	| "sqlite-unavailable"
+	| "sqlite-query-failed"
+	| "unsafe-profile"
+	| "no-host-cookies";
+
+export interface BrowserCookieAttemptDiagnostic {
+	browser: string;
+	profile: string;
+	status: BrowserCookieAttemptStatus;
+}
+
+export interface BrowserCookieDiagnosticDetails {
+	message: string;
+	attempts: BrowserCookieAttemptDiagnostic[];
+}
+
 interface BrowserCookieEntry {
 	name: string;
 	value: string;
@@ -56,6 +77,7 @@ const WINDOWS_BROWSER_CONFIGS: BrowserConfig[] = [
 
 const browserPasswordCache = new Map<string, Promise<string | null>>();
 let lastCookieDiagnostic: string | null = null;
+let lastCookieDiagnosticDetails: BrowserCookieDiagnosticDetails | null = null;
 let sqliteModule: typeof import("node:sqlite") | null = null;
 let sqliteImportAttempted = false;
 
@@ -65,6 +87,14 @@ export function getLastGoogleCookieDiagnostic(): string | null {
 
 export function getLastBrowserCookieDiagnostic(): string | null {
 	return lastCookieDiagnostic;
+}
+
+export function getLastGoogleCookieDiagnosticDetails(): BrowserCookieDiagnosticDetails | null {
+	return lastCookieDiagnosticDetails;
+}
+
+export function getLastBrowserCookieDiagnosticDetails(): BrowserCookieDiagnosticDetails | null {
+	return lastCookieDiagnosticDetails;
 }
 
 export async function getGoogleCookies(
@@ -83,15 +113,16 @@ export async function getBrowserCookiesForHosts(
 	options: { hosts: string[]; profile?: string; requiredCookies?: string[]; cookieNames?: Iterable<string>; requiredLabel?: string; requestUrl?: URL },
 ): Promise<{ cookies: CookieMap; warnings: string[]; cookieHeader?: string } | null> {
 	lastCookieDiagnostic = null;
+	lastCookieDiagnosticDetails = null;
 	if (!isBrowserCookieAccessAllowed()) {
-		lastCookieDiagnostic = "Browser cookie access is disabled; enable allowBrowserCookies to use browser cookies.";
+		setCookieDiagnostic("Browser cookie access is disabled; enable allowBrowserCookies to use browser cookies.");
 		return null;
 	}
 
 	const currentPlatform = process.platform;
 	const configs = currentPlatform === "darwin" ? MACOS_BROWSER_CONFIGS : currentPlatform === "linux" ? LINUX_BROWSER_CONFIGS : currentPlatform === "win32" ? WINDOWS_BROWSER_CONFIGS : [];
 	if (configs.length === 0) {
-		lastCookieDiagnostic = "Chromium cookie extraction is unsupported on this platform.";
+		setCookieDiagnostic("Chromium cookie extraction is unsupported on this platform.");
 		return null;
 	}
 
@@ -99,16 +130,17 @@ export async function getBrowserCookiesForHosts(
 	const rawProfile = typeof options.profile === "string" ? options.profile.trim() : "";
 	const requestedProfile = normalizeProfileName(options.profile);
 	if (rawProfile && !requestedProfile) {
-		lastCookieDiagnostic = "Configured Chromium profile must be a profile directory name, not a path.";
+		setCookieDiagnostic("Configured Chromium profile must be a profile directory name, not a path.");
 		return null;
 	}
 	const requiredCookies = normalizeCookieNames(options.requiredCookies);
 	const cookieNames = normalizeCookieNames(options.cookieNames ? [...options.cookieNames] : undefined);
 	const hosts = normalizeHosts(options.hosts);
 	if (hosts.length === 0) {
-		lastCookieDiagnostic = "No valid cookie hosts were requested.";
+		setCookieDiagnostic("No valid cookie hosts were requested.");
 		return null;
 	}
+	const attempts: BrowserCookieAttemptDiagnostic[] = [];
 	const home = currentPlatform === "win32" ? process.env.USERPROFILE || homedir() : homedir();
 	let sawCookieDatabase = false;
 	let sawRequiredCookies = false;
@@ -116,6 +148,7 @@ export async function getBrowserCookiesForHosts(
 	let sawBackendFailure: SqliteFailure | undefined;
 	let sawUnsafeProfilePath = false;
 	let sawWindowsAppBoundCookie = false;
+	let sawDecryptionFailure = false;
 
 	for (const config of configs) {
 		const profiles = requestedProfile ? [requestedProfile] : listBrowserProfiles(home, config);
@@ -123,11 +156,18 @@ export async function getBrowserCookiesForHosts(
 			const profilePath = resolveProfilePath(home, config, profile);
 			if (profilePath === "outside-root") {
 				sawUnsafeProfilePath = true;
+				recordCookieAttempt(attempts, config, profile, "unsafe-profile");
 				continue;
 			}
-			if (!profilePath) continue;
+			if (!profilePath) {
+				recordCookieAttempt(attempts, config, profile, "missing-database");
+				continue;
+			}
 			const cookiesPath = cookieDatabasePath(profilePath, config);
-			if (!cookiesPath) continue;
+			if (!cookiesPath) {
+				recordCookieAttempt(attempts, config, profile, "missing-database");
+				continue;
+			}
 			sawCookieDatabase = true;
 
 			const tempDir = mkdtempSync(join(tmpdir(), "pi-chrome-cookies-"));
@@ -139,8 +179,15 @@ export async function getBrowserCookiesForHosts(
 
 				if (requiredCookies?.length) {
 					const preflight = await hasCookieNames(tempDb, hosts, requiredCookies);
-					if (preflight.failure) sawBackendFailure = preflight.failure;
-					if (!preflight.present) continue;
+					if (preflight.failure) {
+						sawBackendFailure = preflight.failure;
+						recordCookieAttempt(attempts, config, profile, preflight.failure === "unavailable" ? "sqlite-unavailable" : "sqlite-query-failed");
+						continue;
+					}
+					if (!preflight.present) {
+						recordCookieAttempt(attempts, config, profile, "missing-required-cookies");
+						continue;
+					}
 					sawRequiredCookies = true;
 				}
 
@@ -151,19 +198,25 @@ export async function getBrowserCookiesForHosts(
 					warningSet.add(currentPlatform === "win32"
 						? `Could not read ${config.name} Windows cookie encryption key`
 						: `Could not read ${config.name} cookie encryption password`);
+					recordCookieAttempt(attempts, config, profile, "password-read-failed");
 					continue;
 				}
 				const metaVersion = await readMetaVersion(tempDb);
-				if (metaVersion.failure) sawBackendFailure = metaVersion.failure;
+				if (metaVersion.failure) {
+					sawBackendFailure = metaVersion.failure;
+					recordCookieAttempt(attempts, config, profile, metaVersion.failure === "unavailable" ? "sqlite-unavailable" : "sqlite-query-failed");
+				}
 				if (metaVersion.value === null) continue;
 				const rowsResult = await queryCookieRows(tempDb, hosts, cookieNames ?? null, Boolean(options.requestUrl));
 				if (rowsResult.status === "failure") {
 					sawBackendFailure = rowsResult.failure;
+					recordCookieAttempt(attempts, config, profile, rowsResult.failure === "unavailable" ? "sqlite-unavailable" : "sqlite-query-failed");
 					continue;
 				}
 
 				const entries: BrowserCookieEntry[] = [];
 				const cookies: CookieMap = {};
+				const requiredDecryptFailures = new Set<string>();
 				for (const row of rowsResult.rows) {
 					const name = typeof row.name === "string" ? row.name : "";
 					if (!name) continue;
@@ -174,6 +227,7 @@ export async function getBrowserCookiesForHosts(
 						value = currentPlatform === "win32"
 							? decryptWindowsCookieValue(encrypted, key, metaVersion.value >= 24)
 							: decryptCookieValue(encrypted, key, metaVersion.value >= 24);
+						if (!value && requiredCookies?.includes(name)) requiredDecryptFailures.add(name);
 					}
 					if (!value) continue;
 					const path = typeof row.path === "string" && row.path.startsWith("/") ? row.path : "/";
@@ -183,8 +237,20 @@ export async function getBrowserCookiesForHosts(
 				}
 
 				if (entries.length > 0) sawAnyHostCookie = true;
-				if (requiredCookies?.length && !requiredCookies.every((name) => Boolean(cookies[name]))) continue;
-				if (entries.length === 0) continue;
+				if (requiredCookies?.length && !requiredCookies.every((name) => Boolean(cookies[name]))) {
+					if (requiredCookies.some((name) => !cookies[name] && requiredDecryptFailures.has(name))) {
+						sawDecryptionFailure = true;
+						recordCookieAttempt(attempts, config, profile, "decryption-failed");
+					} else {
+						recordCookieAttempt(attempts, config, profile, "missing-required-cookies");
+					}
+					continue;
+				}
+				if (entries.length === 0) {
+					recordCookieAttempt(attempts, config, profile, requiredDecryptFailures.size > 0 ? "decryption-failed" : "no-host-cookies");
+					if (requiredDecryptFailures.size > 0) sawDecryptionFailure = true;
+					continue;
+				}
 				return {
 					cookies,
 					warnings: [...warningSet],
@@ -197,29 +263,40 @@ export async function getBrowserCookiesForHosts(
 	}
 
 	if (sawBackendFailure === "unavailable") {
-		lastCookieDiagnostic = "SQLite backend unavailable: install sqlite3 or use a runtime with SQLite support.";
+		setCookieDiagnostic("SQLite backend unavailable: install sqlite3 or use a runtime with SQLite support.", attempts);
 	} else if (sawBackendFailure === "query") {
-		lastCookieDiagnostic = "SQLite query failed while reading the copied Chromium cookie database.";
+		setCookieDiagnostic("SQLite query failed while reading the copied Chromium cookie database.", attempts);
 	} else if (sawUnsafeProfilePath) {
-		lastCookieDiagnostic = "Configured Chromium profile must resolve inside the browser profile root.";
+		setCookieDiagnostic("Configured Chromium profile must resolve inside the browser profile root.", attempts);
 	} else if (!sawCookieDatabase) {
-		lastCookieDiagnostic = requestedProfile
+		setCookieDiagnostic(requestedProfile
 			? `Chromium profile '${requestedProfile}' does not contain a cookie database.`
-			: "No detected Chromium profile contains a cookie database.";
+			: "No detected Chromium profile contains a cookie database.", attempts);
 	} else if (requiredCookies?.length && !sawRequiredCookies) {
-		lastCookieDiagnostic = `No detected Chromium profile contains the required ${options.requiredLabel ?? "browser"} cookies.`;
+		setCookieDiagnostic(`No detected Chromium profile contains the required ${options.requiredLabel ?? "browser"} cookies.`, attempts);
 	} else if (sawWindowsAppBoundCookie) {
-		lastCookieDiagnostic = "Windows Chromium v20 app-bound cookies are not supported.";
-	} else if (!sawAnyHostCookie) {
-		lastCookieDiagnostic = options.requestUrl
-			? "No detected Chromium profile contains cookies for the requested URL."
-			: "No detected Chromium profile contains cookies for the requested host.";
+		setCookieDiagnostic("Windows Chromium v20 app-bound cookies are not supported.", attempts);
 	} else if (warningSet.size > 0) {
-		lastCookieDiagnostic = [...warningSet][0];
+		setCookieDiagnostic([...warningSet][0], attempts);
+	} else if (sawDecryptionFailure) {
+		setCookieDiagnostic(`Required ${options.requiredLabel ?? "browser"} cookies could not be decrypted.`, attempts);
+	} else if (!sawAnyHostCookie) {
+		setCookieDiagnostic(options.requestUrl
+			? "No detected Chromium profile contains cookies for the requested URL."
+			: "No detected Chromium profile contains cookies for the requested host.", attempts);
 	} else {
-		lastCookieDiagnostic = "Required Gemini cookies were not available or could not be decrypted.";
+		setCookieDiagnostic("Required Gemini cookies were not available or could not be decrypted.", attempts);
 	}
 	return null;
+}
+
+function setCookieDiagnostic(message: string, attempts: BrowserCookieAttemptDiagnostic[] = []): void {
+	lastCookieDiagnostic = message;
+	lastCookieDiagnosticDetails = { message, attempts };
+}
+
+function recordCookieAttempt(attempts: BrowserCookieAttemptDiagnostic[], config: BrowserConfig, profile: string, status: BrowserCookieAttemptStatus): void {
+	attempts.push({ browser: config.name, profile, status });
 }
 
 function normalizeProfileName(value: string | undefined): string | undefined {

--- a/gemini-web.ts
+++ b/gemini-web.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
-import { getLastGoogleCookieDiagnostic, type CookieMap, getGoogleCookies } from "./chrome-cookies.ts";
+import { getLastGoogleCookieDiagnostic, getLastGoogleCookieDiagnosticDetails, type BrowserCookieDiagnosticDetails, type CookieMap, getGoogleCookies } from "./chrome-cookies.ts";
 import { getChromeProfileFromConfig, isBrowserCookieAccessAllowed, normalizeChromeProfile } from "./gemini-web-config.ts";
 
 const GEMINI_APP_URL = "https://gemini.google.com/app";
@@ -110,6 +110,10 @@ export async function isGeminiWebAvailable(chromeProfile?: string): Promise<Cook
 
 export function getGeminiWebAvailabilityDiagnostic(): string | null {
 	return isBrowserCookieAccessAllowed() ? getLastGoogleCookieDiagnostic() : null;
+}
+
+export function getGeminiWebAvailabilityDiagnosticDetails(): BrowserCookieDiagnosticDetails | null {
+	return isBrowserCookieAccessAllowed() ? getLastGoogleCookieDiagnosticDetails() : null;
 }
 
 export async function getActiveGoogleEmail(cookies: CookieMap): Promise<string | null> {

--- a/index.ts
+++ b/index.ts
@@ -42,7 +42,7 @@ import { join } from "node:path";
 import { isPerplexityAvailable } from "./perplexity.ts";
 import { isExaAvailable } from "./exa.ts";
 import { isGeminiApiAvailable } from "./gemini-api.ts";
-import { getActiveGoogleEmail, getGeminiWebAvailabilityDiagnostic, isGeminiWebAvailable } from "./gemini-web.ts";
+import { getActiveGoogleEmail, getGeminiWebAvailabilityDiagnostic, getGeminiWebAvailabilityDiagnosticDetails, isGeminiWebAvailable } from "./gemini-web.ts";
 import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
 import { isBraveAvailable } from "./brave.ts";
 import { isOpenAISearchAvailable } from "./openai-search.ts";
@@ -3321,14 +3321,16 @@ export default function (pi: ExtensionAPI) {
 			const cookies = await isGeminiWebAvailable();
 			if (!cookies) {
 				const diagnostic = getGeminiWebAvailabilityDiagnostic();
+				const diagnosticDetails = getGeminiWebAvailabilityDiagnosticDetails();
+				const attempted = formatCookieAttempts(diagnosticDetails?.attempts ?? []);
 				const text = diagnostic
-					? `Gemini Web is unavailable: ${diagnostic}`
+					? `Gemini Web is unavailable: ${diagnostic}${attempted ? ` Attempted browser profiles: ${attempted}.` : ""}`
 					: "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser.";
 				pi.sendMessage({
 					customType: "google-account",
 					content: [{ type: "text", text }],
 					display: true,
-					details: { available: false, cookieAccessAllowed: true, diagnostic },
+					details: { available: false, cookieAccessAllowed: true, diagnostic, cookieDiagnostic: diagnosticDetails },
 				}, { triggerTurn: true, deliverAs: "followUp" });
 				return;
 			}
@@ -3346,6 +3348,10 @@ export default function (pi: ExtensionAPI) {
 			}, { triggerTurn: true, deliverAs: "followUp" });
 		},
 	});
+
+	function formatCookieAttempts(attempts: { browser: string; profile: string; status: string }[]): string {
+		return attempts.map(({ browser, profile, status }) => `${browser}/${profile} (${status})`).join(", ");
+	}
 
 	if (isCommandEnabled(initConfig, "search")) pi.registerCommand("search", {
 		description: "Browse stored web search results",

--- a/test/chrome-cookie-extraction.test.mjs
+++ b/test/chrome-cookie-extraction.test.mjs
@@ -15,7 +15,11 @@ function createFixture(home, profile, rows = [], options = {}) {
 	const base = targetPlatform === "darwin"
 		? browser === "Brave"
 			? join(home, "Library", "Application Support", "BraveSoftware", "Brave-Browser")
-			: join(home, "Library", "Application Support", "Google", "Chrome")
+			: browser === "Helium"
+				? join(home, "Library", "Application Support", "net.imput.helium")
+				: browser === "Arc"
+					? join(home, "Library", "Application Support", "Arc", "User Data")
+					: join(home, "Library", "Application Support", "Google", "Chrome")
 		: targetPlatform === "win32"
 			? browser === "Edge"
 				? join(home, "AppData", "Local", "Microsoft", "Edge", "User Data")
@@ -84,8 +88,16 @@ function writeFailThenSucceedPasswordCommand(bin, countPath) {
 	return { COUNT_FILE: countPath };
 }
 
+function writeFailPasswordCommand(bin, countPath, targetPlatform = process.platform) {
+	const command = targetPlatform === "darwin" ? "security" : "secret-tool";
+	const script = `#!/bin/sh\nn=0\n[ -f "$COUNT_FILE" ] && n=$(cat "$COUNT_FILE")\nprintf '%s' $((n + 1)) > "$COUNT_FILE"\nprintf 'sensitive stderr' >&2\nexit 1\n`;
+	writeFileSync(join(bin, command), script);
+	chmodSync(join(bin, command), 0o755);
+	return { COUNT_FILE: countPath };
+}
+
 function runCookies(home, env, options = "{ requiredCookies: ['__Secure-1PSID', '__Secure-1PSIDTS'] }", platformOverride) {
-	return runCookieScript(env, `const r = await m.getGoogleCookies(${options}); console.log(JSON.stringify({ result: r, diagnostic: m.getLastGoogleCookieDiagnostic() }));`, platformOverride);
+	return runCookieScript(env, `const r = await m.getGoogleCookies(${options}); console.log(JSON.stringify({ result: r, diagnostic: m.getLastGoogleCookieDiagnostic(), details: m.getLastGoogleCookieDiagnosticDetails() }));`, platformOverride);
 }
 
 function runCookieScript(env, body, platformOverride) {
@@ -241,7 +253,47 @@ test("required-cookie preflight avoids password invocation for unrelated profile
 	const result = runCookies(home, env);
 	assert.equal(result.result, null);
 	assert.equal(result.diagnostic.includes("required Gemini cookies"), true);
+	assert.equal(result.details.attempts.some((attempt) => attempt.browser === "Chrome" && attempt.profile === "Profile 1" && attempt.status === "missing-required-cookies"), true);
 	assert.equal(existsSync(countPath), false);
+	rmSync(home, { recursive: true, force: true });
+	rmSync(bin, { recursive: true, force: true });
+});
+
+test("diagnostics report browser profile when password-store access fails", (t) => {
+	skipWithoutPython(t);
+	const home = mkdtempSync(join(tmpdir(), "pi-cookie-keychain-failure-"));
+	const bin = mkdtempSync(join(tmpdir(), "pi-cookie-bin-"));
+	createFixture(home, "Default", [
+		["__Secure-1PSID", "one", ".google.com", null, 1],
+		["__Secure-1PSIDTS", "two", ".google.com", null, 2],
+	], { browser: "Helium", targetPlatform: "darwin" });
+	const env = makeEnvironment(home, bin);
+	Object.assign(env, writeFailPasswordCommand(bin, join(home, "password-count"), "darwin"));
+	const result = runCookies(home, env, undefined, "darwin");
+	assert.equal(result.result, null);
+	assert.equal(result.diagnostic, "Could not read Helium cookie encryption password");
+	assert.deepEqual(result.details.attempts[0], { browser: "Helium", profile: "Default", status: "password-read-failed" });
+	assert.doesNotMatch(JSON.stringify(result), /one|two|peanuts|sensitive stderr/);
+	rmSync(home, { recursive: true, force: true });
+	rmSync(bin, { recursive: true, force: true });
+});
+
+test("diagnostics distinguish required cookie decryption failure", (t) => {
+	skipWithoutPython(t);
+	const home = mkdtempSync(join(tmpdir(), "pi-cookie-decrypt-failure-"));
+	const bin = mkdtempSync(join(tmpdir(), "pi-cookie-bin-"));
+	const encrypted = `hex:${Buffer.from("v10bad-ciphertext").toString("hex")}`;
+	createFixture(home, "Profile 2", [
+		["__Secure-1PSID", "", ".google.com", encrypted, 1],
+		["__Secure-1PSIDTS", "", ".google.com", encrypted, 2],
+	]);
+	const env = makeEnvironment(home, bin);
+	Object.assign(env, writePasswordCommand(bin, join(home, "password-count")));
+	const result = runCookies(home, env);
+	assert.equal(result.result, null);
+	assert.match(result.diagnostic, /could not be decrypted/);
+	assert.equal(result.details.attempts.some((attempt) => attempt.browser === "Chrome" && attempt.profile === "Profile 2" && attempt.status === "decryption-failed"), true);
+	assert.doesNotMatch(JSON.stringify(result), /peanuts|bad-ciphertext/);
 	rmSync(home, { recursive: true, force: true });
 	rmSync(bin, { recursive: true, force: true });
 });
@@ -357,6 +409,8 @@ test("unavailable SQLite backends produce actionable sanitized diagnostics", (t)
 	const result = runCookies(home, env);
 	assert.equal(result.result, null);
 	assert.match(result.diagnostic, /SQLite backend unavailable/);
+	assert.equal(result.details.attempts.some((attempt) => attempt.browser === "Chrome" && attempt.profile === "Profile 2" && attempt.status === "sqlite-unavailable"), true);
+	assert.equal(result.details.attempts.some((attempt) => attempt.browser === "Chrome" && attempt.profile === "Profile 2" && attempt.status === "missing-required-cookies"), false);
 	assert.doesNotMatch(result.diagnostic, /one|peanuts|stderr|password/i);
 	rmSync(home, { recursive: true, force: true });
 	rmSync(bin, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Improves Gemini Web browser-cookie diagnostics without adding the new browser-selection or custom profile-path API requested in #297.

`/google-account` now reports sanitized attempted browser/profile entries and distinguishes missing required cookies, password-store access failures, and decryption failures. The diagnostics do not include cookie values, passwords, raw Keychain stderr, or profile paths.

Closes #296.

## Validation

- `node --test test/chrome-cookie-extraction.test.mjs test/gemini-web-cookie-opt-in.test.mjs`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh review found no issues.

## Note

#297 remains open because browser selection and custom profile paths need a separate product/API/security decision.
