### PR TITLE
fix: contain Defuddle fallback errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 - Cleaned the unreleased XCrawl provider docs, parser shape, provider availability types, and focused tests.
 
+### Fixed
+
+- Kept Defuddle selector-processing failures out of the Pi console and stopped treating the raw page body as a successful extraction. Thanks to [@riabiy](https://github.com/riabiy) for #315.
+
 ## [0.25.0] - 2026-08-25
 
 ### Highlights

--- a/extract.ts
+++ b/extract.ts
@@ -43,10 +43,40 @@ type FetchRouting = { providers: FetchProvider[]; allowRemoteHostedProviders: bo
 const DEFAULT_FETCH_PROVIDER_ORDER: FetchProvider[] = ["http", "firecrawl", "jina", "tinyfish", "search1api", "querit", "kagi", "ollama", "parallel", "brightdata", "gemini"];
 const REMOTE_HOSTED_FETCH_PROVIDERS = new Set<FetchProvider>(["jina", "tinyfish", "search1api", "querit", "kagi", "ollama", "parallel", "parallel-mcp", "brightdata", "gemini"]);
 
+function isDefuddleConsoleError(args: Parameters<typeof console.error>): boolean {
+	const prefix = args[0];
+	return prefix === "Defuddle" || (typeof prefix === "string" && /^Defuddle(?:\s|:)/.test(prefix));
+}
+
 async function extractWithDefuddle(text: string, url: string): Promise<{ title: string; content: string } | null> {
 	const { Defuddle } = await import("defuddle/node");
 	const { document } = parseHTML(text);
-	const result = await Defuddle(document as unknown as Document, url, { markdown: true, useAsync: false });
+	let processingError: unknown;
+	const originalConsoleError = console.error;
+	console.error = (...args) => {
+		if (isDefuddleConsoleError(args)) {
+			if (args[0] === "Defuddle" && args[1] === "Error processing document:") {
+				processingError = args[2];
+			}
+			return;
+		}
+		originalConsoleError(...args);
+	};
+
+	let resultPromise: ReturnType<typeof Defuddle>;
+	try {
+		// With useAsync:false, Defuddle parses synchronously before returning its promise.
+		// Keep the console interception limited to that call so unrelated Pi output is
+		// never routed through this fallback's handler.
+		resultPromise = Defuddle(document as unknown as Document, url, { markdown: true, useAsync: false });
+	} finally {
+		console.error = originalConsoleError;
+	}
+
+	const result = await resultPromise;
+	if (processingError !== undefined) {
+		throw new Error(`Defuddle failed to process document: ${errorMessage(processingError)}`);
+	}
 	return typeof result.content === "string" ? { title: result.title, content: result.content } : null;
 }
 

--- a/test/rsc-fallback.test.mjs
+++ b/test/rsc-fallback.test.mjs
@@ -71,6 +71,28 @@ test("short Readability output falls back to useful Defuddle content", async (t)
 	assert.match(result.content, /Useful Defuddle content after the short Readability article/);
 });
 
+test("Defuddle processing failures stay contained and do not return the fallback body", async (t) => {
+	const originalConsoleError = console.error;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+		console.error = originalConsoleError;
+	});
+	const paragraph = "This is substantial article text that should be extracted as the page's main content. ";
+	const html = `<!doctype html><html><head><title>Defuddle selector failure</title></head><body><nav><a href="/">Home</a></nav><template id="B:0"></template><div hidden id="S:a"><h1>Defuddle selector failure</h1><p>${paragraph.repeat(20)}</p></div><template id="P:a"></template><footer><p>Copyright 2026 Example Inc. All rights reserved.</p></footer></body></html>`;
+	globalThis.fetch = async () => new Response(html, {
+		status: 200,
+		headers: { "content-type": "text/html" },
+	});
+
+	const consoleErrors = [];
+	console.error = (...args) => { consoleErrors.push(args); };
+	const result = await extractContent("https://example.com/defuddle-selector-failure", undefined, { lookup });
+
+	assert.equal(consoleErrors.length, 0);
+	assert.match(result.error, /Defuddle failed to process document: Unknown pseudo-class :a/);
+	assert.doesNotMatch(result.content, /Copyright 2026/);
+});
+
 test("short non-RSC pages remain incomplete", async (t) => {
 	t.after(() => { globalThis.fetch = originalFetch; });
 	globalThis.fetch = async () => new Response(


### PR DESCRIPTION
Fixes #315.

This contains Defuddle's internal selector-processing console output around the local fallback call. When Defuddle reports a processing error and returns body-level fallback content, `fetch_content` now returns a normal extraction error instead of a successful page body.

Validation:
- `node --test test/rsc-fallback.test.mjs`
- `npm run typecheck`
- `npm test`
- `git diff --check`

Thanks to [@riabiy](https://github.com/riabiy) for the report and reproduction.
