### PR TITLE
feat: select browser cookie profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added deterministic Chromium cookie selection with `browserCookies.browser` and `browserCookies.profile`; arbitrary profile paths remain unsupported. Thanks to [@lmilojevicc](https://github.com/lmilojevicc) for issue #297.
 - Auto-specialize GitHub pull request and issue URLs in `fetch_content`, with `gh`-first metadata, bounded REST fallback, comment-anchor inclusion, truncation markers, and the `githubPrIssue.enabled` opt-out (#294).
 - Added opt-in `searchRouting.useCurrentModel` routing for automatic searches. Official OpenAI GPT Responses models can now fund an isolated Hosted `web_search` request using their exact model, endpoint, credentials, and headers before configured fallbacks. Thanks to [@nyankosama](https://github.com/nyankosama) for PR #293.
 - Added strict Hosted Search response validation: responses must contain a real `web_search_call`; explicit unsupported-tool errors are classified separately for configured fallback routes.

--- a/README.md
+++ b/README.md
@@ -405,7 +405,10 @@ Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODIN
   "image": {
     "enabled": true
   },
-  "chromeProfile": "Profile 2",
+  "browserCookies": {
+    "browser": "helium",
+    "profile": "Profile 2"
+  },
   "allowBrowserCookies": false,
   "searchModel": "gemini-3.6-flash",
   "summaryModel": "anthropic/claude-haiku-4-5",
@@ -478,6 +481,8 @@ A command source is not run while the extension loads or registers tools. Each s
 Set `braveBaseUrl`, `exaBaseUrl`, or `tavilyBaseUrl` to route those providers through a compatible HTTPS API gateway. `BRAVE_BASE_URL`, `EXA_BASE_URL`, and `TAVILY_BASE_URL` are the environment-variable equivalents and take precedence over config. Brave appends `/web/search`, Exa appends `/answer` or `/search`, and Tavily appends `/search`. Defaults remain the providers' official API roots. `exaBaseUrl` applies only to keyed direct API calls; zero-config Exa MCP search continues to use Exa's hosted MCP endpoint. Invalid overrides fail before a request is sent instead of falling back to an official endpoint, and credential headers are removed if a gateway redirects to another origin.
 
 `authFetch` configures named local browser-cookie auth profiles for explicit `fetch_content` calls. A profile can be a host array (`"work": ["docs.company.com"]`) or an object with `hosts`, optional `chromeProfile`, `redirects: "same-origin"`, and `cache: "session" | "off"`.
+
+`browserCookies` selects the Chromium browser preset and profile used for Gemini Web cookies, for example `{ "browserCookies": { "browser": "helium", "profile": "Profile 1" } }`. When `browser` is set, cookie discovery checks only that browser, which avoids unrelated password-store prompts. Supported preset names are `helium`, `chrome`, `brave`, `arc`, `chromium`, and `edge`, subject to platform availability. Omit `browser` to keep automatic browser discovery. `profile` must be a profile directory name. The old top-level `chromeProfile` field is rejected; move it to `browserCookies.profile`. Arbitrary profile paths and `profilePath` are intentionally not supported.
 
 `fetchContent.domainPolicy` is an optional hostname allow/deny policy for `fetch_content` target URLs. It is off when omitted. Each bare hostname matches itself and its subdomains; `deny` wins when a hostname matches both lists. The policy is checked before HTTP(S) target handling and before each redirect followed by this extension's own fetch path. Local file paths and non-HTTP sources are not subject to this policy. It is an additional restriction: the existing SSRF guard still blocks private and internal destinations. Remote extraction services can still perform their own DNS, redirects, and egress after this extension preflights the submitted target URL, so third-party hosted HTTP(S) fallbacks stay disabled unless `fetchRouting.allowRemoteHostedProviders` is enabled for separately isolated provider deployments.
 

--- a/chrome-cookies.ts
+++ b/chrome-cookies.ts
@@ -3,11 +3,12 @@ import { pbkdf2Sync, createDecipheriv } from "node:crypto";
 import { copyFileSync, existsSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
 import { isAbsolute, join, sep } from "node:path";
-import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
+import { isBrowserCookieAccessAllowed, type BrowserCookiePreset } from "./gemini-web-config.ts";
 
 export type CookieMap = Record<string, string>;
 
 interface BrowserConfig {
+	id: BrowserCookiePreset;
 	name: string;
 	baseDir: string;
 	usesLocalAppData?: boolean;
@@ -59,20 +60,20 @@ const ALL_COOKIE_NAMES = new Set([
 ]);
 
 const MACOS_BROWSER_CONFIGS: BrowserConfig[] = [
-	{ name: "Helium", baseDir: "Library/Application Support/net.imput.helium", keychainService: "Helium Storage Key", keychainAccount: "Helium" },
-	{ name: "Chrome", baseDir: "Library/Application Support/Google/Chrome", keychainService: "Chrome Safe Storage", keychainAccount: "Chrome" },
-	{ name: "Brave", baseDir: "Library/Application Support/BraveSoftware/Brave-Browser", keychainService: "Brave Safe Storage", keychainAccount: "Brave" },
-	{ name: "Arc", baseDir: "Library/Application Support/Arc/User Data", keychainService: "Arc Safe Storage", keychainAccount: "Arc" },
+	{ id: "helium", name: "Helium", baseDir: "Library/Application Support/net.imput.helium", keychainService: "Helium Storage Key", keychainAccount: "Helium" },
+	{ id: "chrome", name: "Chrome", baseDir: "Library/Application Support/Google/Chrome", keychainService: "Chrome Safe Storage", keychainAccount: "Chrome" },
+	{ id: "brave", name: "Brave", baseDir: "Library/Application Support/BraveSoftware/Brave-Browser", keychainService: "Brave Safe Storage", keychainAccount: "Brave" },
+	{ id: "arc", name: "Arc", baseDir: "Library/Application Support/Arc/User Data", keychainService: "Arc Safe Storage", keychainAccount: "Arc" },
 ];
 
 const LINUX_BROWSER_CONFIGS: BrowserConfig[] = [
-	{ name: "Chromium", baseDir: ".config/chromium", secretToolApp: "chromium" },
-	{ name: "Chrome", baseDir: ".config/google-chrome", secretToolApp: "chrome" },
+	{ id: "chromium", name: "Chromium", baseDir: ".config/chromium", secretToolApp: "chromium" },
+	{ id: "chrome", name: "Chrome", baseDir: ".config/google-chrome", secretToolApp: "chrome" },
 ];
 
 const WINDOWS_BROWSER_CONFIGS: BrowserConfig[] = [
-	{ name: "Chrome", baseDir: "Google/Chrome/User Data", usesLocalAppData: true },
-	{ name: "Edge", baseDir: "Microsoft/Edge/User Data", usesLocalAppData: true },
+	{ id: "chrome", name: "Chrome", baseDir: "Google/Chrome/User Data", usesLocalAppData: true },
+	{ id: "edge", name: "Edge", baseDir: "Microsoft/Edge/User Data", usesLocalAppData: true },
 ];
 
 const browserPasswordCache = new Map<string, Promise<string | null>>();
@@ -98,10 +99,11 @@ export function getLastBrowserCookieDiagnosticDetails(): BrowserCookieDiagnostic
 }
 
 export async function getGoogleCookies(
-	options?: { profile?: string; requiredCookies?: string[] },
+	options?: { browser?: BrowserCookiePreset; profile?: string; requiredCookies?: string[] },
 ): Promise<{ cookies: CookieMap; warnings: string[] } | null> {
 	return getBrowserCookiesForHosts({
 		hosts: GOOGLE_ORIGINS.map((origin) => new URL(origin).hostname),
+		browser: options?.browser,
 		profile: options?.profile,
 		requiredCookies: options?.requiredCookies,
 		cookieNames: ALL_COOKIE_NAMES,
@@ -110,7 +112,7 @@ export async function getGoogleCookies(
 }
 
 export async function getBrowserCookiesForHosts(
-	options: { hosts: string[]; profile?: string; requiredCookies?: string[]; cookieNames?: Iterable<string>; requiredLabel?: string; requestUrl?: URL },
+	options: { hosts: string[]; browser?: BrowserCookiePreset; profile?: string; requiredCookies?: string[]; cookieNames?: Iterable<string>; requiredLabel?: string; requestUrl?: URL },
 ): Promise<{ cookies: CookieMap; warnings: string[]; cookieHeader?: string } | null> {
 	lastCookieDiagnostic = null;
 	lastCookieDiagnosticDetails = null;
@@ -120,7 +122,12 @@ export async function getBrowserCookiesForHosts(
 	}
 
 	const currentPlatform = process.platform;
-	const configs = currentPlatform === "darwin" ? MACOS_BROWSER_CONFIGS : currentPlatform === "linux" ? LINUX_BROWSER_CONFIGS : currentPlatform === "win32" ? WINDOWS_BROWSER_CONFIGS : [];
+	const platformConfigs = currentPlatform === "darwin" ? MACOS_BROWSER_CONFIGS : currentPlatform === "linux" ? LINUX_BROWSER_CONFIGS : currentPlatform === "win32" ? WINDOWS_BROWSER_CONFIGS : [];
+	const configs = options.browser ? platformConfigs.filter((config) => config.id === options.browser) : platformConfigs;
+	if (options.browser && configs.length === 0) {
+		setCookieDiagnostic(`Browser preset '${options.browser}' is not supported on this platform.`);
+		return null;
+	}
 	if (configs.length === 0) {
 		setCookieDiagnostic("Chromium cookie extraction is unsupported on this platform.");
 		return null;

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -409,8 +409,16 @@ async function isResolvedProviderAvailable(provider: ResolvedSearchProvider, opt
 	if (provider === "perplexity") return isPerplexityAvailable();
 	if (provider === "searxng") return isSearXNGAvailable();
 	if (provider === "duckduckgo") return isDuckDuckGoAvailable();
-	if (provider === "gemini") return isGeminiApiAvailable() || !!(await isGeminiWebAvailable());
+	if (provider === "gemini") return isGeminiApiAvailable() || await isGeminiWebOptionallyAvailable();
 	return isExaAvailable();
+}
+
+async function isGeminiWebOptionallyAvailable(): Promise<boolean> {
+	try {
+		return !!(await isGeminiWebAvailable());
+	} catch {
+		return false;
+	}
 }
 
 function providerLabel(provider: ResolvedSearchProvider): string {

--- a/gemini-web-config.ts
+++ b/gemini-web-config.ts
@@ -4,8 +4,15 @@ import { getWebSearchConfigPath } from "./utils.ts";
 const CONFIG_PATH = getWebSearchConfigPath();
 
 interface GeminiWebConfig {
-	chromeProfile?: string;
+	browserCookies?: BrowserCookieSelection;
 	allowBrowserCookies?: boolean;
+}
+
+export type BrowserCookiePreset = "helium" | "chrome" | "brave" | "arc" | "chromium" | "edge";
+
+export interface BrowserCookieSelection {
+	browser?: BrowserCookiePreset;
+	profile?: string;
 }
 
 let cachedConfig: GeminiWebConfig | null = null;
@@ -16,6 +23,34 @@ export function normalizeChromeProfile(value: unknown): string | undefined {
 	return normalized.length > 0 ? normalized : undefined;
 }
 
+function parseBrowserCookies(value: unknown): BrowserCookieSelection | undefined {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`browserCookies in ${CONFIG_PATH} must be an object`);
+	}
+	const raw = value as Record<string, unknown>;
+	if ("profilePath" in raw) {
+		throw new Error(`browserCookies.profilePath is not supported; use a browser preset and profile directory name in ${CONFIG_PATH}`);
+	}
+	let browser: BrowserCookiePreset | undefined;
+	if (raw.browser !== undefined) {
+		if (typeof raw.browser !== "string") throw new Error(`browserCookies.browser in ${CONFIG_PATH} must be a supported browser name`);
+		const normalized = raw.browser.trim().toLowerCase();
+		if (!(["helium", "chrome", "brave", "arc", "chromium", "edge"] as string[]).includes(normalized)) {
+			throw new Error(`Unsupported browserCookies.browser ${JSON.stringify(raw.browser)} in ${CONFIG_PATH}`);
+		}
+		browser = normalized as BrowserCookiePreset;
+	}
+	if (raw.profile !== undefined && typeof raw.profile !== "string") {
+		throw new Error(`browserCookies.profile in ${CONFIG_PATH} must be a profile directory name`);
+	}
+	const profile = normalizeChromeProfile(raw.profile);
+	if (profile && (profile === "." || profile === ".." || profile.includes("/") || profile.includes("\\"))) {
+		throw new Error(`browserCookies.profile in ${CONFIG_PATH} must be a profile directory name, not a path`);
+	}
+	return { ...(browser ? { browser } : {}), ...(profile ? { profile } : {}) };
+}
+
 function loadConfig(): GeminiWebConfig {
 	if (cachedConfig) return cachedConfig;
 	if (!existsSync(CONFIG_PATH)) {
@@ -24,28 +59,41 @@ function loadConfig(): GeminiWebConfig {
 	}
 
 	const rawText = readFileSync(CONFIG_PATH, "utf-8");
-	let raw: { chromeProfile?: unknown; allowBrowserCookies?: unknown };
+	let raw: { chromeProfile?: unknown; browserCookies?: unknown; allowBrowserCookies?: unknown };
 	try {
-		raw = JSON.parse(rawText) as { chromeProfile?: unknown; allowBrowserCookies?: unknown };
+		raw = JSON.parse(rawText) as { chromeProfile?: unknown; browserCookies?: unknown; allowBrowserCookies?: unknown };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
 	}
 
+	if (raw.chromeProfile !== undefined) {
+		throw new Error(`chromeProfile in ${CONFIG_PATH} is no longer supported; use browserCookies.profile`);
+	}
 	cachedConfig = {
-		chromeProfile: normalizeChromeProfile(raw.chromeProfile),
+		browserCookies: parseBrowserCookies(raw.browserCookies),
 		allowBrowserCookies: raw.allowBrowserCookies === true,
 	};
 	return cachedConfig;
 }
 
-export function getChromeProfileFromConfig(): string | undefined {
-	return loadConfig().chromeProfile;
+export function getBrowserCookieSelectionFromConfig(): BrowserCookieSelection {
+	return { ...loadConfig().browserCookies };
 }
 
 export function isBrowserCookieAccessAllowed(): boolean {
 	if (process.env.PI_ALLOW_BROWSER_COOKIES === "1" || process.env.FEYNMAN_ALLOW_BROWSER_COOKIES === "1") {
 		return true;
 	}
-	return loadConfig().allowBrowserCookies === true;
+	if (!existsSync(CONFIG_PATH)) return false;
+
+	const rawText = readFileSync(CONFIG_PATH, "utf-8");
+	let raw: { allowBrowserCookies?: unknown };
+	try {
+		raw = JSON.parse(rawText) as { allowBrowserCookies?: unknown };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${CONFIG_PATH}: ${message}`);
+	}
+	return raw.allowBrowserCookies === true;
 }

--- a/gemini-web.ts
+++ b/gemini-web.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import { getLastGoogleCookieDiagnostic, getLastGoogleCookieDiagnosticDetails, type BrowserCookieDiagnosticDetails, type CookieMap, getGoogleCookies } from "./chrome-cookies.ts";
-import { getChromeProfileFromConfig, isBrowserCookieAccessAllowed, normalizeChromeProfile } from "./gemini-web-config.ts";
+import { getBrowserCookieSelectionFromConfig, isBrowserCookieAccessAllowed, normalizeChromeProfile } from "./gemini-web-config.ts";
 
 const GEMINI_APP_URL = "https://gemini.google.com/app";
 const GEMINI_STREAM_GENERATE_URL =
@@ -100,8 +100,10 @@ export interface GeminiWebOptions {
 export async function isGeminiWebAvailable(chromeProfile?: string): Promise<CookieMap | null> {
 	if (!isBrowserCookieAccessAllowed()) return null;
 
+	const configured = getBrowserCookieSelectionFromConfig();
 	const result = await getGoogleCookies({
-		profile: normalizeChromeProfile(chromeProfile) ?? getChromeProfileFromConfig(),
+		browser: configured.browser,
+		profile: normalizeChromeProfile(chromeProfile) ?? configured.profile,
 		requiredCookies: REQUIRED_COOKIES,
 	});
 	if (!result) return null;

--- a/index.ts
+++ b/index.ts
@@ -384,7 +384,7 @@ function shouldAutoOpenCuratorBrowser(config: WebSearchConfig): boolean {
 }
 
 async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderAvailability> {
-	const geminiWebAvail = await isGeminiWebAvailable();
+	const geminiWebAvail = await getOptionalGeminiWebAvailability();
 	const geminiApiAvail = isGeminiApiAvailable();
 	const providers = {
 		openai: await isOpenAISearchAvailable(ctx),
@@ -419,6 +419,14 @@ async function getProviderAvailability(ctx: ExtensionContext): Promise<ProviderA
 		all: Object.entries(providers).some(([provider, available]) => provider !== "parallel-mcp" && provider !== "duckduckgo" && provider !== "anysearch" && provider !== "xai" && provider !== "brightdata" && provider !== "serpbase" && provider !== "serper" && provider !== "valyu" && provider !== "gemini" && available) || geminiApiAvail,
 		...providers,
 	};
+}
+
+async function getOptionalGeminiWebAvailability() {
+	try {
+		return await isGeminiWebAvailable();
+	} catch {
+		return null;
+	}
 }
 
 function shouldUseOpenAICodexDefault(ctx?: Pick<ExtensionContext, "model">): boolean {

--- a/test/chrome-cookie-extraction.test.mjs
+++ b/test/chrome-cookie-extraction.test.mjs
@@ -167,6 +167,30 @@ test("auto-discovery finds a Brave profile on macOS", (t) => {
 	rmSync(bin, { recursive: true, force: true });
 });
 
+test("browser selection checks only the requested preset", (t) => {
+	skipWithoutPython(t);
+	const home = mkdtempSync(join(tmpdir(), "pi-cookie-selected-browser-"));
+	const bin = mkdtempSync(join(tmpdir(), "pi-cookie-bin-"));
+	createFixture(home, "Profile 1", [
+		["__Secure-1PSID", "helium-one", ".google.com", null, 1],
+		["__Secure-1PSIDTS", "helium-two", ".google.com", null, 2],
+	], { browser: "Helium", targetPlatform: "darwin" });
+	createFixture(home, "Profile 1", [
+		["__Secure-1PSID", "chrome-one", ".google.com", null, 1],
+		["__Secure-1PSIDTS", "chrome-two", ".google.com", null, 2],
+	], { browser: "Chrome", targetPlatform: "darwin" });
+	const env = makeEnvironment(home, bin);
+	const argsPath = join(home, "password-args");
+	Object.assign(env, writePasswordCommand(bin, join(home, "password-count"), "darwin", argsPath));
+	const result = runCookies(home, env, "{ browser: 'helium', profile: 'Profile 1', requiredCookies: ['__Secure-1PSID', '__Secure-1PSIDTS'] }", "darwin");
+	assert.deepEqual(result.result.cookies, { "__Secure-1PSIDTS": "helium-two", "__Secure-1PSID": "helium-one" });
+	assert.deepEqual(readFileSync(argsPath, "utf8").trim().split("\n"), [
+		"find-generic-password", "-w", "-a", "Helium", "-s", "Helium Storage Key",
+	]);
+	rmSync(home, { recursive: true, force: true });
+	rmSync(bin, { recursive: true, force: true });
+});
+
 test("Windows Chrome profiles decrypt v10 cookies with DPAPI keys", (t) => {
 	skipWithoutPython(t);
 	const home = mkdtempSync(join(tmpdir(), "pi-cookie-windows-"));

--- a/test/gemini-web-cookie-opt-in.test.mjs
+++ b/test/gemini-web-cookie-opt-in.test.mjs
@@ -23,6 +23,17 @@ function runCookieAccessCheck(home, extraEnv = {}) {
 	});
 }
 
+function runBrowserCookieConfig(home) {
+	const env = { ...process.env, HOME: home, USERPROFILE: home };
+	delete env.PI_CODING_AGENT_DIR;
+	delete env.XDG_CONFIG_HOME;
+	return spawnSync(process.execPath, ["--experimental-strip-types", "--input-type=module"], {
+		input: `const { getBrowserCookieSelectionFromConfig } = await import(${JSON.stringify(moduleUrl)}); console.log(JSON.stringify(getBrowserCookieSelectionFromConfig()));`,
+		encoding: "utf8",
+		env,
+	});
+}
+
 test("Gemini Web never forwards browser cookies across origins", async () => {
 	const { getActiveGoogleEmail, setGeminiFetchOverrideForTests } = await import(geminiWebUrl);
 	const calls = [];
@@ -123,4 +134,45 @@ test("browser cookie access is disabled unless explicitly allowed", async () => 
 	child = runCookieAccessCheck(envHome, { PI_ALLOW_BROWSER_COOKIES: "1" });
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "true");
+});
+
+test("disabled browser cookie access does not validate legacy profile selection", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-cookie-legacy-disabled-"));
+	await mkdir(join(home, ".pi"), { recursive: true });
+	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify({ chromeProfile: "Profile 1" }) + "\n", "utf8");
+
+	const child = runCookieAccessCheck(home);
+	assert.equal(child.status, 0, child.stderr);
+	assert.equal(child.stdout.trim(), "false");
+});
+
+test("browser cookie config validates presets and rejects arbitrary profile paths", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-browser-cookie-config-"));
+	await mkdir(join(home, ".pi"), { recursive: true });
+	const configPath = join(home, ".pi", "web-search.json");
+	await writeFile(configPath, JSON.stringify({ browserCookies: { browser: "Helium", profile: "Profile 1" } }) + "\n", "utf8");
+
+	let child = runBrowserCookieConfig(home);
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout), { browser: "helium", profile: "Profile 1" });
+
+	await writeFile(configPath, JSON.stringify({ chromeProfile: "Profile 1", allowBrowserCookies: true }) + "\n", "utf8");
+	child = runBrowserCookieConfig(home);
+	assert.notEqual(child.status, 0);
+	assert.match(child.stderr, /chromeProfile.*no longer supported.*browserCookies\.profile/);
+
+	await writeFile(configPath, JSON.stringify({ browserCookies: { browser: "safari", profile: "Profile 1" } }) + "\n", "utf8");
+	child = runBrowserCookieConfig(home);
+	assert.notEqual(child.status, 0);
+	assert.match(child.stderr, /Unsupported browserCookies\.browser/);
+
+	await writeFile(configPath, JSON.stringify({ browserCookies: { browser: "helium", profile: 1 } }) + "\n", "utf8");
+	child = runBrowserCookieConfig(home);
+	assert.notEqual(child.status, 0);
+	assert.match(child.stderr, /browserCookies\.profile.*must be a profile directory name/);
+
+	await writeFile(configPath, JSON.stringify({ browserCookies: { browser: "helium", profilePath: "/tmp/Profile 1" } }) + "\n", "utf8");
+	child = runBrowserCookieConfig(home);
+	assert.notEqual(child.status, 0);
+	assert.match(child.stderr, /profilePath is not supported/);
 });

--- a/test/provider-precedence.test.mjs
+++ b/test/provider-precedence.test.mjs
@@ -146,6 +146,16 @@ test("configured explicit-only SerpBase fails instead of falling back", async ()
 	assert.doesNotMatch(result.content[0].text, /Unexpected fallback fetch/);
 });
 
+test("legacy Gemini Web profile config does not block unrelated configured providers", async () => {
+	const calls = runTool(await createConfig({
+		provider: "tavily",
+		tavilyApiKey: "tavily-test-key",
+		allowBrowserCookies: true,
+		chromeProfile: "Profile 1",
+	}));
+	assert.deepEqual(calls, ["https://api.tavily.com/search"]);
+});
+
 test("malformed config root fails with an explicit object-shape error", async () => {
 	const root = await mkdtemp(join(tmpdir(), "pi-web-access-invalid-config-root-"));
 	const agentDir = join(root, "agent-dir");


### PR DESCRIPTION
Closes #297.

Summary:
- Add `browserCookies.browser` with a named `browserCookies.profile` to select one supported browser preset deterministically.
- Keep automatic browser discovery unchanged when `browser` is omitted.
- Reject unsupported browser names, `profilePath`, non-string profiles, and path-like profile names at config load.
- Preserve cookie opt-in and diagnostics.

This intentionally does not add arbitrary `profilePath` support in v1 because that is a larger filesystem and security boundary.

Credit is included in `CHANGELOG.md`: Thanks to [@lmilojevicc](https://github.com/lmilojevicc) for issue #297.

Validation:
- `node --test test/chrome-cookie-extraction.test.mjs test/gemini-web-cookie-opt-in.test.mjs`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh exact-head review found no issues.
