### PR TITLE
fix: set Defuddle document location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Set the Defuddle fallback document URL before parsing pages with relative canonical links, preventing `ERR_INVALID_URL` warnings. Thanks to [@bin115885](https://github.com/bin115885) for issue #322.
+
 ## [0.26.0] - 2026-08-28
 
 ### Highlights

--- a/extract.ts
+++ b/extract.ts
@@ -51,6 +51,10 @@ function isDefuddleConsoleError(args: Parameters<typeof console.error>): boolean
 async function extractWithDefuddle(text: string, url: string): Promise<{ title: string; content: string } | null> {
 	const { Defuddle } = await import("defuddle/node");
 	const { document } = parseHTML(text);
+	Object.defineProperty(document, "location", {
+		value: new URL(url),
+		configurable: true,
+	});
 	let processingError: unknown;
 	const originalConsoleError = console.error;
 	console.error = (...args) => {

--- a/test/rsc-fallback.test.mjs
+++ b/test/rsc-fallback.test.mjs
@@ -57,6 +57,25 @@ test("null Readability output falls back to local Defuddle extraction", async (t
 	assert.match(result.content, /https:\/\/example\.com\/openapi\.json/);
 });
 
+test("Defuddle fallback resolves relative canonical URLs against the fetched URL", async (t) => {
+	const originalConsoleWarn = console.warn;
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+		console.warn = originalConsoleWarn;
+	});
+	const article = "Defuddle content with a relative canonical URL stays quiet. ".repeat(20);
+	globalThis.fetch = async () => new Response(
+		`<!doctype html><html><head><title>Relative canonical</title><link rel="canonical" href="/relative-canonical"></head><body><aside><main>${article}</main></aside></body></html>`,
+		{ status: 200, headers: { "content-type": "text/html" } },
+	);
+	const warnings = [];
+	console.warn = (...args) => { warnings.push(args); };
+
+	const result = await extractContent("https://example.com/relative-canonical", undefined, { lookup });
+	assert.equal(result.error, null);
+	assert.deepEqual(warnings, []);
+});
+
 test("short Readability output falls back to useful Defuddle content", async (t) => {
 	t.after(() => { globalThis.fetch = originalFetch; });
 	const article = "Useful Defuddle content after the short Readability article. ".repeat(20);


### PR DESCRIPTION
Closes #322.\n\nThis gives the local Defuddle fallback a document URL before parsing pages that use relative canonical links, so Defuddle does not print URL parse warnings into Pi output.\n\nThanks to @bin115885 for the report.\n\nGates run:\n- node --test test/rsc-fallback.test.mjs\n- npm run typecheck\n- git diff --check origin/main...HEAD\n\nFresh review: /Users/nicobailon/.pi/agent/memory/pi-web-access/issue322-defuddle-fresh-review-20260828.md