### PR TITLE
fix: point 404/410 fetch failures at search instead of provider config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Added Defuddle as a local fallback when Readability and RSC extraction cannot recover useful HTML content. Thanks to [@tobru](https://github.com/tobru) for issue #300.
 - Kept Gemini ADC config parse errors, GitHub PR/issue REST fallback failures, and Defuddle fallback failures visible instead of silently downgrading them.
+- Pointed definitive `fetch_content` 404/410 failures to search guidance instead of provider configuration. Thanks to [@Daniishkhan](https://github.com/Daniishkhan) for PR #308.
 - Improved Gemini Web browser-cookie diagnostics so `/google-account` shows sanitized attempted browser/profile entries and distinguishes missing required cookies, password-store access, and decryption failures. Thanks to [@lmilojevicc](https://github.com/lmilojevicc) for issue #296.
 - Made `get_search_content` tolerate bridge defaults when `findText` is supplied, while preserving ordinary pagination. Thanks to [@ZacharyQin](https://github.com/ZacharyQin) for PR #295.
 

--- a/extract.ts
+++ b/extract.ts
@@ -876,6 +876,21 @@ export async function extractContent(
 	const finalHttpResult = httpResult as ExtractedContent | null;
 	if (finalHttpResult && declaredLinks.length > 0) return { ...finalHttpResult, error: null };
 
+	// A definitive 404/410 from the origin means no extraction provider can
+	// retrieve the page, so the provider-configuration checklist below would
+	// send users down the wrong path. Point at search instead.
+	if (finalHttpResult?.status === 404 || finalHttpResult?.status === 410) {
+		return {
+			...finalHttpResult,
+			error: [
+				finalHttpResult.error,
+				"",
+				`The origin server says this page does not exist (HTTP ${finalHttpResult.status}), so extraction providers cannot retrieve it.`,
+				"The page may have moved or been renamed. Use web_search to find the current URL, then retry fetch_content with it.",
+			].join("\n"),
+		};
+	}
+
 	const guidance = [
 		finalHttpResult?.error ?? "No fetch_content provider returned content",
 		...(firecrawlError ? [`Firecrawl fallback failed: ${firecrawlError}`] : []),

--- a/extract.ts
+++ b/extract.ts
@@ -191,6 +191,33 @@ function loadFetchRouting(): FetchRouting {
 	return { providers, allowRemoteHostedProviders: allowRemoteHostedProvidersValue === true };
 }
 
+const DEFAULT_PUBLIC_TOOL_NAMES = { webSearch: "web_search", fetchContent: "fetch_content" } as const;
+const PUBLIC_TOOL_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+
+/** Resolve the registered public tool names for guidance text. Lenient on
+ * purpose: malformed config falls back to the defaults, matching what
+ * extension init registers when toolNames fails validation. */
+function loadPublicToolNames(): { webSearch: string; fetchContent: string } {
+	try {
+		if (!existsSync(WEB_SEARCH_CONFIG_PATH)) return { ...DEFAULT_PUBLIC_TOOL_NAMES };
+		const parsed: unknown = JSON.parse(readFileSync(WEB_SEARCH_CONFIG_PATH, "utf-8"));
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { ...DEFAULT_PUBLIC_TOOL_NAMES };
+		const toolNames = (parsed as Record<string, unknown>).toolNames;
+		if (!toolNames || typeof toolNames !== "object" || Array.isArray(toolNames)) return { ...DEFAULT_PUBLIC_TOOL_NAMES };
+		const record = toolNames as Record<string, unknown>;
+		const resolve = (key: "webSearch" | "fetchContent"): string => {
+			const value = record[key];
+			if (typeof value !== "string") return DEFAULT_PUBLIC_TOOL_NAMES[key];
+			const trimmed = value.trim();
+			return PUBLIC_TOOL_NAME_PATTERN.test(trimmed) ? trimmed : DEFAULT_PUBLIC_TOOL_NAMES[key];
+		};
+		const resolved = { webSearch: resolve("webSearch"), fetchContent: resolve("fetchContent") };
+		return resolved.webSearch === resolved.fetchContent ? { ...DEFAULT_PUBLIC_TOOL_NAMES } : resolved;
+	} catch {
+		return { ...DEFAULT_PUBLIC_TOOL_NAMES };
+	}
+}
+
 function abortedResult(url: string): ExtractedContent {
 	return { url, title: "", content: "", error: "Aborted" };
 }
@@ -880,17 +907,19 @@ export async function extractContent(
 	// retrieve the page, so the provider-configuration checklist below would
 	// send users down the wrong path. Point at search instead.
 	if (finalHttpResult?.status === 404 || finalHttpResult?.status === 410) {
+		const toolNames = loadPublicToolNames();
 		return {
 			...finalHttpResult,
 			error: [
 				finalHttpResult.error,
 				"",
 				`The origin server says this page does not exist (HTTP ${finalHttpResult.status}), so extraction providers cannot retrieve it.`,
-				"The page may have moved or been renamed. Use web_search to find the current URL, then retry fetch_content with it.",
+				`The page may have moved or been renamed. Use ${toolNames.webSearch} to find the current URL, then retry ${toolNames.fetchContent} with it.`,
 			].join("\n"),
 		};
 	}
 
+	const { webSearch: searchToolName } = loadPublicToolNames();
 	const guidance = [
 		finalHttpResult?.error ?? "No fetch_content provider returned content",
 		...(firecrawlError ? [`Firecrawl fallback failed: ${firecrawlError}`] : []),
@@ -914,7 +943,7 @@ export async function extractContent(
 		`  • Set brightdataApiKey and brightdataUnlockerZone in ${WEB_SEARCH_CONFIG_PATH} or BRIGHTDATA_API_KEY and BRIGHTDATA_UNLOCKER_ZONE`,
 		`  • Set GEMINI_API_KEY in ${WEB_SEARCH_CONFIG_PATH}`,
 		"  • Sign into gemini.google.com in Chrome",
-		"  • Use web_search to find content about this topic",
+		`  • Use ${searchToolName} to find content about this topic`,
 	].join("\n");
 	return { ...(finalHttpResult ?? { url, title: "", content: "", error: null }), error: guidance };
 }

--- a/extract.ts
+++ b/extract.ts
@@ -191,31 +191,30 @@ function loadFetchRouting(): FetchRouting {
 	return { providers, allowRemoteHostedProviders: allowRemoteHostedProvidersValue === true };
 }
 
-const DEFAULT_PUBLIC_TOOL_NAMES = { webSearch: "web_search", fetchContent: "fetch_content" } as const;
-const PUBLIC_TOOL_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+/** Names of the search/fetch tools the caller has actually registered, so
+ * failure guidance never points at tools that do not exist in the session. */
+export interface RegisteredToolNames {
+	webSearch?: string;
+	fetchContent?: string;
+}
 
-/** Resolve the registered public tool names for guidance text. Lenient on
- * purpose: malformed config falls back to the defaults, matching what
- * extension init registers when toolNames fails validation. */
-function loadPublicToolNames(): { webSearch: string; fetchContent: string } {
-	try {
-		if (!existsSync(WEB_SEARCH_CONFIG_PATH)) return { ...DEFAULT_PUBLIC_TOOL_NAMES };
-		const parsed: unknown = JSON.parse(readFileSync(WEB_SEARCH_CONFIG_PATH, "utf-8"));
-		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { ...DEFAULT_PUBLIC_TOOL_NAMES };
-		const toolNames = (parsed as Record<string, unknown>).toolNames;
-		if (!toolNames || typeof toolNames !== "object" || Array.isArray(toolNames)) return { ...DEFAULT_PUBLIC_TOOL_NAMES };
-		const record = toolNames as Record<string, unknown>;
-		const resolve = (key: "webSearch" | "fetchContent"): string => {
-			const value = record[key];
-			if (typeof value !== "string") return DEFAULT_PUBLIC_TOOL_NAMES[key];
-			const trimmed = value.trim();
-			return PUBLIC_TOOL_NAME_PATTERN.test(trimmed) ? trimmed : DEFAULT_PUBLIC_TOOL_NAMES[key];
-		};
-		const resolved = { webSearch: resolve("webSearch"), fetchContent: resolve("fetchContent") };
-		return resolved.webSearch === resolved.fetchContent ? { ...DEFAULT_PUBLIC_TOOL_NAMES } : resolved;
-	} catch {
-		return { ...DEFAULT_PUBLIC_TOOL_NAMES };
+/** Guidance for definitive origin 404/410 responses: no extraction provider
+ * can retrieve a page the origin says is gone, so point at the registered
+ * search/fetch tools (when the caller knows them) instead of provider config. */
+function notFoundGuidance(result: ExtractedContent, toolNames?: RegisteredToolNames): string {
+	const lines = [
+		result.error ?? `HTTP ${result.status}`,
+		"",
+		`The origin server says this page does not exist (HTTP ${result.status}), so extraction providers cannot retrieve it.`,
+	];
+	if (toolNames?.webSearch && toolNames.fetchContent) {
+		lines.push(`The page may have moved or been renamed. Use ${toolNames.webSearch} to find the current URL, then retry ${toolNames.fetchContent} with it.`);
+	} else if (toolNames?.webSearch) {
+		lines.push(`The page may have moved or been renamed. Use ${toolNames.webSearch} to find the current URL.`);
+	} else {
+		lines.push("The page may have moved or been renamed. Find the current URL, then retry the fetch with it.");
 	}
+	return lines.join("\n");
 }
 
 function abortedResult(url: string): ExtractedContent {
@@ -262,6 +261,7 @@ export interface ExtractOptions {
 	mode?: "readable" | "raw" | "answer";
 	answerModel?: string;
 	authFetchProfile?: AuthFetchProfile;
+	toolNames?: RegisteredToolNames;
 	/** Custom DNS resolver used for SSRF validation. Primarily a test seam. */
 	lookup?: Lookup;
 }
@@ -907,19 +907,10 @@ export async function extractContent(
 	// retrieve the page, so the provider-configuration checklist below would
 	// send users down the wrong path. Point at search instead.
 	if (finalHttpResult?.status === 404 || finalHttpResult?.status === 410) {
-		const toolNames = loadPublicToolNames();
-		return {
-			...finalHttpResult,
-			error: [
-				finalHttpResult.error,
-				"",
-				`The origin server says this page does not exist (HTTP ${finalHttpResult.status}), so extraction providers cannot retrieve it.`,
-				`The page may have moved or been renamed. Use ${toolNames.webSearch} to find the current URL, then retry ${toolNames.fetchContent} with it.`,
-			].join("\n"),
-		};
+		return { ...finalHttpResult, error: notFoundGuidance(finalHttpResult, options?.toolNames) };
 	}
 
-	const { webSearch: searchToolName } = loadPublicToolNames();
+	const searchToolName = options?.toolNames?.webSearch;
 	const guidance = [
 		finalHttpResult?.error ?? "No fetch_content provider returned content",
 		...(firecrawlError ? [`Firecrawl fallback failed: ${firecrawlError}`] : []),
@@ -943,7 +934,7 @@ export async function extractContent(
 		`  • Set brightdataApiKey and brightdataUnlockerZone in ${WEB_SEARCH_CONFIG_PATH} or BRIGHTDATA_API_KEY and BRIGHTDATA_UNLOCKER_ZONE`,
 		`  • Set GEMINI_API_KEY in ${WEB_SEARCH_CONFIG_PATH}`,
 		"  • Sign into gemini.google.com in Chrome",
-		`  • Use ${searchToolName} to find content about this topic`,
+		...(searchToolName ? [`  • Use ${searchToolName} to find content about this topic`] : []),
 	].join("\n");
 	return { ...(finalHttpResult ?? { url, title: "", content: "", error: null }), error: guidance };
 }

--- a/index.ts
+++ b/index.ts
@@ -994,6 +994,12 @@ export default function (pi: ExtensionAPI) {
 	const sourceCheckEnabled = isToolEnabled(initConfig, "sourceCheck");
 	const fetchContentEnabled = isToolEnabled(initConfig, "fetchContent");
 	const getSearchContentEnabled = isToolEnabled(initConfig, "getSearchContent");
+	// Names as registered this session, so fetch failure guidance never points
+	// at tools that are disabled or were renamed after init.
+	const registeredToolNames = {
+		...(webSearchEnabled ? { webSearch: toolNames.webSearch } : {}),
+		...(fetchContentEnabled ? { fetchContent: toolNames.fetchContent } : {}),
+	};
 	const storedContentSources = joinToolNames([
 		...(webSearchEnabled ? [toolNames.webSearch] : []),
 		...(sourceCheckEnabled ? [toolNames.sourceCheck] : []),
@@ -1013,7 +1019,7 @@ export default function (pi: ExtensionAPI) {
 		const fetchId = generateId();
 		const controller = new AbortController();
 		pendingFetches.set(fetchId, controller);
-		fetchAllContent(urls, controller.signal)
+		fetchAllContent(urls, controller.signal, { toolNames: registeredToolNames })
 			.then((fetched) => {
 				if (!sessionActive || !pendingFetches.has(fetchId)) return;
 				const data = {
@@ -2317,7 +2323,7 @@ export default function (pi: ExtensionAPI) {
 			if (params.fetchContent && results.length > 0) {
 				const urls = results.slice(0, 5).map((result) => result.url);
 				try {
-					fetched = await fetchAllContent(urls, signal);
+					fetched = await fetchAllContent(urls, signal, { toolNames: registeredToolNames });
 				} catch (err) {
 					if (signal?.aborted || isAbortError(err)) throw err;
 					fetched = urls.map((url) => ({ url, title: "", content: "", error: err instanceof Error ? err.message : String(err) }));
@@ -2437,7 +2443,7 @@ export default function (pi: ExtensionAPI) {
 					return { ...rest, ...(authFetchProfile ? { authFetchProfile } : {}) };
 				})()
 				: { ...extractionOptions, ...(authFetchProfile ? { authFetchProfile } : {}) };
-			const fetchResults = await fetchAllContent(urlList, signal, fetchOptions);
+			const fetchResults = await fetchAllContent(urlList, signal, { ...fetchOptions, toolNames: registeredToolNames });
 			const presentedResults = mode === "answer"
 				? await Promise.all(fetchResults.map(async result => {
 					if (result.error) return result;

--- a/test/fetch-not-found-guidance.test.mjs
+++ b/test/fetch-not-found-guidance.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { extractContent } from "../extract.ts";
+
+const originalFetch = globalThis.fetch;
+const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
+
+test("404 drops the provider checklist and points at search", async (t) => {
+	t.after(() => { globalThis.fetch = originalFetch; });
+	globalThis.fetch = async () => new Response("gone", { status: 404, statusText: "Not Found" });
+
+	const result = await extractContent("https://example.com/missing-page", undefined, { lookup });
+
+	assert.equal(result.status, 404);
+	assert.match(result.error, /HTTP 404: Not Found/);
+	assert.doesNotMatch(result.error, /Fallback options:/);
+	assert.match(result.error, /web_search/);
+});
+
+test("410 gets the same not-found guidance", async (t) => {
+	t.after(() => { globalThis.fetch = originalFetch; });
+	globalThis.fetch = async () => new Response("gone", { status: 410, statusText: "Gone" });
+
+	const result = await extractContent("https://example.com/retired", undefined, { lookup });
+
+	assert.equal(result.status, 410);
+	assert.doesNotMatch(result.error, /Fallback options:/);
+	assert.match(result.error, /web_search/);
+});
+
+test("transient errors keep the fallback checklist", async (t) => {
+	t.after(() => { globalThis.fetch = originalFetch; });
+	globalThis.fetch = async () => new Response("broken", { status: 500, statusText: "Internal Server Error" });
+
+	const result = await extractContent("https://example.com/oops", undefined, { lookup });
+
+	assert.equal(result.status, 500);
+	assert.match(result.error, /Fallback options:/);
+});

--- a/test/fetch-not-found-guidance.test.mjs
+++ b/test/fetch-not-found-guidance.test.mjs
@@ -1,79 +1,92 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import { mkdtemp, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { test } from "node:test";
 
 import { extractContent } from "../extract.ts";
 
-const extractUrl = new URL("../extract.ts", import.meta.url).href;
 const originalFetch = globalThis.fetch;
 const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
+const toolNames = { webSearch: "web_search", fetchContent: "fetch_content" };
 
-test("404 drops the provider checklist and points at search", async (t) => {
+function stubStatus(t, status, statusText) {
 	t.after(() => { globalThis.fetch = originalFetch; });
-	globalThis.fetch = async () => new Response("gone", { status: 404, statusText: "Not Found" });
+	globalThis.fetch = async () => new Response("gone", { status, statusText });
+}
 
-	const result = await extractContent("https://example.com/missing-page", undefined, { lookup });
+test("404 drops the provider checklist and points at the registered tools", async (t) => {
+	stubStatus(t, 404, "Not Found");
+
+	const result = await extractContent("https://example.com/missing-page", undefined, { lookup, toolNames });
 
 	assert.equal(result.status, 404);
 	assert.match(result.error, /HTTP 404: Not Found/);
 	assert.doesNotMatch(result.error, /Fallback options:/);
 	assert.match(result.error, /web_search/);
+	assert.match(result.error, /fetch_content/);
 });
 
 test("410 gets the same not-found guidance", async (t) => {
-	t.after(() => { globalThis.fetch = originalFetch; });
-	globalThis.fetch = async () => new Response("gone", { status: 410, statusText: "Gone" });
+	stubStatus(t, 410, "Gone");
 
-	const result = await extractContent("https://example.com/retired", undefined, { lookup });
+	const result = await extractContent("https://example.com/retired", undefined, { lookup, toolNames });
 
 	assert.equal(result.status, 410);
 	assert.doesNotMatch(result.error, /Fallback options:/);
 	assert.match(result.error, /web_search/);
 });
 
-test("transient errors keep the fallback checklist", async (t) => {
-	t.after(() => { globalThis.fetch = originalFetch; });
-	globalThis.fetch = async () => new Response("broken", { status: 500, statusText: "Internal Server Error" });
+test("guidance uses the registered public tool names", async (t) => {
+	stubStatus(t, 404, "Not Found");
 
-	const result = await extractContent("https://example.com/oops", undefined, { lookup });
+	const result = await extractContent("https://example.com/missing-page", undefined, {
+		lookup,
+		toolNames: { webSearch: "webfinder", fetchContent: "pageget" },
+	});
+
+	assert.match(result.error, /webfinder/);
+	assert.match(result.error, /pageget/);
+	assert.doesNotMatch(result.error, /web_search/);
+});
+
+test("guidance stays generic when the caller does not know the tool names", async (t) => {
+	stubStatus(t, 404, "Not Found");
+
+	const result = await extractContent("https://example.com/missing-page", undefined, { lookup });
+
+	assert.doesNotMatch(result.error, /Fallback options:/);
+	assert.doesNotMatch(result.error, /web_search/);
+	assert.match(result.error, /Find the current URL, then retry the fetch/);
+});
+
+test("guidance omits the fetch tool when only search is registered", async (t) => {
+	stubStatus(t, 404, "Not Found");
+
+	const result = await extractContent("https://example.com/missing-page", undefined, {
+		lookup,
+		toolNames: { webSearch: "web_search" },
+	});
+
+	assert.match(result.error, /web_search/);
+	assert.doesNotMatch(result.error, /fetch_content/);
+});
+
+test("transient errors keep the fallback checklist", async (t) => {
+	stubStatus(t, 500, "Internal Server Error");
+
+	const result = await extractContent("https://example.com/oops", undefined, { lookup, toolNames });
 
 	assert.equal(result.status, 500);
 	assert.match(result.error, /Fallback options:/);
+	assert.match(result.error, /Use web_search to find content about this topic/);
 });
 
-test("guidance uses the configured public tool names", async () => {
-	const root = await mkdtemp(join(tmpdir(), "pi-fetch-404-names-"));
-	await writeFile(
-		join(root, "web-search.json"),
-		JSON.stringify({ toolNames: { webSearch: "webfinder", fetchContent: "pageget" } }) + "\n",
-		"utf8",
-	);
-	const childEnv = { ...process.env, PI_CODING_AGENT_DIR: root, HOME: root, USERPROFILE: root };
-	for (const key of [
-		"FIRECRAWL_BASE_URL", "FIRECRAWL_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY",
-		"SEARCH1API_KEY", "SEARCH1API_API_KEY", "QUERIT_API_KEY", "KAGI_API_KEY", "OLLAMA_API_KEY",
-		"BRIGHTDATA_API_KEY", "BRIGHTDATA_UNLOCKER_ZONE", "GEMINI_API_KEY", "GOOGLE_GEMINI_API_KEY", "GOOGLE_API_KEY",
-	]) delete childEnv[key];
+test("the checklist search bullet follows the registered search tool name", async (t) => {
+	stubStatus(t, 500, "Internal Server Error");
 
-	const child = spawnSync(process.execPath, ["--input-type=module"], {
-		input: `
-			globalThis.fetch = async () => new Response("gone", { status: 404, statusText: "Not Found" });
-			const { extractContent } = await import(${JSON.stringify(extractUrl)});
-			const result = await extractContent("https://example.com/missing-page", undefined, { lookup: async () => [{ address: "93.184.216.34", family: 4 }] });
-			console.log(JSON.stringify(result));
-		`,
-		encoding: "utf8",
-		env: childEnv,
-		maxBuffer: 2 * 1024 * 1024,
+	const result = await extractContent("https://example.com/oops", undefined, {
+		lookup,
+		toolNames: { webSearch: "webfinder" },
 	});
-	assert.equal(child.status, 0, child.stderr);
 
-	const result = JSON.parse(child.stdout.trim());
-	assert.equal(result.status, 404);
-	assert.match(result.error, /webfinder/);
-	assert.match(result.error, /pageget/);
+	assert.match(result.error, /Use webfinder to find content about this topic/);
 	assert.doesNotMatch(result.error, /web_search/);
 });

--- a/test/fetch-not-found-guidance.test.mjs
+++ b/test/fetch-not-found-guidance.test.mjs
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 
 import { extractContent } from "../extract.ts";
 
+const extractUrl = new URL("../extract.ts", import.meta.url).href;
 const originalFetch = globalThis.fetch;
 const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
 
@@ -37,4 +42,38 @@ test("transient errors keep the fallback checklist", async (t) => {
 
 	assert.equal(result.status, 500);
 	assert.match(result.error, /Fallback options:/);
+});
+
+test("guidance uses the configured public tool names", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-fetch-404-names-"));
+	await writeFile(
+		join(root, "web-search.json"),
+		JSON.stringify({ toolNames: { webSearch: "webfinder", fetchContent: "pageget" } }) + "\n",
+		"utf8",
+	);
+	const childEnv = { ...process.env, PI_CODING_AGENT_DIR: root, HOME: root, USERPROFILE: root };
+	for (const key of [
+		"FIRECRAWL_BASE_URL", "FIRECRAWL_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY",
+		"SEARCH1API_KEY", "SEARCH1API_API_KEY", "QUERIT_API_KEY", "KAGI_API_KEY", "OLLAMA_API_KEY",
+		"BRIGHTDATA_API_KEY", "BRIGHTDATA_UNLOCKER_ZONE", "GEMINI_API_KEY", "GOOGLE_GEMINI_API_KEY", "GOOGLE_API_KEY",
+	]) delete childEnv[key];
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			globalThis.fetch = async () => new Response("gone", { status: 404, statusText: "Not Found" });
+			const { extractContent } = await import(${JSON.stringify(extractUrl)});
+			const result = await extractContent("https://example.com/missing-page", undefined, { lookup: async () => [{ address: "93.184.216.34", family: 4 }] });
+			console.log(JSON.stringify(result));
+		`,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+	assert.equal(child.status, 0, child.stderr);
+
+	const result = JSON.parse(child.stdout.trim());
+	assert.equal(result.status, 404);
+	assert.match(result.error, /webfinder/);
+	assert.match(result.error, /pageget/);
+	assert.doesNotMatch(result.error, /web_search/);
 });


### PR DESCRIPTION
## Summary

When `fetch_content` gets a definitive 404 or 410 from the origin server, the error currently ends with the "Fallback options" checklist (configure Firecrawl, TinyFish, Kagi, etc.). No extraction provider can retrieve a page the origin says is gone, so the checklist sends users down the wrong path — I hit this fetching an Apollo docs page that had been renamed, and spent a while looking at provider config before realizing the URL itself was dead.

This replaces the checklist for 404/410 responses with a short note that the page likely moved and a pointer to `web_search` to find the current URL. All other failures keep the existing checklist unchanged.

Before:

```
HTTP 404: Not Found

Fallback options:
  • Set firecrawlBaseUrl in ~/.pi/web-search.json to a self-hosted Firecrawl instance
  • Set tinyfishApiKey in ~/.pi/web-search.json or TINYFISH_API_KEY
  ...
```

After:

```
HTTP 404: Not Found

The origin server says this page does not exist (HTTP 404), so extraction providers cannot retrieve it.
The page may have moved or been renamed. Use web_search to find the current URL, then retry fetch_content with it.
```

The fallback chain itself is untouched — a provider that can still serve the page (e.g. a cached copy) returns successfully before this message is built, so this only changes the all-providers-failed guidance text.

## Changes

- `extract.ts`: short-circuit the guidance builder for HTTP 404/410 with not-found-specific guidance.
- `test/fetch-not-found-guidance.test.mjs`: covers 404, 410, and asserts transient errors (500) still get the full checklist.

## Test plan

- `node --test test/fetch-not-found-guidance.test.mjs` — 3/3 pass
- `npm test` — 559/560 pass; the one failure (`chrome-cookie-extraction` › "failed password lookups are retried instead of cached") also fails for me on unmodified `main`, so it looks environment-related and unrelated to this change
- `npm run typecheck` — clean
