### PR TITLE
fix(web_search): expand JSON-array strings in the `query` field

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -358,9 +358,11 @@ function expandQueryString(query: unknown): string[] {
 	if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
 		try {
 			const parsed: unknown = JSON.parse(trimmed);
-			if (Array.isArray(parsed)) {
+			// Only expand an unambiguously string-only array. Mixed or non-string
+			// arrays are kept as the literal query so we never silently drop
+			// members or collapse them into an empty search.
+			if (Array.isArray(parsed) && parsed.every((entry): entry is string => typeof entry === "string")) {
 				return parsed
-					.filter((entry): entry is string => typeof entry === "string")
 					.map((entry) => entry.trim())
 					.filter((entry) => entry.length > 0);
 			}
@@ -1774,7 +1776,7 @@ export default function (pi: ExtensionAPI) {
 		async execute(callId, params, signal, onUpdate, ctx) {
 			return runWithProxy(typeof params.proxy === "string" ? params.proxy : undefined, async () => {
 				const rawQueryList: unknown[] = Array.isArray(params.queries)
-					? params.queries.flatMap(expandQueryString)
+					? params.queries
 					: (params.query !== undefined ? expandQueryString(params.query) : []);
 				const queryList = normalizeQueryList(rawQueryList);
 				const configWorkflow = loadConfigForExtensionInit().workflow;
@@ -2070,7 +2072,7 @@ export default function (pi: ExtensionAPI) {
 		renderCall(args, theme) {
 			const input = args as { query?: unknown; queries?: unknown };
 			const rawQueryList: unknown[] = Array.isArray(input.queries)
-				? input.queries.flatMap(expandQueryString)
+				? input.queries
 				: (input.query !== undefined ? expandQueryString(input.query) : []);
 			const queryList = normalizeQueryList(rawQueryList);
 			if (queryList.length === 0) {

--- a/index.ts
+++ b/index.ts
@@ -346,6 +346,31 @@ function normalizeQueryList(queryList: unknown[]): string[] {
 	return normalized;
 }
 
+// Some local models serialize a multi-query list into the single-string `query`
+// field as a JSON array (query: "[\"a\", \"b\"]") instead of using the
+// `queries` parameter. Forwarding that raw string verbatim makes every backend
+// search for the literal array text and return zero results, with no signal to
+// the model that its argument shape was wrong. Expand a string that parses as a
+// JSON array of strings so each element is searched independently.
+function expandQueryString(query: unknown): string[] {
+	if (typeof query !== "string") return [];
+	const trimmed = query.trim();
+	if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+		try {
+			const parsed: unknown = JSON.parse(trimmed);
+			if (Array.isArray(parsed)) {
+				return parsed
+					.filter((entry): entry is string => typeof entry === "string")
+					.map((entry) => entry.trim())
+					.filter((entry) => entry.length > 0);
+			}
+		} catch {
+			// Not JSON — treat as a literal query string.
+		}
+	}
+	return [query];
+}
+
 function getCuratorTimeoutSeconds(): number {
 	const source = loadConfig();
 	const explicit = normalizeCuratorTimeoutSeconds(source.curatorTimeoutSeconds);
@@ -1749,8 +1774,8 @@ export default function (pi: ExtensionAPI) {
 		async execute(callId, params, signal, onUpdate, ctx) {
 			return runWithProxy(typeof params.proxy === "string" ? params.proxy : undefined, async () => {
 				const rawQueryList: unknown[] = Array.isArray(params.queries)
-					? params.queries
-					: (params.query !== undefined ? [params.query] : []);
+					? params.queries.flatMap(expandQueryString)
+					: (params.query !== undefined ? expandQueryString(params.query) : []);
 				const queryList = normalizeQueryList(rawQueryList);
 				const configWorkflow = loadConfigForExtensionInit().workflow;
 				const workflow = resolveWorkflow(params.workflow ?? configWorkflow, ctx?.hasUI !== false);
@@ -2045,8 +2070,8 @@ export default function (pi: ExtensionAPI) {
 		renderCall(args, theme) {
 			const input = args as { query?: unknown; queries?: unknown };
 			const rawQueryList: unknown[] = Array.isArray(input.queries)
-				? input.queries
-				: (input.query !== undefined ? [input.query] : []);
+				? input.queries.flatMap(expandQueryString)
+				: (input.query !== undefined ? expandQueryString(input.query) : []);
 			const queryList = normalizeQueryList(rawQueryList);
 			if (queryList.length === 0) {
 				return new Text(theme.fg("toolTitle", theme.bold("search ")) + theme.fg("error", "(no query)"), 0, 0);

--- a/test/web-search-query-expand.test.mjs
+++ b/test/web-search-query-expand.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const indexUrl = new URL("../index.ts", import.meta.url).href;
+
+function runChild(script, env) {
+	const childEnv = { ...process.env };
+	for (const key of [
+		"PI_CODING_AGENT_DIR",
+		"XDG_CONFIG_HOME",
+		"XCRAWL_API_KEY",
+		"OPENAI_API_KEY",
+		"BRAVE_API_KEY",
+		"PARALLEL_API_KEY",
+		"TINYFISH_API_KEY",
+		"TAVILY_API_KEY",
+		"JINA_API_KEY",
+		"EXA_API_KEY",
+		"PERPLEXITY_API_KEY",
+		"GEMINI_API_KEY",
+	]) {
+		delete childEnv[key];
+	}
+	Object.assign(childEnv, env);
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+}
+
+test("web_search expands a JSON-array string in query into separate searches", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-317-"));
+	await writeFile(join(home, "web-search.json"), JSON.stringify({ xcrawlApiKey: "xc-test-key" }) + "\n", "utf8");
+
+	// What a small/local model actually sends: the queries array serialized as a
+	// JSON string inside the single-string `query` field.
+	const brokenQuery = '["AGP version", "Compose BOM", "CameraX"]';
+
+	const child = runChild(`
+		const requests = [];
+		globalThis.fetch = async (url, init) => {
+			let q = null;
+			try { q = JSON.parse(init.body).q; } catch {}
+			requests.push({ url: String(url), q });
+			return new Response(JSON.stringify({
+				search_metadata: { status: "completed" },
+				total_credits_used: 1,
+				organic_results: [
+					{ position: 1, title: "R1", link: "https://example.com/1", snippet: "s1" },
+					{ position: 2, title: "R2", link: "https://example.com/2", snippet: "s2" },
+				],
+			}), { status: 200 });
+		};
+		const { default: initializeExtension } = await import(${JSON.stringify(indexUrl)});
+		const tools = [];
+		initializeExtension({
+			registerTool(tool) { tools.push(tool); },
+			registerCommand() {},
+			registerShortcut() {},
+			on() {},
+			appendEntry() {},
+			sendMessage() {},
+			exec() { return { code: 0 }; },
+		});
+		const webSearch = tools.find((tool) => tool.name === "web_search");
+		await webSearch.execute("call", {
+			query: ${JSON.stringify(brokenQuery)},
+			provider: "xcrawl",
+			workflow: "none",
+			numResults: 2,
+		});
+		console.log(JSON.stringify(requests));
+	`, { PI_CODING_AGENT_DIR: home });
+
+	assert.equal(child.status, 0, child.stderr);
+	const requests = JSON.parse(child.stdout.trim());
+	const queries = requests
+		.filter((request) => request.url === "https://run.xcrawl.com/v1/serp")
+		.map((request) => request.q);
+
+	// Three independent backend queries, not one literal JSON-array string.
+	assert.deepEqual(queries, ["AGP version", "Compose BOM", "CameraX"]);
+});

--- a/test/web-search-query-expand.test.mjs
+++ b/test/web-search-query-expand.test.mjs
@@ -34,14 +34,14 @@ function runChild(script, env) {
 	});
 }
 
-test("web_search expands a JSON-array string in query into separate searches", async () => {
+async function setupHome() {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-317-"));
 	await writeFile(join(home, "web-search.json"), JSON.stringify({ xcrawlApiKey: "xc-test-key" }) + "\n", "utf8");
+	return home;
+}
 
-	// What a small/local model actually sends: the queries array serialized as a
-	// JSON string inside the single-string `query` field.
-	const brokenQuery = '["AGP version", "Compose BOM", "CameraX"]';
-
+// Runs web_search with the given params and returns the queries XCrawl actually received.
+function capturedQueries(home, params) {
 	const child = runChild(`
 		const requests = [];
 		globalThis.fetch = async (url, init) => {
@@ -69,21 +69,51 @@ test("web_search expands a JSON-array string in query into separate searches", a
 			exec() { return { code: 0 }; },
 		});
 		const webSearch = tools.find((tool) => tool.name === "web_search");
-		await webSearch.execute("call", {
-			query: ${JSON.stringify(brokenQuery)},
-			provider: "xcrawl",
-			workflow: "none",
-			numResults: 2,
-		});
-		console.log(JSON.stringify(requests));
+		await webSearch.execute("call", ${JSON.stringify(params)});
+		const queries = requests
+			.filter((request) => request.url === "https://run.xcrawl.com/v1/serp")
+			.map((request) => request.q);
+		console.log(JSON.stringify(queries));
 	`, { PI_CODING_AGENT_DIR: home });
-
 	assert.equal(child.status, 0, child.stderr);
-	const requests = JSON.parse(child.stdout.trim());
-	const queries = requests
-		.filter((request) => request.url === "https://run.xcrawl.com/v1/serp")
-		.map((request) => request.q);
+	return JSON.parse(child.stdout.trim());
+}
 
-	// Three independent backend queries, not one literal JSON-array string.
+test("web_search expands a JSON-array string in query into separate searches", async () => {
+	const home = await setupHome();
+	// What a small/local model actually sends: the queries array serialized as
+	// a JSON string inside the single-string `query` field.
+	const queries = capturedQueries(home, {
+		query: '["AGP version", "Compose BOM", "CameraX"]',
+		provider: "xcrawl",
+		workflow: "none",
+		numResults: 2,
+	});
 	assert.deepEqual(queries, ["AGP version", "Compose BOM", "CameraX"]);
+});
+
+test("web_search keeps mixed JSON arrays in query as a single literal query", async () => {
+	const home = await setupHome();
+	const queries = capturedQueries(home, {
+		query: '["AGP version", 5]',
+		provider: "xcrawl",
+		workflow: "none",
+		numResults: 2,
+	});
+	// Not an unambiguous string array — keep it verbatim rather than silently
+	// dropping the non-string member.
+	assert.deepEqual(queries, ['["AGP version", 5]']);
+});
+
+test("web_search does not reinterpret already-structured queries entries", async () => {
+	const home = await setupHome();
+	const queries = capturedQueries(home, {
+		queries: ['["AGP version", "Compose BOM"]'],
+		provider: "xcrawl",
+		workflow: "none",
+		numResults: 2,
+	});
+	// The plural `queries` field is already structured — expansion stays scoped
+	// to the malformed singular `query` field.
+	assert.deepEqual(queries, ['["AGP version", "Compose BOM"]']);
 });


### PR DESCRIPTION
Closes #317.

## Problem

`web_search` returned 0 results when a local model serialized a multi-query list into the single-string `query` field as a JSON array, e.g. `query: "[\"a\", \"b\"]"`. The raw string was forwarded verbatim to every backend (SearXNG receives `q=["a","b"]`), so every engine returned zero hits with no signal to the model that its argument shape was wrong.

## Fix

Added `expandQueryString()`: if a query string parses as a JSON array of strings, expand it into independent queries; otherwise keep it as a single literal query. Applied at both `rawQueryList` construction sites — the `web_search` execute handler and the `renderCall` display path.

## Verification

- **Reproduced first**: a regression test captured the backend receiving one literal `["AGP version", "Compose BOM", "CameraX"]` instead of three queries.
- `test/web-search-query-expand.test.mjs` added; after the fix it asserts three independent backend queries.
- `npx tsc --noEmit`: clean.
- Full `npm test`: 606 pass / 2 fail — the 2 are the pre-existing Gemini cookie/credential environment failures, unrelated to this change.