### PR TITLE
fix: expand JSON-array web search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Expanded JSON-array strings supplied in the singular `web_search` `query` field into independent searches, with a clear no-query error for empty arrays. Thanks to [@alex-rs](https://github.com/alex-rs) for #317 and [@zeroicey](https://github.com/zeroicey) for PR #319.
 - Kept Defuddle selector-processing failures out of the Pi console and stopped treating the raw page body as a successful extraction. Thanks to [@riabiy](https://github.com/riabiy) for #315.
 
 ## [0.25.0] - 2026-08-25

--- a/index.ts
+++ b/index.ts
@@ -346,6 +346,33 @@ function normalizeQueryList(queryList: unknown[]): string[] {
 	return normalized;
 }
 
+// Some local models serialize a multi-query list into the single-string `query`
+// field as a JSON array (query: "[\"a\", \"b\"]") instead of using the
+// `queries` parameter. Forwarding that raw string verbatim makes every backend
+// search for the literal array text and return zero results, with no signal to
+// the model that its argument shape was wrong. Expand a string that parses as a
+// JSON array of strings so each element is searched independently.
+function expandQueryString(query: unknown): string[] {
+	if (typeof query !== "string") return [];
+	const trimmed = query.trim();
+	if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+		try {
+			const parsed: unknown = JSON.parse(trimmed);
+			// Only expand an unambiguously string-only array. Mixed or non-string
+			// arrays are kept as the literal query so we never silently drop
+			// members or collapse them into an empty search.
+			if (Array.isArray(parsed) && parsed.every((entry): entry is string => typeof entry === "string")) {
+				return parsed
+					.map((entry) => entry.trim())
+					.filter((entry) => entry.length > 0);
+			}
+		} catch {
+			// Not JSON — treat as a literal query string.
+		}
+	}
+	return [query];
+}
+
 function getCuratorTimeoutSeconds(): number {
 	const source = loadConfig();
 	const explicit = normalizeCuratorTimeoutSeconds(source.curatorTimeoutSeconds);
@@ -1750,7 +1777,7 @@ export default function (pi: ExtensionAPI) {
 			return runWithProxy(typeof params.proxy === "string" ? params.proxy : undefined, async () => {
 				const rawQueryList: unknown[] = Array.isArray(params.queries)
 					? params.queries
-					: (params.query !== undefined ? [params.query] : []);
+					: (params.query !== undefined ? expandQueryString(params.query) : []);
 				const queryList = normalizeQueryList(rawQueryList);
 				const configWorkflow = loadConfigForExtensionInit().workflow;
 				const workflow = resolveWorkflow(params.workflow ?? configWorkflow, ctx?.hasUI !== false);
@@ -2046,7 +2073,7 @@ export default function (pi: ExtensionAPI) {
 			const input = args as { query?: unknown; queries?: unknown };
 			const rawQueryList: unknown[] = Array.isArray(input.queries)
 				? input.queries
-				: (input.query !== undefined ? [input.query] : []);
+				: (input.query !== undefined ? expandQueryString(input.query) : []);
 			const queryList = normalizeQueryList(rawQueryList);
 			if (queryList.length === 0) {
 				return new Text(theme.fg("toolTitle", theme.bold("search ")) + theme.fg("error", "(no query)"), 0, 0);

--- a/test/web-search-query-expand.test.mjs
+++ b/test/web-search-query-expand.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const indexUrl = new URL("../index.ts", import.meta.url).href;
+
+function runChild(script, env) {
+	const childEnv = { ...process.env };
+	for (const key of [
+		"PI_CODING_AGENT_DIR",
+		"XDG_CONFIG_HOME",
+		"XCRAWL_API_KEY",
+		"OPENAI_API_KEY",
+		"BRAVE_API_KEY",
+		"PARALLEL_API_KEY",
+		"TINYFISH_API_KEY",
+		"TAVILY_API_KEY",
+		"JINA_API_KEY",
+		"EXA_API_KEY",
+		"PERPLEXITY_API_KEY",
+		"GEMINI_API_KEY",
+	]) {
+		delete childEnv[key];
+	}
+	Object.assign(childEnv, env);
+	return spawnSync(process.execPath, ["--input-type=module"], {
+		input: script,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+}
+
+async function setupHome() {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-317-"));
+	await writeFile(join(home, "web-search.json"), JSON.stringify({ xcrawlApiKey: "xc-test-key" }) + "\n", "utf8");
+	return home;
+}
+
+// Runs web_search with the given params and returns the result plus queries XCrawl received.
+function runWebSearch(home, params) {
+	const child = runChild(`
+		const requests = [];
+		globalThis.fetch = async (url, init) => {
+			let q = null;
+			try { q = JSON.parse(init.body).q; } catch {}
+			requests.push({ url: String(url), q });
+			return new Response(JSON.stringify({
+				search_metadata: { status: "completed" },
+				total_credits_used: 1,
+				organic_results: [
+					{ position: 1, title: "R1", link: "https://example.com/1", snippet: "s1" },
+					{ position: 2, title: "R2", link: "https://example.com/2", snippet: "s2" },
+				],
+			}), { status: 200 });
+		};
+		const { default: initializeExtension } = await import(${JSON.stringify(indexUrl)});
+		const tools = [];
+		initializeExtension({
+			registerTool(tool) { tools.push(tool); },
+			registerCommand() {},
+			registerShortcut() {},
+			on() {},
+			appendEntry() {},
+			sendMessage() {},
+			exec() { return { code: 0 }; },
+		});
+		const webSearch = tools.find((tool) => tool.name === "web_search");
+		const result = await webSearch.execute("call", ${JSON.stringify(params)});
+		const queries = requests
+			.filter((request) => request.url === "https://run.xcrawl.com/v1/serp")
+			.map((request) => request.q);
+		console.log(JSON.stringify({ result, queries }));
+	`, { PI_CODING_AGENT_DIR: home });
+	assert.equal(child.status, 0, child.stderr);
+	return JSON.parse(child.stdout.trim());
+}
+
+function capturedQueries(home, params) {
+	return runWebSearch(home, params).queries;
+}
+
+test("web_search expands a JSON-array string in query into separate searches", async () => {
+	const home = await setupHome();
+	// What a small/local model actually sends: the queries array serialized as
+	// a JSON string inside the single-string `query` field.
+	const queries = capturedQueries(home, {
+		query: '["AGP version", "Compose BOM", "CameraX"]',
+		provider: "xcrawl",
+		workflow: "none",
+		numResults: 2,
+	});
+	assert.deepEqual(queries, ["AGP version", "Compose BOM", "CameraX"]);
+});
+
+test("web_search keeps mixed JSON arrays in query as a single literal query", async () => {
+	const home = await setupHome();
+	const queries = capturedQueries(home, {
+		query: '["AGP version", 5]',
+		provider: "xcrawl",
+		workflow: "none",
+		numResults: 2,
+	});
+	// Not an unambiguous string array — keep it verbatim rather than silently
+	// dropping the non-string member.
+	assert.deepEqual(queries, ['["AGP version", 5]']);
+});
+
+test("web_search does not reinterpret already-structured queries entries", async () => {
+	const home = await setupHome();
+	const queries = capturedQueries(home, {
+		queries: ['["AGP version", "Compose BOM"]'],
+		provider: "xcrawl",
+		workflow: "none",
+		numResults: 2,
+	});
+	// The plural `queries` field is already structured — expansion stays scoped
+	// to the malformed singular `query` field.
+	assert.deepEqual(queries, ['["AGP version", "Compose BOM"]']);
+});
+
+test("web_search reports the existing no-query error for empty JSON-array strings", async () => {
+	const home = await setupHome();
+	for (const query of ["[]", '["   "]']) {
+		const { result, queries } = runWebSearch(home, {
+			query,
+			provider: "xcrawl",
+			workflow: "none",
+			numResults: 2,
+		});
+		assert.deepEqual(queries, []);
+		assert.equal(result.details.error, "No query provided");
+		assert.equal(result.content[0].text, "Error: No query provided. Use 'query' or 'queries' parameter.");
+	}
+});


### PR DESCRIPTION
Closes #317.
Supersedes #319.

This preserves @zeroicey's implementation on an owner branch and adds the required changelog credit for both the report and the fix.

When local models serialize multiple web search queries as a JSON-array string in the singular `query` field, `web_search` now expands a non-empty string-only array into independent searches. Structured `queries[]` entries remain literal, mixed arrays remain literal, and empty or blank-only arrays return the existing clear no-query error without issuing a backend search.

Validation:
- `node --test test/web-search-query-expand.test.mjs`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh replacement review found no issues.

Thanks to @alex-rs for #317 and @zeroicey for #319.
