### PR TITLE
fix: tolerate get search content bridge defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Improved Gemini Web browser-cookie diagnostics so `/google-account` shows sanitized attempted browser/profile entries and distinguishes missing required cookies, password-store access, and decryption failures. Thanks to [@lmilojevicc](https://github.com/lmilojevicc) for issue #296.
+- Made `get_search_content` tolerate bridge defaults when `findText` is supplied, while preserving ordinary pagination. Thanks to [@ZacharyQin](https://github.com/ZacharyQin) for PR #295.
 
 ## [0.24.2] - 2026-08-22
 

--- a/get-search-content-params.ts
+++ b/get-search-content-params.ts
@@ -1,0 +1,26 @@
+export interface GetSearchContentParams {
+	responseId: string;
+	query?: string;
+	queryIndex?: number;
+	url?: string;
+	urlIndex?: number;
+	offset?: number;
+	limit?: number;
+	findText?: string | string[];
+	findMode?: string;
+}
+
+export function normalizeGetSearchContentParams(params: GetSearchContentParams): GetSearchContentParams {
+	// Tool bridges may serialize optional selectors and slice defaults even when unset.
+	const normalized = { ...params };
+
+	if (normalized.query?.trim() === "") delete normalized.query;
+	if (normalized.url?.trim() === "") delete normalized.url;
+
+	if (normalized.findText !== undefined) {
+		delete normalized.offset;
+		delete normalized.limit;
+	}
+
+	return normalized;
+}

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import { Type } from "typebox";
 import { StringEnum, type ImageContent, type TextContent } from "@earendil-works/pi-ai/compat";
 import type { ExtractedContent, ExtractOptions } from "./extract.ts";
 import { normalizeFetchContentParams } from "./fetch-params.ts";
+import { normalizeGetSearchContentParams } from "./get-search-content-params.ts";
 import { resolveAuthFetchProfile, type AuthFetchProfile } from "./auth-fetch.ts";
 import { findContent, type FindMode } from "./content-find.ts";
 import { answerFromPage } from "./page-query.ts";
@@ -2691,24 +2692,17 @@ export default function (pi: ExtensionAPI) {
 			queryIndex: Type.Optional(Type.Integer({ minimum: 0, description: "Get content for query at index" })),
 			url: Type.Optional(Type.String({ description: "Get content for this URL" })),
 			urlIndex: Type.Optional(Type.Integer({ minimum: 0, description: "Get content for URL at index" })),
-			offset: Type.Optional(Type.Integer({ minimum: 0, description: "Character offset for fetched URL content slices (default 0). Cannot be combined with findText." })),
-			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: maxInlineContentChars, description: "Maximum characters to return for fetched URL content slices (default and max are set by maxInlineContentChars). Cannot be combined with findText." })),
+			offset: Type.Optional(Type.Integer({ minimum: 0, description: "Character offset for fetched URL content slices (default 0). Ignored when findText is supplied." })),
+			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: maxInlineContentChars, description: "Maximum characters to return for fetched URL content slices (default and max are set by maxInlineContentChars). Ignored when findText is supplied." })),
 			findText: Type.Optional(Type.Union([
 				Type.String({ minLength: 1, maxLength: 500 }),
 				Type.Array(Type.String({ minLength: 1, maxLength: 500 }), { minItems: 1, maxItems: 10 }),
-			], { description: "Text or texts to find in the selected stored content. Cannot be combined with offset or limit." })),
+			], { description: "Text or texts to find in the selected stored content. When supplied, offset and limit are ignored." })),
 			findMode: Type.Optional(StringEnum(["exact", "case-insensitive", "fuzzy"], { description: "Matching mode for findText (default: case-insensitive). Requires findText." })),
 		}),
 
 		async execute(_toolCallId, params): Promise<AgentToolResult<Record<string, unknown>>> {
-			if (params.findText !== undefined && (params.offset !== undefined || params.limit !== undefined)) {
-				const offset = formatInputValue(params.offset);
-				const limit = formatInputValue(params.limit);
-				return {
-					content: [{ type: "text", text: `findText cannot be combined with offset or limit. Received offset=${offset}, limit=${limit}; omit offset and limit when using findText.` }],
-					details: { error: "Incompatible find options" },
-				};
-			}
+			params = normalizeGetSearchContentParams(params);
 			if (params.findMode !== undefined && params.findText === undefined) {
 				return {
 					content: [{ type: "text", text: `findMode ${formatInputValue(params.findMode)} requires findText; provide findText or omit findMode.` }],
@@ -2732,6 +2726,22 @@ export default function (pi: ExtensionAPI) {
 					};
 				}
 				const serialized = JSON.stringify(artifact, null, 2);
+				if (params.findText !== undefined) {
+					try {
+						const found = findContent(serialized, normalizeFindQueries(params.findText), (params.findMode ?? "case-insensitive") as FindMode);
+						const { text, ...findDetails } = found;
+						return {
+							content: [{ type: "text", text }],
+							details: { responseId: artifact.id, type: "research", contentLength: serialized.length, findMode: params.findMode ?? "case-insensitive", ...findDetails },
+						};
+					} catch (err) {
+						const error = err instanceof Error ? err.message : String(err);
+						return {
+							content: [{ type: "text", text: `Unable to find ${formatInputValue(params.findText)} in research artifact for responseId ${formatInputValue(params.responseId)}: ${error}. Check findText and use a supported findMode.` }],
+							details: { error, responseId: params.responseId, type: "research" },
+						};
+					}
+				}
 				const offset = params.offset ?? 0;
 				const limit = params.limit ?? maxInlineContentChars;
 				if (!Number.isInteger(offset) || offset < 0) {

--- a/test/get-search-content.test.mjs
+++ b/test/get-search-content.test.mjs
@@ -34,6 +34,24 @@ function storeFetchedContent(content) {
 	});
 }
 
+function storeSearchContent() {
+	storeResult("search-result", {
+		id: "search-result",
+		type: "search",
+		timestamp: Date.now(),
+		queries: [{
+			query: "CotEditor scripts",
+			answer: "",
+			results: [
+				{ title: "ScriptManager.swift", url: "https://example.com/script-manager", snippet: "UNIX script support" },
+				{ title: "UNIX script", url: "https://example.com/unix-script", snippet: "Script support" },
+				{ title: "ScriptMenu", url: "https://example.com/script-menu", snippet: "Menu integration" },
+			],
+			error: null,
+		}],
+	});
+}
+
 test("get_search_content schemas constrain numeric parameters", () => {
 	const properties = getContentTool().parameters.properties;
 
@@ -114,15 +132,15 @@ test("get_search_content rejects unsafe fetched content ranges", async () => {
 	assert.match(outOfRange.content[0].text, /Received offset 99/);
 	assert.match(outOfRange.content[0].text, /valid range is 0-13/);
 
-	const incompatible = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, findText: "content", offset: 1 });
-	assert.equal(incompatible.details.error, "Incompatible find options");
-	assert.match(incompatible.content[0].text, /Received offset=1, limit=undefined/);
-
 	const missingFindText = await tool.execute("call", { responseId: "large-fetch", urlIndex: 0, findMode: "fuzzy" });
 	assert.equal(missingFindText.details.error, "findMode requires findText");
 	assert.match(missingFindText.content[0].text, /findMode "fuzzy" requires findText/);
 
-	const artifact = buildResearchArtifact({ query: "stored claim", results: [] });
+	const artifact = buildResearchArtifact({
+		query: "stored claim",
+		results: [{ url: "https://example.com/research", title: "Research source", snippet: "The bridge defaults match this research passage.", rank: 1 }],
+		summary: "Unique bridge research summary marker.",
+	});
 	artifact.id = "stored-research";
 	storeResearchArtifact(artifact);
 	const researchInvalidLimit = await tool.execute("call", { responseId: "stored-research", limit: 30_001 });
@@ -134,6 +152,40 @@ test("get_search_content rejects unsafe fetched content ranges", async () => {
 	assert.equal(researchOutOfRange.details.error, "Offset out of range");
 	assert.match(researchOutOfRange.content[0].text, /responseId "stored-research"/);
 	assert.match(researchOutOfRange.content[0].text, /valid range is 0-/);
+
+	const researchFind = await tool.execute("call", {
+		responseId: "stored-research",
+		offset: 0,
+		limit: 10_000,
+		findText: "Unique bridge research summary marker",
+	});
+	assert.equal(researchFind.details.type, "research");
+	assert.equal(researchFind.details.findMode, "case-insensitive");
+	assert.equal(researchFind.details.matchCount, 1);
+	assert.match(researchFind.content[0].text, /^Text matches \(case-insensitive\)/);
+	assert.match(researchFind.content[0].text, /Unique bridge research summary marker/);
+});
+
+test("get_search_content normalizes bridge defaults for search matches", async () => {
+	const tool = getContentTool();
+	storeSearchContent();
+
+	const result = await tool.execute("call", {
+		responseId: "search-result",
+		query: "",
+		queryIndex: 0,
+		url: "",
+		urlIndex: 0,
+		offset: 0,
+		limit: 10_000,
+		findText: ["ScriptManager.swift", "UNIX script", "ScriptMenu"],
+		findMode: "case-insensitive",
+	});
+
+	assert.equal(result.details.findMode, "case-insensitive");
+	assert.equal(result.details.matchCount, 3);
+	assert.match(result.content[0].text, /ScriptManager\.swift/);
+	assert.match(result.content[0].text, /ScriptMenu/);
 });
 
 test("get_search_content returns small fetched content without continuation noise", async () => {
@@ -155,7 +207,12 @@ test("get_search_content finds bounded passages in stored fetched content", asyn
 
 	const result = await tool.execute("call", {
 		responseId: "large-fetch",
+		query: "",
+		queryIndex: 0,
+		url: "",
 		urlIndex: 0,
+		offset: 0,
+		limit: 10_000,
 		findText: "installation",
 	});
 


### PR DESCRIPTION
Replacement for contributor PR #295.

This reapplies the accepted `get_search_content` bridge-default fix onto current `main` from an owner branch, so we do not push to the contributor fork.

Summary:
- Normalize empty `query` and `url` selector strings.
- Let `findText` take precedence over bridge-injected `offset` and `limit`.
- Preserve pagination behavior when `findText` is absent.
- Update schema/help text and focused tests.

Credit is preserved in `CHANGELOG.md`: Thanks to [@ZacharyQin](https://github.com/ZacharyQin) for PR #295.

Validation:
- `node --test test/get-search-content.test.mjs`
- `npm run typecheck`
- `git diff --check`

Fresh exact-head review found no issues.
