### PR TITLE
fix(xcrawl): resolve API-origin-relative result links to absolute URLs

### DIFF
--- a/test/xcrawl-provider.test.mjs
+++ b/test/xcrawl-provider.test.mjs
@@ -69,6 +69,26 @@ test("XCrawl sends Bearer credentials to the SERP endpoint, normalizes null titl
 	assert.equal(output.routedProvider, "xcrawl");
 });
 
+test("XCrawl resolves API-origin-relative result links to absolute URLs", async () => {
+	const home = await createHome({ xcrawlApiKey: "xc-test-key" });
+	const child = runChild(`
+		globalThis.fetch = async () => new Response(JSON.stringify(${JSON.stringify(serpEnvelope({
+			organic: [
+				{ position: 1, title: "Redirect result", link: "/goto?url=CAESAAAA", snippet: "Obfuscated link." },
+				{ position: 2, title: null, link: "https://www.example.com/absolute", snippet: "Absolute link." },
+			],
+		}))}), { status: 200 });
+		const { searchWithXCrawl } = await import(${JSON.stringify(xcrawlModuleUrl)});
+		const response = await searchWithXCrawl("links");
+		console.log(JSON.stringify(response.results));
+	`, { PI_CODING_AGENT_DIR: home });
+	assert.equal(child.status, 0, child.stderr);
+	const results = JSON.parse(child.stdout.trim());
+	assert.equal(results[0].url, "https://run.xcrawl.com/goto?url=CAESAAAA");
+	assert.equal(results[1].url, "https://www.example.com/absolute");
+	assert.equal(results[1].title, "https://www.example.com/absolute");
+});
+
 test("XCrawl applies the shared domain filter client-side", async () => {
 	const home = await createHome({ xcrawlApiKey: "xc-test-key" });
 	const child = runChild(`

--- a/xcrawl.ts
+++ b/xcrawl.ts
@@ -83,6 +83,19 @@ function hostnameOf(url: string): string {
 	}
 }
 
+// XCrawl's Google SERP results can carry links relative to the API origin
+// (e.g. "/goto?url=..." redirect stubs) instead of the documented absolute
+// URLs. Resolve those against the API origin so callers always receive a
+// well-formed absolute URL; absolute http(s) links pass through unchanged.
+function absolutizeLink(link: string): string {
+	if (/^https?:\/\//i.test(link)) return link;
+	try {
+		return new URL(link, XCRAWL_API_URL).href;
+	} catch {
+		return link;
+	}
+}
+
 // Normalize a shared domainFilter entry the same way Valyu does before
 // matching: trim, lowercase, strip URL/paths/ports, validate the shape.
 function normalizeDomain(value: string): string | null {
@@ -151,9 +164,10 @@ function parseResponse(value: unknown): SearchResponse["results"] {
 		if (snippet !== undefined && snippet !== null && typeof snippet !== "string") {
 			throw invalidResponse(`expected organic_results[${index}].snippet to be a string or null`);
 		}
+		const resolved = absolutizeLink(link);
 		results.push({
-			title: typeof title === "string" && title.trim().length > 0 ? title : link,
-			url: link,
+			title: typeof title === "string" && title.trim().length > 0 ? title : resolved,
+			url: resolved,
 			snippet: typeof snippet === "string" ? snippet : "",
 		});
 	}


### PR DESCRIPTION
## What

`xcrawl.ts` now resolves result `link` values that are not absolute `http(s)` URLs against the XCrawl API origin before emitting them.

## Why

XCrawl's Google SERP (`/v1/serp`, `engine=google_search`) currently returns `organic_results[].link` as API-origin-relative redirect stubs, e.g.:

```json
{ "link": "/goto?url=CAESXAHrOzAV..." }
```

Their docs still show absolute URLs (`"link": "https://openai.com/"`), so this looks like a server-side change. Taking those values verbatim produced broken relative result URLs (and a relative "Source" URL in the answer text). With this change we emit `https://run.xcrawl.com/goto?url=...`, which is a well-formed absolute URL, and non-relative links continue to pass through unchanged.

## Note

This is the defensive provider-side fix. Separately, XCrawl's `/goto` resolver currently returns `403 Access Denied: Only /v1 and /v2 endpoints are available`, so the resulting absolute URL is still an XCrawl-side redirect that only becomes clickable once XCrawl exposes the resolver (or restores absolute links). That upstream regression is worth reporting to XCrawl; see the follow-up for reference.

## Tests

- `test/xcrawl-provider.test.mjs`: added a regression test for relative `/goto` link resolution.
- `npx tsc --noEmit`: clean.
- xcrawl test file: 13/13 pass.
- Full `npm test`: 606 pass / 2 fail — the 2 failures are the pre-existing Gemini cookie/credential environment failures, unrelated to this change.