### PR TITLE
feat: route hosted search by current model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Auto-specialize GitHub pull request and issue URLs in `fetch_content`, with `gh`-first metadata, bounded REST fallback, comment-anchor inclusion, truncation markers, and the `githubPrIssue.enabled` opt-out (#294).
+- Added opt-in `searchRouting.useCurrentModel` routing for automatic searches. Official OpenAI GPT Responses models can now fund an isolated Hosted `web_search` request using their exact model, endpoint, credentials, and headers before configured fallbacks. Thanks to [@nyankosama](https://github.com/nyankosama) for PR #293.
+- Added strict Hosted Search response validation: responses must contain a real `web_search_call`; explicit unsupported-tool errors are classified separately for configured fallback routes.
 
 ### Fixed
 - Improved Gemini Web browser-cookie diagnostics so `/google-account` shows sanitized attempted browser/profile entries and distinguishes missing required cookies, password-store access, and decryption failures. Thanks to [@lmilojevicc](https://github.com/lmilojevicc) for issue #296.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Auto-specialize GitHub pull request and issue URLs in `fetch_content`, with `gh`-first metadata, bounded REST fallback, comment-anchor inclusion, truncation markers, and the `githubPrIssue.enabled` opt-out (#294).
 - Added opt-in `searchRouting.useCurrentModel` routing for automatic searches. Official OpenAI GPT Responses models can now fund an isolated Hosted `web_search` request using their exact model, endpoint, credentials, and headers before configured fallbacks. Thanks to [@nyankosama](https://github.com/nyankosama) for PR #293.
 - Added strict Hosted Search response validation: responses must contain a real `web_search_call`; explicit unsupported-tool errors are classified separately for configured fallback routes.
+- Extended current-model Hosted Search routing to official `openai-codex` GPT Responses models through the Codex Responses endpoint.
 
 ### Fixed
 - Improved Gemini Web browser-cookie diagnostics so `/google-account` shows sanitized attempted browser/profile entries and distinguishes missing required cookies, password-store access, and decryption failures. Thanks to [@lmilojevicc](https://github.com/lmilojevicc) for issue #296.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To route automatic searches through the active Pi model, configure an ordered ro
 }
 ```
 
-With `useCurrentModel: true`, the automatic `openai` step uses Hosted `web_search` only when the active model is a GPT model from provider `openai`, uses `openai-responses`, and points at HTTPS `api.openai.com`. Third-party gateways, Azure, Codex Responses, and other models continue to the next route entry. A tool-level `provider` or top-level `provider` remains an explicit override; `provider: "openai"` keeps the existing independent OpenAI/Codex search-model behavior.
+With `useCurrentModel: true`, the automatic `openai` step uses Hosted `web_search` when the active model is a GPT model backed by an official OpenAI Responses endpoint: `openai`/`openai-responses` on HTTPS `api.openai.com`, or `openai-codex`/`openai-codex-responses` on the official ChatGPT Codex endpoint. Third-party gateways, Azure, and other models continue to the next route entry. A tool-level `provider` or top-level `provider` remains an explicit override; `provider: "openai"` keeps the existing independent OpenAI/Codex search-model behavior.
 
 For sandboxed networks that provide outbound proxy transport through environment variables, set `ssrf.trustEnvProxy` to `true` to skip local DNS preflight for proxied hostnames:
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ In `auto` mode (default), `web_search` tries a configured SearXNG endpoint first
 
 If your OpenAI key belongs to a third-party Responses-compatible gateway, set `openaiResponsesUrl` to that gateway's full Responses endpoint. The default remains `https://api.openai.com/v1/responses`.
 
+To route automatic searches through the active Pi model, configure an ordered route without a top-level `provider`:
+
+```json
+{
+  "searchRouting": {
+    "providers": ["openai", "tavily"],
+    "useCurrentModel": true,
+    "fallbackOn": ["unsupported", "transient", "quota", "network", "invalid-response"]
+  }
+}
+```
+
+With `useCurrentModel: true`, the automatic `openai` step uses Hosted `web_search` only when the active model is a GPT model from provider `openai`, uses `openai-responses`, and points at HTTPS `api.openai.com`. Third-party gateways, Azure, Codex Responses, and other models continue to the next route entry. A tool-level `provider` or top-level `provider` remains an explicit override; `provider: "openai"` keeps the existing independent OpenAI/Codex search-model behavior.
+
 For sandboxed networks that provide outbound proxy transport through environment variables, set `ssrf.trustEnvProxy` to `true` to skip local DNS preflight for proxied hostnames:
 
 ```json
@@ -262,7 +276,7 @@ When Readability fails or returns only a cookie notice, the extension can retry 
 
 ```
 web_search(query)
-  → SearXNG (if configured) → OpenAI (when suitable) → Exa → Brave → Parallel → TinyFish → Search1API → Searchinfinity → Querit → Tavily → Firecrawl → Jina → SERPdive → Perplexity → Gemini
+  → configured searchRouting (optionally active-model-aware OpenAI Hosted Search) → automatic provider chain
 
 fetch_content(url)
   → Video file?  Gemini API (Files API) → Gemini Web (if browser cookies enabled)
@@ -360,9 +374,9 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "geminiApiKey": "AIza...",
   "geminiBaseUrl": "https://my-gateway.example.com/gemini",
   "cloudflareApiKey": "...",
-  "provider": "openai",
   "searchRouting": {
     "providers": ["openai", "brave", "exa"],
+    "useCurrentModel": false,
     "fallbackOn": ["transient", "quota", "network", "invalid-response"]
   },
   "fetchRouting": {

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -7,7 +7,12 @@ import { getGeminiWebAvailabilityDiagnostic, isGeminiWebAvailable, queryWithCook
 import { isPerplexityAvailable, searchWithPerplexity, type SearchResult, type SearchResponse, type SearchOptions } from "./perplexity.ts";
 import { isExaAvailable, searchWithExa } from "./exa.ts";
 import { isBraveAvailable, searchWithBrave } from "./brave.ts";
-import { isOpenAISearchAvailable, searchWithOpenAI } from "./openai-search.ts";
+import {
+	isCurrentModelHostedSearchEligible,
+	isOpenAISearchAvailable,
+	searchWithCurrentModelOpenAI,
+	searchWithOpenAI,
+} from "./openai-search.ts";
 import { isParallelAvailable, searchWithParallel } from "./parallel.ts";
 import { isParallelMcpAvailable, searchWithParallelMcp } from "./parallel-mcp.ts";
 import { isTinyFishAvailable, searchWithTinyFish } from "./tinyfish.ts";
@@ -46,12 +51,14 @@ export type SearchProviderErrorKind =
 	| "auth"
 	| "invalid-request"
 	| "invalid-response"
+	| "unsupported"
 	| "aborted"
 	| "unknown";
 
 export interface SearchRoutingConfig {
 	providers: ResolvedSearchProvider[];
-	fallbackOn: Array<Extract<SearchProviderErrorKind, "transient" | "quota" | "network" | "invalid-response">>;
+	useCurrentModel?: boolean;
+	fallbackOn: Array<Extract<SearchProviderErrorKind, "transient" | "quota" | "network" | "invalid-response" | "unsupported">>;
 }
 
 export class SearchProviderError extends Error {
@@ -96,7 +103,7 @@ const DEFAULT_SEARCH_MODEL = "gemini-3.6-flash";
 // Explicit-only providers (Parallel MCP, DuckDuckGo, AnySearch, xAI, Bright Data, SerpBase, Serper, Valyu) are deliberately absent:
 // `all` must never fan out to an opt-in or paid provider without the user asking for it.
 const ALL_SEARCH_PROVIDERS: ResolvedSearchProvider[] = ["searxng", "openai", "exa", "brave", "parallel", "tinyfish", "search1api", "searchinfinity", "querit", "tavily", "firecrawl", "jina", "serpdive", "kagi", "ollama", "perplexity", "gemini", "bocha"];
-const VALID_ROUTING_KINDS = ["transient", "quota", "network", "invalid-response"] as const;
+const VALID_ROUTING_KINDS = ["transient", "quota", "network", "invalid-response", "unsupported"] as const;
 
 type SearchConfig = {
 	searchProvider: SearchProviderSelection;
@@ -144,19 +151,27 @@ function normalizeSearchRouting(value: unknown): SearchRoutingConfig {
 	}
 	const raw = value as Record<string, unknown>;
 	const providers = normalizeResolvedProviderList(raw.providers, `searchRouting.providers in ${CONFIG_PATH}`);
+	const useCurrentModel = raw.useCurrentModel;
+	if (useCurrentModel !== undefined && typeof useCurrentModel !== "boolean") {
+		throw new Error(`searchRouting.useCurrentModel in ${CONFIG_PATH} must be a boolean`);
+	}
 	if (!Array.isArray(raw.fallbackOn) || raw.fallbackOn.length === 0) {
 		throw new Error(`searchRouting.fallbackOn in ${CONFIG_PATH} must be a non-empty array`);
 	}
 	const fallbackOn: SearchRoutingConfig["fallbackOn"] = [];
 	for (const kind of raw.fallbackOn) {
 		if (typeof kind !== "string" || !VALID_ROUTING_KINDS.includes(kind as typeof VALID_ROUTING_KINDS[number])) {
-			throw new Error(`searchRouting.fallbackOn in ${CONFIG_PATH} may only contain transient, quota, network, or invalid-response`);
+			throw new Error(`searchRouting.fallbackOn in ${CONFIG_PATH} may only contain transient, quota, network, invalid-response, or unsupported`);
 		}
 		if (!fallbackOn.includes(kind as SearchRoutingConfig["fallbackOn"][number])) {
 			fallbackOn.push(kind as SearchRoutingConfig["fallbackOn"][number]);
 		}
 	}
-	return { providers, fallbackOn };
+	return {
+		providers,
+		...(useCurrentModel !== undefined ? { useCurrentModel: useCurrentModel as boolean } : {}),
+		fallbackOn,
+	};
 }
 
 export function getConfiguredSearchRouting(): SearchRoutingConfig | undefined {
@@ -278,6 +293,7 @@ function classifyProviderError(provider: ResolvedSearchProvider, err: unknown): 
 	const lower = message.toLowerCase();
 	const status = providerErrorStatus(message);
 	let kind: SearchProviderErrorKind = "unknown";
+	const mentionsUnsupportedWebSearch = /(?:web[_ -]?search|web[_ -]?search_preview|(?:the )?tool)\b.*\b(?:unsupported|not supported|does not support|doesn't support|unknown|unrecognized|unavailable|not found)|\b(?:unsupported|not supported|does not support|doesn't support|unknown|unrecognized|unavailable|not found)\b.*\b(?:web[_ -]?search|web[_ -]?search_preview|(?:the )?tool)/i.test(lower);
 	if (err instanceof CredentialResolutionError || /(?:api )?key (?:not found|missing)|credential resolution/.test(lower)) {
 		kind = "credential";
 	} else if (isAbortError(err)) {
@@ -286,6 +302,8 @@ function classifyProviderError(provider: ResolvedSearchProvider, err: unknown): 
 		kind = "quota";
 	} else if (status === 401 || status === 403) {
 		kind = "auth";
+	} else if (provider === "openai" && (status === 400 || status === 422) && mentionsUnsupportedWebSearch) {
+		kind = "unsupported";
 	} else if (status === 400 || status === 422) {
 		kind = "invalid-request";
 	} else if (status === 402 || status === 429) {
@@ -298,7 +316,7 @@ function classifyProviderError(provider: ResolvedSearchProvider, err: unknown): 
 		kind = "auth";
 	} else if (/bad request|invalid request/.test(lower)) {
 		kind = "invalid-request";
-	} else if (/invalid json|no parseable response|no parseable results|invalid response|returned empty response/.test(lower)) {
+	} else if (/invalid json|no parseable response|no parseable results|invalid response|returned empty response|no web_search_call/.test(lower)) {
 		kind = "invalid-response";
 	} else if (/temporar|service unavailable|server error/.test(lower)) {
 		kind = "transient";
@@ -314,9 +332,12 @@ async function searchWithResolvedProvider(
 	provider: ResolvedSearchProvider,
 	query: string,
 	options: FullSearchOptions,
+	useCurrentModel = false,
 ): Promise<AttributedSearchResponse> {
 	if (provider === "openai") {
-		const result = await searchWithOpenAI(query, options, options.extensionContext);
+		const result = useCurrentModel
+			? await searchWithCurrentModelOpenAI(query, options, options.extensionContext)
+			: await searchWithOpenAI(query, options, options.extensionContext);
 		return { ...result, provider };
 	}
 	if (provider === "brave") return { ...(await searchWithBrave(query, options)), provider };
@@ -357,8 +378,12 @@ async function searchWithResolvedProvider(
 	throw new Error("Exa search returned no results.");
 }
 
-async function isResolvedProviderAvailable(provider: ResolvedSearchProvider, options: FullSearchOptions): Promise<boolean> {
-	if (provider === "openai") return isOpenAISearchAvailable(options.extensionContext);
+async function isResolvedProviderAvailable(provider: ResolvedSearchProvider, options: FullSearchOptions, useCurrentModel = false): Promise<boolean> {
+	if (provider === "openai") {
+		return useCurrentModel
+			? isCurrentModelHostedSearchEligible(options.extensionContext)
+			: isOpenAISearchAvailable(options.extensionContext);
+	}
 	if (provider === "brave") return isBraveAvailable();
 	if (provider === "parallel") return isParallelAvailable();
 	if (provider === "parallel-mcp") return isParallelMcpAvailable();
@@ -499,12 +524,13 @@ async function searchWithConfiguredRouting(
 ): Promise<AttributedSearchResponse> {
 	const diagnostics: string[] = [];
 	for (const provider of routing.providers) {
-		if (!(await isResolvedProviderAvailable(provider, options))) {
+		const useCurrentModel = provider === "openai" && routing.useCurrentModel === true;
+		if (!(await isResolvedProviderAvailable(provider, options, useCurrentModel))) {
 			diagnostics.push(`${provider}: unavailable`);
 			continue;
 		}
 		try {
-			return await searchWithResolvedProvider(provider, query, options);
+			return await searchWithResolvedProvider(provider, query, options, useCurrentModel);
 		} catch (err) {
 			const classified = classifyProviderError(provider, err);
 			diagnostics.push(`${provider} [${classified.kind}]: ${errorMessage(err)}`);

--- a/index.ts
+++ b/index.ts
@@ -45,7 +45,7 @@ import { isGeminiApiAvailable } from "./gemini-api.ts";
 import { getActiveGoogleEmail, getGeminiWebAvailabilityDiagnostic, getGeminiWebAvailabilityDiagnosticDetails, isGeminiWebAvailable } from "./gemini-web.ts";
 import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
 import { isBraveAvailable } from "./brave.ts";
-import { isOpenAISearchAvailable } from "./openai-search.ts";
+import { isCurrentModelHostedSearchEligible, isOpenAISearchAvailable } from "./openai-search.ts";
 import { isParallelAvailable } from "./parallel.ts";
 import { isParallelMcpAvailable } from "./parallel-mcp.ts";
 import { isTinyFishAvailable } from "./tinyfish.ts";
@@ -453,7 +453,7 @@ export function resolveCuratorDefaultProvider(
 	ctx?: Pick<ExtensionContext, "model">,
 	options?: Pick<PendingCurate, "numResults" | "recencyFilter">,
 ): CuratorProvider {
-	return resolveProvider(provider, available, options, shouldUseOpenAICodexDefault(ctx));
+	return resolveProvider(provider, available, options, shouldUseOpenAICodexDefault(ctx), ctx);
 }
 
 function firstAvailableProvider(available: ProviderAvailability, preferOpenAI: boolean, fallback: ResolvedSearchProvider): ResolvedSearchProvider {
@@ -484,6 +484,7 @@ function resolveProvider(
 	available: ProviderAvailability,
 	options?: Pick<PendingCurate, "numResults" | "recencyFilter">,
 	preferOpenAICodexDefault = false,
+	ctx?: Pick<ExtensionContext, "model">,
 ): CuratorProvider {
 	if (Array.isArray(provider)) return "all";
 	const preferOpenAI = shouldPreferOpenAI(options, preferOpenAICodexDefault);
@@ -492,9 +493,10 @@ function resolveProvider(
 		const routing = getConfiguredSearchRouting();
 		if (routing) {
 			for (const candidate of routing.providers) {
+				if (candidate === "openai" && routing.useCurrentModel === true && !isCurrentModelHostedSearchEligible(ctx)) continue;
 				if (available[candidate]) return candidate;
 			}
-			return routing.providers[0];
+			return routing.providers.find(candidate => candidate !== "openai" || routing.useCurrentModel !== true || isCurrentModelHostedSearchEligible(ctx)) ?? routing.providers[0];
 		}
 		return firstAvailableProvider(available, preferOpenAI, "exa");
 	}

--- a/openai-search.ts
+++ b/openai-search.ts
@@ -47,6 +47,30 @@ interface OpenAIAuth {
 	model: string;
 	headers: ProviderHeaders;
 	responsesUrl: string;
+	useCodexEndpoint?: boolean;
+}
+
+type CurrentModel = NonNullable<ExtensionContext["model"]>;
+
+function resolveOfficialModelResponsesUrl(model: CurrentModel): string {
+	const url = new URL(model.baseUrl);
+	if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "api.openai.com") {
+		throw new Error("Current model base URL is not the official OpenAI API endpoint");
+	}
+	const pathname = url.pathname.replace(/\/+$/u, "");
+	url.pathname = `${pathname}/responses`;
+	return url.toString();
+}
+
+export function isCurrentModelHostedSearchEligible(ctx?: Pick<ExtensionContext, "model">): boolean {
+	const model = ctx?.model;
+	if (!model || model.provider !== "openai" || model.api !== "openai-responses" || !/^gpt-/iu.test(model.id)) return false;
+	try {
+		resolveOfficialModelResponsesUrl(model);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 interface NormalizedDomainFilters {
@@ -240,6 +264,25 @@ export async function isOpenAISearchAvailable(ctx?: ExtensionContext): Promise<b
 	});
 }
 
+async function resolveCurrentModelAuth(ctx: ExtensionContext, signal?: AbortSignal): Promise<OpenAIAuth> {
+	const model = ctx.model;
+	if (!model || !isCurrentModelHostedSearchEligible(ctx)) {
+		throw new Error("Current model is not eligible for official OpenAI Hosted web search");
+	}
+	const resolved = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+	if (signal?.aborted) signal.throwIfAborted();
+	if (!resolved.ok) throw new Error(`OpenAI current model authentication failed: ${resolved.error}`);
+	if (!resolved.apiKey) throw new Error("OpenAI current model authentication failed: API key unavailable");
+	return {
+		provider: "openai",
+		apiKey: resolved.apiKey,
+		model: model.id,
+		headers: resolved.headers ?? {},
+		responsesUrl: resolveOfficialModelResponsesUrl(model),
+		useCodexEndpoint: false,
+	};
+}
+
 function buildInstructions(options: SearchOptions): string {
 	const lines = [
 		"Search the web and return a concise answer grounded only in the web results.",
@@ -279,14 +322,26 @@ function buildWebSearchTool(options: SearchOptions): Record<string, unknown> {
 	return tool;
 }
 
-async function parseOpenAIResponse(response: Response): Promise<Record<string, unknown>> {
+interface ParsedOpenAIResponse {
+	payload: Record<string, unknown>;
+	webSearchCallSeen: boolean;
+}
+
+function isWebSearchCall(item: unknown): boolean {
+	return !!item && typeof item === "object" && (item as { type?: unknown }).type === "web_search_call";
+}
+
+async function parseOpenAIResponse(response: Response): Promise<ParsedOpenAIResponse> {
 	const text = await response.text();
 	const trimmed = text.trim();
 	if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
 		try {
 			const parsed = JSON.parse(trimmed);
-			if (Array.isArray(parsed)) return { output: parsed };
-			return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : { output: [] };
+			const payload = Array.isArray(parsed)
+				? { output: parsed }
+				: parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : { output: [] };
+			const output = Array.isArray(payload.output) ? payload.output : [];
+			return { payload, webSearchCallSeen: output.some(isWebSearchCall) };
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			throw new Error(`OpenAI API returned invalid JSON: ${message}`);
@@ -295,13 +350,18 @@ async function parseOpenAIResponse(response: Response): Promise<Record<string, u
 
 	const outputItems: unknown[] = [];
 	let completedResponse: Record<string, unknown> | null = null;
+	let webSearchCallSeen = false;
 	for (const line of text.split("\n")) {
 		if (!line.startsWith("data: ")) continue;
 		const data = line.slice(6).trim();
 		if (!data || data === "[DONE]") continue;
 		try {
 			const parsed = JSON.parse(data) as Record<string, unknown>;
-			if (parsed.type === "response.output_item.done" && parsed.item) outputItems.push(parsed.item);
+			if (typeof parsed.type === "string" && parsed.type.startsWith("response.web_search_call")) webSearchCallSeen = true;
+			if (parsed.type === "response.output_item.done" && parsed.item) {
+				outputItems.push(parsed.item);
+				webSearchCallSeen ||= isWebSearchCall(parsed.item);
+			}
 			if ((parsed.type === "response.done" || parsed.type === "response.completed") && parsed.response && typeof parsed.response === "object") {
 				completedResponse = parsed.response as Record<string, unknown>;
 			}
@@ -311,9 +371,10 @@ async function parseOpenAIResponse(response: Response): Promise<Record<string, u
 
 	if (completedResponse) {
 		const output = Array.isArray(completedResponse.output) ? completedResponse.output : [];
-		return output.length > 0 ? completedResponse : { ...completedResponse, output: outputItems };
+		const payload = output.length > 0 ? completedResponse : { ...completedResponse, output: outputItems };
+		return { payload, webSearchCallSeen: webSearchCallSeen || output.some(isWebSearchCall) };
 	}
-	if (outputItems.length > 0) return { output: outputItems };
+	if (outputItems.length > 0) return { payload: { output: outputItems }, webSearchCallSeen: webSearchCallSeen || outputItems.some(isWebSearchCall) };
 	throw new Error("OpenAI API returned no parseable response output");
 }
 
@@ -411,21 +472,11 @@ function extractAnswer(output: unknown[]): string {
 	return parts.join("\n").trim();
 }
 
-export async function searchWithOpenAI(
+async function runOpenAISearch(
 	query: string,
-	options: SearchOptions = {},
-	ctx?: ExtensionContext,
+	options: SearchOptions,
+	auth: OpenAIAuth,
 ): Promise<SearchResponse> {
-	const auth = await resolveOpenAIAuth(ctx, options.signal);
-	if (!auth) {
-		throw new Error(
-			"OpenAI web search unavailable. Either:\n" +
-			"  1. Use /login to sign in with a Codex subscription\n" +
-			`  2. Create ${CONFIG_PATH} with { "openaiApiKey": "your-key" }\n` +
-			"  3. Set OPENAI_API_KEY environment variable",
-		);
-	}
-
 	const activityId = activityMonitor.logStart({ type: "api", query });
 	const headers: Record<string, string> = {
 		...toRequestHeaders(auth.headers),
@@ -433,7 +484,7 @@ export async function searchWithOpenAI(
 		"Content-Type": "application/json",
 		"OpenAI-Beta": "responses=experimental",
 	};
-	const useCodexEndpoint = auth.provider === "openai-codex" || isCodexJwt(auth.apiKey);
+	const useCodexEndpoint = auth.useCodexEndpoint ?? (auth.provider === "openai-codex" || isCodexJwt(auth.apiKey));
 	if (useCodexEndpoint) {
 		const accountId = extractAccountId(auth.apiKey);
 		if (accountId) headers["chatgpt-account-id"] = accountId;
@@ -469,7 +520,8 @@ export async function searchWithOpenAI(
 		}
 
 		const parsed = await parseOpenAIResponse(response);
-		const output = Array.isArray(parsed.output) ? parsed.output : [];
+		const output = Array.isArray(parsed.payload.output) ? parsed.payload.output : [];
+		if (!parsed.webSearchCallSeen) throw new Error("OpenAI web_search returned no web_search_call");
 		const answer = extractAnswer(output);
 		const results = extractSearchResults(output, options.numResults);
 
@@ -492,4 +544,31 @@ export async function searchWithOpenAI(
 		if (err instanceof Error) redactedError.name = err.name;
 		throw redactedError;
 	}
+}
+
+export async function searchWithOpenAI(
+	query: string,
+	options: SearchOptions = {},
+	ctx?: ExtensionContext,
+): Promise<SearchResponse> {
+	const auth = await resolveOpenAIAuth(ctx, options.signal);
+	if (!auth) {
+		throw new Error(
+			"OpenAI web search unavailable. Either:\n" +
+			"  1. Use /login to sign in with a Codex subscription\n" +
+			`  2. Create ${CONFIG_PATH} with { "openaiApiKey": "your-key" }\n` +
+			"  3. Set OPENAI_API_KEY environment variable",
+		);
+	}
+	return runOpenAISearch(query, options, auth);
+}
+
+export async function searchWithCurrentModelOpenAI(
+	query: string,
+	options: SearchOptions = {},
+	ctx?: ExtensionContext,
+): Promise<SearchResponse> {
+	if (!ctx) throw new Error("OpenAI current-model search requires an extension context");
+	const auth = await resolveCurrentModelAuth(ctx, options.signal);
+	return runOpenAISearch(query, options, auth);
 }

--- a/openai-search.ts
+++ b/openai-search.ts
@@ -52,21 +52,38 @@ interface OpenAIAuth {
 
 type CurrentModel = NonNullable<ExtensionContext["model"]>;
 
-function resolveOfficialModelResponsesUrl(model: CurrentModel): string {
+interface CurrentModelSearchTarget {
+	responsesUrl: string;
+	useCodexEndpoint: boolean;
+}
+
+function resolveCurrentModelSearchTarget(model: CurrentModel): CurrentModelSearchTarget {
 	const url = new URL(model.baseUrl);
-	if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "api.openai.com") {
-		throw new Error("Current model base URL is not the official OpenAI API endpoint");
+	if (url.protocol !== "https:") throw new Error("Current model base URL must use HTTPS");
+
+	if (model.provider === "openai" && model.api === "openai-responses" && url.hostname.toLowerCase() === "api.openai.com") {
+		const pathname = url.pathname.replace(/\/+$/u, "");
+		url.pathname = `${pathname}/responses`;
+		return { responsesUrl: url.toString(), useCodexEndpoint: false };
 	}
-	const pathname = url.pathname.replace(/\/+$/u, "");
-	url.pathname = `${pathname}/responses`;
-	return url.toString();
+
+	if (
+		model.provider === "openai-codex" &&
+		model.api === "openai-codex-responses" &&
+		url.hostname.toLowerCase() === "chatgpt.com" &&
+		url.pathname.replace(/\/+$/u, "") === "/backend-api"
+	) {
+		return { responsesUrl: CODEX_RESPONSES_URL, useCodexEndpoint: true };
+	}
+
+	throw new Error("Current model is not backed by an official OpenAI Responses endpoint");
 }
 
 export function isCurrentModelHostedSearchEligible(ctx?: Pick<ExtensionContext, "model">): boolean {
 	const model = ctx?.model;
-	if (!model || model.provider !== "openai" || model.api !== "openai-responses" || !/^gpt-/iu.test(model.id)) return false;
+	if (!model || !/^gpt-/iu.test(model.id)) return false;
 	try {
-		resolveOfficialModelResponsesUrl(model);
+		resolveCurrentModelSearchTarget(model);
 		return true;
 	} catch {
 		return false;
@@ -269,6 +286,7 @@ async function resolveCurrentModelAuth(ctx: ExtensionContext, signal?: AbortSign
 	if (!model || !isCurrentModelHostedSearchEligible(ctx)) {
 		throw new Error("Current model is not eligible for official OpenAI Hosted web search");
 	}
+	const target = resolveCurrentModelSearchTarget(model);
 	const resolved = await ctx.modelRegistry.getApiKeyAndHeaders(model);
 	if (signal?.aborted) signal.throwIfAborted();
 	if (!resolved.ok) throw new Error(`OpenAI current model authentication failed: ${resolved.error}`);
@@ -278,8 +296,8 @@ async function resolveCurrentModelAuth(ctx: ExtensionContext, signal?: AbortSign
 		apiKey: resolved.apiKey,
 		model: model.id,
 		headers: resolved.headers ?? {},
-		responsesUrl: resolveOfficialModelResponsesUrl(model),
-		useCodexEndpoint: false,
+		responsesUrl: target.responsesUrl,
+		useCodexEndpoint: target.useCodexEndpoint,
 	};
 }
 

--- a/test/provider-credential-source.test.mjs
+++ b/test/provider-credential-source.test.mjs
@@ -79,7 +79,10 @@ test("previously unsupported providers resolve explicit env and command sources 
 		globalThis.fetch = async (url, init = {}) => {
 			calls.push({ url: String(url), headers: Object.fromEntries(new Headers(init.headers)) });
 			return new Response(JSON.stringify({
-				output: [{ type: "message", content: [{ type: "output_text", text: "OpenAI answer" }] }],
+				output: [
+					{ type: "web_search_call", action: { sources: [] } },
+					{ type: "message", content: [{ type: "output_text", text: "OpenAI answer" }] },
+				],
 			}), { status: 200 });
 		};
 		await searchWithOpenAI("openai", { numResults: 1 });

--- a/test/provider-precedence.test.mjs
+++ b/test/provider-precedence.test.mjs
@@ -34,7 +34,10 @@ function runTool(agentDir, provider) {
 			const urlText = String(url);
 			calls.push(urlText);
 			if (urlText === "https://api.openai.com/v1/responses") {
-				return new Response(JSON.stringify({ output: [{ type: "message", content: [{ type: "output_text", text: "openai answer" }] }] }), { status: 200 });
+				return new Response(JSON.stringify({ output: [
+					{ type: "web_search_call", action: { sources: [] } },
+					{ type: "message", content: [{ type: "output_text", text: "openai answer" }] },
+				] }), { status: 200 });
 			}
 			if (urlText === "https://api.perplexity.ai/chat/completions") {
 				return new Response(JSON.stringify({ choices: [{ message: { content: "perplexity answer" } }], citations: ["https://perplexity.example/source"] }), { status: 200 });

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -891,7 +891,10 @@ test("OpenAI search uses configured Responses endpoint", async () => {
 			capturedUrl = String(url);
 			capturedAuthorization = init.headers.Authorization;
 			return new Response(JSON.stringify({
-				output: [{ type: "message", content: [{ type: "output_text", text: "gateway answer" }] }],
+				output: [
+					{ type: "web_search_call", action: { sources: [] } },
+					{ type: "message", content: [{ type: "output_text", text: "gateway answer" }] },
+				],
 			}), { status: 200, headers: { "content-type": "application/json" } });
 		};
 
@@ -958,7 +961,10 @@ test("auto search prefers Codex-backed OpenAI search when the selected model is 
 				throw new Error("Expected Codex search first, got " + capturedUrl);
 			}
 			return new Response(JSON.stringify({
-				output: [{ type: "message", content: [{ type: "output_text", text: "codex search answer" }] }],
+				output: [
+					{ type: "web_search_call", action: { sources: [] } },
+					{ type: "message", content: [{ type: "output_text", text: "codex search answer" }] },
+				],
 			}), { status: 200, headers: { "content-type": "application/json" } });
 		};
 
@@ -1032,7 +1038,10 @@ test("OpenAI search falls back to API key when model registry cannot enumerate",
 		globalThis.fetch = async (url, init) => {
 			capturedBody = JSON.parse(init.body);
 			return new Response(JSON.stringify({
-				output: [{ type: "message", content: [{ type: "output_text", text: "fallback answer" }] }],
+				output: [
+					{ type: "web_search_call", action: { sources: [] } },
+					{ type: "message", content: [{ type: "output_text", text: "fallback answer" }] },
+				],
 			}), { status: 200, headers: { "content-type": "application/json" } });
 		};
 
@@ -1062,7 +1071,10 @@ test("OpenAI search uses configured model with selected registry auth", async ()
 		globalThis.fetch = async (url, init) => {
 			capturedBody = JSON.parse(init.body);
 			return new Response(JSON.stringify({
-				output: [{ type: "message", content: [{ type: "output_text", text: "registry answer" }] }],
+				output: [
+					{ type: "web_search_call", action: { sources: [] } },
+					{ type: "message", content: [{ type: "output_text", text: "registry answer" }] },
+				],
 			}), { status: 200, headers: { "content-type": "application/json" } });
 		};
 
@@ -1107,7 +1119,10 @@ test("OpenAI search honors configured provider priority", async () => {
 		globalThis.fetch = async (url, init) => {
 			capturedAuthorization = init.headers.Authorization;
 			return new Response(JSON.stringify({
-				output: [{ type: "message", content: [{ type: "output_text", text: "second account answer" }] }],
+				output: [
+					{ type: "web_search_call", action: { sources: [] } },
+					{ type: "message", content: [{ type: "output_text", text: "second account answer" }] },
+				],
 			}), { status: 200, headers: { "content-type": "application/json" } });
 		};
 

--- a/test/search-routing.test.mjs
+++ b/test/search-routing.test.mjs
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 const searchModuleUrl = new URL("../gemini-search.ts", import.meta.url).href;
+const indexModuleUrl = new URL("../index.ts", import.meta.url).href;
 
 async function createConfig(config) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-search-routing-"));
@@ -284,4 +285,258 @@ test("invalid searchRouting configuration fails loudly", async () => {
 	const output = JSON.parse(child.stdout.trim());
 	assert.equal(output.ok, false);
 	assert.match(output.error, /searchRouting\.providers .*invalid provider: auto/);
+});
+
+test("current-model routing uses the official OpenAI model, auth, headers, and endpoint", async () => {
+	const home = await createConfig({
+		searchRouting: {
+			providers: ["openai", "tavily"],
+			useCurrentModel: true,
+			fallbackOn: ["unsupported", "transient", "quota", "network", "invalid-response"],
+		},
+	});
+	const child = runChild(`
+		let captured = null;
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			const target = String(url);
+			calls.push(target);
+			if (target === "https://api.openai.com/v1/responses") {
+				captured = { body: JSON.parse(init.body), headers: Object.fromEntries(new Headers(init.headers)) };
+				return new Response(JSON.stringify({ output: [
+					{ type: "web_search_call", action: { sources: [{ title: "OpenAI source", url: "https://example.com/source?utm_source=openai" }] } },
+					{ type: "message", content: [{ type: "output_text", text: "Hosted answer", annotations: [{ type: "url_citation", url: "https://example.com/source?utm_source=openai", title: "OpenAI source", start_index: 0, end_index: 6 }] }] },
+				] }), { status: 200, headers: { "content-type": "application/json" } });
+			}
+			throw new Error("Tavily must not run");
+		};
+		const model = { provider: "openai", api: "openai-responses", id: "gpt-5.6-terra", baseUrl: "https://api.openai.com/v1" };
+		const ctx = {
+			model,
+			modelRegistry: {
+				getApiKeyAndHeaders: async (selected) => ({ ok: true, apiKey: selected.id + "-key", headers: { "X-Current-Model": "yes" } }),
+			},
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("official hosted search", { provider: "auto", extensionContext: ctx });
+		console.log(JSON.stringify({ provider: result.provider, answer: result.answer, results: result.results, calls, captured }));
+	`, {
+		PI_CODING_AGENT_DIR: home,
+		TAVILY_API_KEY: "tavily-must-not-run",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.provider, "openai");
+	assert.equal(output.answer, "Hosted answer");
+	assert.deepEqual(output.results.map((result) => result.url), ["https://example.com/source"]);
+	assert.deepEqual(output.calls, ["https://api.openai.com/v1/responses"]);
+	assert.equal(output.captured.body.model, "gpt-5.6-terra");
+	assert.equal(output.captured.headers.authorization, "Bearer gpt-5.6-terra-key");
+	assert.equal(output.captured.headers["x-current-model"], "yes");
+});
+
+test("non-official, non-GPT, and Codex current models skip automatic Hosted Search", async () => {
+	const home = await createConfig({
+		searchRouting: { providers: ["openai", "tavily"], useCurrentModel: true, fallbackOn: ["unsupported", "network"] },
+	});
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url) => {
+			const target = String(url);
+			calls.push(target);
+			if (target === "https://api.tavily.com/search") return new Response(JSON.stringify({ answer: "Tavily answer", results: [] }), { status: 200 });
+			throw new Error("Hosted OpenAI must not run: " + target);
+		};
+		const models = [
+			{ provider: "openai", api: "openai-responses", id: "gpt-5.6-sol", baseUrl: "https://ai.feei.cn/v1" },
+			{ provider: "openai", api: "openai-responses", id: "grok-4.6", baseUrl: "https://api.openai.com/v1" },
+			{ provider: "openai-codex", api: "openai-codex-responses", id: "gpt-5.6-sol", baseUrl: "https://api.openai.com/v1" },
+		];
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const results = [];
+		for (const model of models) {
+			results.push((await search(model.id, {
+				provider: "auto",
+				extensionContext: { model, modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "must-not-be-used" }) } },
+			})).provider);
+		}
+		console.log(JSON.stringify({ results, calls }));
+	`, {
+		PI_CODING_AGENT_DIR: home,
+		TAVILY_API_KEY: "tavily-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.deepEqual(output.results, ["tavily", "tavily", "tavily"]);
+	assert.equal(output.calls.length, 3);
+	assert.ok(output.calls.every((url) => url === "https://api.tavily.com/search"));
+});
+
+test("explicit OpenAI provider bypasses current-model restrictions", async () => {
+	const home = await createConfig({
+		searchRouting: { providers: ["openai", "tavily"], useCurrentModel: true, fallbackOn: ["unsupported", "network"] },
+	});
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url, init) => {
+			const target = String(url);
+			calls.push(target);
+			if (target === "https://api.openai.com/v1/responses") {
+				return new Response(JSON.stringify({ output: [
+					{ type: "web_search_call", action: { sources: [] } },
+					{ type: "message", content: [{ type: "output_text", text: "Explicit OpenAI answer" }] },
+				] }), { status: 200 });
+			}
+			throw new Error("Tavily must not run");
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("explicit provider", {
+			provider: "openai",
+			extensionContext: { model: { provider: "openai", api: "openai-responses", id: "gpt-5.6-sol", baseUrl: "https://ai.feei.cn/v1" }, modelRegistry: { getAll: () => [] } },
+		});
+		console.log(JSON.stringify({ provider: result.provider, answer: result.answer, calls }));
+	`, {
+		PI_CODING_AGENT_DIR: home,
+		OPENAI_API_KEY: "explicit-openai-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout.trim()), {
+		provider: "openai",
+		answer: "Explicit OpenAI answer",
+		calls: ["https://api.openai.com/v1/responses"],
+	});
+});
+
+test("unsupported Hosted Search errors fall back to Tavily", async () => {
+	const home = await createConfig({
+		searchRouting: { providers: ["openai", "tavily"], useCurrentModel: true, fallbackOn: ["unsupported"] },
+	});
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url) => {
+			const target = String(url);
+			calls.push(target);
+			if (target === "https://api.openai.com/v1/responses") return new Response("This model does not support web_search", { status: 400 });
+			if (target === "https://api.tavily.com/search") return new Response(JSON.stringify({ answer: "Fallback answer", results: [] }), { status: 200 });
+			throw new Error("Unexpected fetch: " + target);
+		};
+		const ctx = { model: { provider: "openai", api: "openai-responses", id: "gpt-5.6", baseUrl: "https://api.openai.com/v1" }, modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "hosted-key" }) } };
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("unsupported hosted search", { provider: "auto", extensionContext: ctx });
+		console.log(JSON.stringify({ provider: result.provider, answer: result.answer, calls }));
+	`, {
+		PI_CODING_AGENT_DIR: home,
+		TAVILY_API_KEY: "tavily-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout.trim()), {
+		provider: "tavily",
+		answer: "Fallback answer",
+		calls: ["https://api.openai.com/v1/responses", "https://api.tavily.com/search"],
+	});
+});
+
+test("Hosted authentication errors do not silently fall back", async () => {
+	const home = await createConfig({
+		searchRouting: { providers: ["openai", "tavily"], useCurrentModel: true, fallbackOn: ["unsupported", "transient", "quota", "network", "invalid-response"] },
+	});
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url) => {
+			calls.push(String(url));
+			if (String(url) === "https://api.openai.com/v1/responses") return new Response("invalid API key", { status: 401 });
+			throw new Error("Tavily must not run");
+		};
+		const ctx = { model: { provider: "openai", api: "openai-responses", id: "gpt-5.6", baseUrl: "https://api.openai.com/v1" }, modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "hosted-key" }) } };
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		try {
+			await search("auth failure", { provider: "auto", extensionContext: ctx });
+			console.log(JSON.stringify({ ok: true, calls }));
+		} catch (error) {
+			console.log(JSON.stringify({ ok: false, error: String(error), calls }));
+		}
+	`, {
+		PI_CODING_AGENT_DIR: home,
+		TAVILY_API_KEY: "tavily-must-not-run",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.ok, false);
+	assert.match(output.error, /openai search failed \(auth\)/i);
+	assert.deepEqual(output.calls, ["https://api.openai.com/v1/responses"]);
+});
+
+test("a Hosted response without web_search_call is invalid and can fall back", async () => {
+	const home = await createConfig({
+		searchRouting: { providers: ["openai", "tavily"], useCurrentModel: true, fallbackOn: ["invalid-response"] },
+	});
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url) => {
+			const target = String(url);
+			calls.push(target);
+			if (target === "https://api.openai.com/v1/responses") return new Response(JSON.stringify({ output: [{ type: "message", content: [{ type: "output_text", text: "hallucinated answer" }] }] }), { status: 200 });
+			if (target === "https://api.tavily.com/search") return new Response(JSON.stringify({ answer: "Validated fallback", results: [] }), { status: 200 });
+			throw new Error("Unexpected fetch: " + target);
+		};
+		const ctx = { model: { provider: "openai", api: "openai-responses", id: "gpt-5.6", baseUrl: "https://api.openai.com/v1" }, modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "hosted-key" }) } };
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("missing search call", { provider: "auto", extensionContext: ctx });
+		console.log(JSON.stringify({ provider: result.provider, answer: result.answer, calls }));
+	`, {
+		PI_CODING_AGENT_DIR: home,
+		TAVILY_API_KEY: "tavily-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout.trim()), {
+		provider: "tavily",
+		answer: "Validated fallback",
+		calls: ["https://api.openai.com/v1/responses", "https://api.tavily.com/search"],
+	});
+});
+
+test("useCurrentModel is strictly validated", async () => {
+	const home = await createConfig({ searchRouting: { providers: ["openai", "tavily"], useCurrentModel: "yes", fallbackOn: ["network"] } });
+	const child = runChild(`
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		try {
+			await search("invalid current model config", { provider: "auto" });
+			console.log(JSON.stringify({ ok: true }));
+		} catch (error) {
+			console.log(JSON.stringify({ ok: false, error: String(error) }));
+		}
+	`, { PI_CODING_AGENT_DIR: home });
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.ok, false);
+	assert.match(output.error, /searchRouting\.useCurrentModel .*boolean/);
+});
+
+test("Curator auto default follows the same current-model Hosted Search eligibility", async () => {
+	const home = await createConfig({
+		searchRouting: { providers: ["openai", "tavily"], useCurrentModel: true, fallbackOn: ["unsupported", "network"] },
+	});
+	const child = runChild(`
+		const { resolveCuratorDefaultProvider } = await import(${JSON.stringify(indexModuleUrl)});
+		const available = {
+			all: true, openai: true, brave: false, parallel: false, "parallel-mcp": false, tinyfish: false,
+			search1api: false, searchinfinity: false, querit: false, tavily: true, firecrawl: false,
+			jina: false, serpdive: false, searxng: false, duckduckgo: false, perplexity: false,
+			exa: false, gemini: false, kagi: false, bocha: false, ollama: false, anysearch: false,
+			xai: false, brightdata: false, serpbase: false, serper: false, valyu: false,
+		};
+		const official = { model: { provider: "openai", api: "openai-responses", id: "gpt-5.6", baseUrl: "https://api.openai.com/v1" } };
+		const proxy = { model: { provider: "openai", api: "openai-responses", id: "gpt-5.6-sol", baseUrl: "https://ai.feei.cn/v1" } };
+		console.log(JSON.stringify({ official: resolveCuratorDefaultProvider("auto", available, official), proxy: resolveCuratorDefaultProvider("auto", available, proxy) }));
+	`, { PI_CODING_AGENT_DIR: home });
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout.trim()), { official: "openai", proxy: "tavily" });
 });

--- a/test/search-routing.test.mjs
+++ b/test/search-routing.test.mjs
@@ -336,7 +336,7 @@ test("current-model routing uses the official OpenAI model, auth, headers, and e
 	assert.equal(output.captured.headers["x-current-model"], "yes");
 });
 
-test("non-official, non-GPT, and Codex current models skip automatic Hosted Search", async () => {
+test("non-official and non-GPT current models skip automatic Hosted Search", async () => {
 	const home = await createConfig({
 		searchRouting: { providers: ["openai", "tavily"], useCurrentModel: true, fallbackOn: ["unsupported", "network"] },
 	});
@@ -351,7 +351,6 @@ test("non-official, non-GPT, and Codex current models skip automatic Hosted Sear
 		const models = [
 			{ provider: "openai", api: "openai-responses", id: "gpt-5.6-sol", baseUrl: "https://ai.feei.cn/v1" },
 			{ provider: "openai", api: "openai-responses", id: "grok-4.6", baseUrl: "https://api.openai.com/v1" },
-			{ provider: "openai-codex", api: "openai-codex-responses", id: "gpt-5.6-sol", baseUrl: "https://api.openai.com/v1" },
 		];
 		const { search } = await import(${JSON.stringify(searchModuleUrl)});
 		const results = [];
@@ -369,9 +368,51 @@ test("non-official, non-GPT, and Codex current models skip automatic Hosted Sear
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
-	assert.deepEqual(output.results, ["tavily", "tavily", "tavily"]);
-	assert.equal(output.calls.length, 3);
+	assert.deepEqual(output.results, ["tavily", "tavily"]);
+	assert.equal(output.calls.length, 2);
 	assert.ok(output.calls.every((url) => url === "https://api.tavily.com/search"));
+});
+
+test("Codex current models use the official Codex Responses search endpoint", async () => {
+	const home = await createConfig({
+		searchRouting: { providers: ["openai", "tavily"], useCurrentModel: true, fallbackOn: ["unsupported", "network"] },
+	});
+	const child = runChild(`
+		let captured = null;
+		const calls = [];
+		globalThis.fetch = async (url, init = {}) => {
+			const target = String(url);
+			calls.push(target);
+			if (target !== "https://chatgpt.com/backend-api/codex/responses") throw new Error("Tavily must not run: " + target);
+			captured = { body: JSON.parse(init.body), headers: Object.fromEntries(new Headers(init.headers)) };
+			return new Response(JSON.stringify({ output: [
+				{ type: "web_search_call", action: { sources: [{ title: "Codex source", url: "https://example.com/codex" }] } },
+				{ type: "message", content: [{ type: "output_text", text: "Codex hosted answer" }] },
+			] }), { status: 200, headers: { "content-type": "application/json" } });
+		};
+		const model = { provider: "openai-codex", api: "openai-codex-responses", id: "gpt-5.6-sol", baseUrl: "https://chatgpt.com/backend-api" };
+		const ctx = {
+			model,
+			modelRegistry: {
+				getApiKeyAndHeaders: async (selected) => ({ ok: true, apiKey: selected.id + "-key", headers: { "X-Current-Model": "yes" } }),
+			},
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("official Codex hosted search", { provider: "auto", extensionContext: ctx });
+		console.log(JSON.stringify({ provider: result.provider, answer: result.answer, calls, captured }));
+	`, {
+		PI_CODING_AGENT_DIR: home,
+		TAVILY_API_KEY: "tavily-must-not-run",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.provider, "openai");
+	assert.equal(output.answer, "Codex hosted answer");
+	assert.deepEqual(output.calls, ["https://chatgpt.com/backend-api/codex/responses"]);
+	assert.equal(output.captured.body.model, "gpt-5.6-sol");
+	assert.equal(output.captured.headers.authorization, "Bearer gpt-5.6-sol-key");
+	assert.equal(output.captured.headers["x-current-model"], "yes");
 });
 
 test("explicit OpenAI provider bypasses current-model restrictions", async () => {

--- a/test/web-search-answer-render.test.mjs
+++ b/test/web-search-answer-render.test.mjs
@@ -37,10 +37,13 @@ test("web_search preserves OpenAI answers even when no sources are returned", as
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-openai-answer-"));
 	const child = runChild(`
 		globalThis.fetch = async () => new Response(JSON.stringify({
-			output: [{
-				type: "message",
-				content: [{ type: "output_text", text: "Direct answer without citations." }],
-			}],
+			output: [
+				{ type: "web_search_call", action: { sources: [] } },
+				{
+					type: "message",
+					content: [{ type: "output_text", text: "Direct answer without citations." }],
+				},
+			],
 		}), { status: 200, headers: { "content-type": "application/json" } });
 
 		const { default: initializeExtension } = await import(${JSON.stringify(indexUrl)});


### PR DESCRIPTION
Replacement for contributor PR #293.

This reapplies the accepted active-model Hosted Search routing onto current `main` from an owner branch, so we do not push to the contributor fork.

Summary:
- Add opt-in `searchRouting.useCurrentModel` for automatic configured routing.
- Route eligible official OpenAI and Codex Responses active models to Hosted web search.
- Preserve explicit `provider: "openai"` behavior and configured fallback behavior.
- Reject Hosted responses that did not run `web_search_call`.
- Add focused tests and docs.

Credit is preserved in `CHANGELOG.md`: Thanks to [@nyankosama](https://github.com/nyankosama) for PR #293.

Validation:
- `npm run typecheck`
- `node --test test/search-routing.test.mjs test/search-providers.test.mjs test/provider-precedence.test.mjs test/provider-credential-source.test.mjs test/web-search-answer-render.test.mjs`
- `git diff --check origin/main...HEAD`

Fresh exact-head review found no issues.
