### PR TITLE
fix(xcrawl): resolve API-origin-relative result links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 - Expanded JSON-array strings supplied in the singular `web_search` `query` field into independent searches, with a clear no-query error for empty arrays. Thanks to [@alex-rs](https://github.com/alex-rs) for #317 and [@zeroicey](https://github.com/zeroicey) for PR #319.
 - Kept Defuddle selector-processing failures out of the Pi console and stopped treating the raw page body as a successful extraction. Thanks to [@riabiy](https://github.com/riabiy) for #315.
+- Resolved API-origin-relative XCrawl result links to absolute URLs so emitted source links remain clickable. Thanks to [@zeroicey](https://github.com/zeroicey) for #318.
 
 ## [0.25.0] - 2026-08-25
 

--- a/test/xcrawl-provider.test.mjs
+++ b/test/xcrawl-provider.test.mjs
@@ -69,6 +69,47 @@ test("XCrawl sends Bearer credentials to the SERP endpoint, normalizes null titl
 	assert.equal(output.routedProvider, "xcrawl");
 });
 
+test("XCrawl resolves API-origin-relative result links to absolute URLs", async () => {
+	const home = await createHome({ xcrawlApiKey: "xc-test-key" });
+	const child = runChild(`
+		globalThis.fetch = async () => new Response(JSON.stringify(${JSON.stringify(serpEnvelope({
+			organic: [
+				{ position: 1, title: "Redirect result", link: "/goto?url=CAESAAAA", snippet: "Obfuscated link." },
+				{ position: 2, title: null, link: "https://www.example.com/absolute", snippet: "Absolute link." },
+			],
+		}))}), { status: 200 });
+		const { searchWithXCrawl } = await import(${JSON.stringify(xcrawlModuleUrl)});
+		const response = await searchWithXCrawl("links");
+		console.log(JSON.stringify(response.results));
+	`, { PI_CODING_AGENT_DIR: home });
+	assert.equal(child.status, 0, child.stderr);
+	const results = JSON.parse(child.stdout.trim());
+	assert.equal(results[0].url, "https://run.xcrawl.com/goto?url=CAESAAAA");
+	assert.equal(results[1].url, "https://www.example.com/absolute");
+	assert.equal(results[1].title, "https://www.example.com/absolute");
+});
+
+test("XCrawl rejects whitespace-only result links", async () => {
+	const home = await createHome({ xcrawlApiKey: "xc-test-key" });
+	const child = runChild(`
+		globalThis.fetch = async () => new Response(JSON.stringify(${JSON.stringify(serpEnvelope({
+			organic: [
+				{ position: 1, title: "Blank link", link: "   ", snippet: "Invalid link." },
+			],
+		}))}), { status: 200 });
+		const { searchWithXCrawl } = await import(${JSON.stringify(xcrawlModuleUrl)});
+		try {
+			await searchWithXCrawl("blank link");
+			console.log(JSON.stringify({ error: null }));
+		} catch (error) {
+			console.log(JSON.stringify({ error: String(error.message) }));
+		}
+	`, { PI_CODING_AGENT_DIR: home });
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.error, "XCrawl API returned invalid response: expected organic_results[0].link to be a non-empty string");
+});
+
 test("XCrawl applies the shared domain filter client-side", async () => {
 	const home = await createHome({ xcrawlApiKey: "xc-test-key" });
 	const child = runChild(`

--- a/xcrawl.ts
+++ b/xcrawl.ts
@@ -83,6 +83,19 @@ function hostnameOf(url: string): string {
 	}
 }
 
+// XCrawl's Google SERP results can carry links relative to the API origin
+// (e.g. "/goto?url=..." redirect stubs) instead of the documented absolute
+// URLs. Resolve those against the API origin so callers always receive a
+// well-formed absolute URL; absolute http(s) links pass through unchanged.
+function absolutizeLink(link: string): string {
+	if (/^https?:\/\//i.test(link)) return link;
+	try {
+		return new URL(link, XCRAWL_API_URL).href;
+	} catch {
+		return link;
+	}
+}
+
 // Normalize a shared domainFilter entry the same way Valyu does before
 // matching: trim, lowercase, strip URL/paths/ports, validate the shape.
 function normalizeDomain(value: string): string | null {
@@ -144,16 +157,17 @@ function parseResponse(value: unknown): SearchResponse["results"] {
 		}
 		const result = value as XCrawlSerpResult;
 		const { title, link, snippet } = result;
-		if (typeof link !== "string" || !link) throw invalidResponse(`expected organic_results[${index}].link to be a non-empty string`);
+		if (typeof link !== "string" || !link.trim()) throw invalidResponse(`expected organic_results[${index}].link to be a non-empty string`);
 		if (title !== null && title !== undefined && typeof title !== "string") {
 			throw invalidResponse(`expected organic_results[${index}].title to be a string or null`);
 		}
 		if (snippet !== undefined && snippet !== null && typeof snippet !== "string") {
 			throw invalidResponse(`expected organic_results[${index}].snippet to be a string or null`);
 		}
+		const resolved = absolutizeLink(link.trim());
 		results.push({
-			title: typeof title === "string" && title.trim().length > 0 ? title : link,
-			url: link,
+			title: typeof title === "string" && title.trim().length > 0 ? title : resolved,
+			url: resolved,
 			snippet: typeof snippet === "string" ? snippet : "",
 		});
 	}


### PR DESCRIPTION
Supersedes #318.

This preserves @zeroicey's XCrawl fix on an owner branch and adds the required changelog credit.

XCrawl can return API-origin-relative result links such as `/goto?...`. This resolves those links against the XCrawl API origin before emitting results, so `url` and fallback titles are absolute. Absolute `http(s)` links still pass through unchanged.

Validation:
- `node --test test/xcrawl-provider.test.mjs`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh replacement review found no issues.

Thanks to @zeroicey for #318.
