### PR TITLE
fix: clean stale GitHub clone runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Cleaned stale GitHub clone runtime directories after a crashed process when the owner can be proven dead, while preserving runtimes with unknown or live owners. Thanks to [@yazanabuashour](https://github.com/yazanabuashour) for issue #331.
+
 ## [0.27.0] - 2026-08-28
 
 ### Highlights

--- a/github-extract.ts
+++ b/github-extract.ts
@@ -1,4 +1,5 @@
-import { chmodSync, closeSync, existsSync, lstatSync, mkdirSync, mkdtempSync, openSync, readFileSync, readSync, readdirSync, realpathSync, rmSync, statSync, unlinkSync } from "node:fs";
+import { chmodSync, closeSync, constants as fsConstants, existsSync, fstatSync, lstatSync, mkdirSync, mkdtempSync, openSync, readFileSync, readSync, readdirSync, realpathSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { lstat as lstatAsync, open as openAsync, opendir as opendirAsync, readFile as readFileAsync, realpath as realpathAsync, rm as rmAsync, type FileHandle } from "node:fs/promises";
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { basename, dirname, extname, join, resolve as resolvePath, sep as pathSep } from "node:path";
@@ -29,6 +30,9 @@ const NOISE_DIRS = new Set([
 
 const MAX_INLINE_FILE_CHARS = 100_000;
 const MAX_TREE_ENTRIES = 200;
+const CLONE_RUNTIME_OWNER_FILENAME = ".owner.json";
+const CLONE_RUNTIME_OWNER_VERSION = 1;
+const MAX_CLONE_RUNTIME_OWNER_BYTES = 1024;
 
 export interface GitHubUrlInfo {
 	owner: string;
@@ -49,6 +53,14 @@ interface CloneDestination {
 	localPath: string;
 }
 
+interface CloneRuntimeOwner {
+	version: 1;
+	pid: number;
+	platform: string;
+	bootId?: string;
+	startTime?: string;
+}
+
 interface GitHubCloneConfig {
 	enabled: boolean;
 	maxRepoSizeMB: number;
@@ -57,6 +69,7 @@ interface GitHubCloneConfig {
 }
 
 const cloneCache = new Map<string, CachedClone>();
+const startedCloneRuntimeCleanups = new Set<string>();
 
 let cachedConfig: GitHubCloneConfig | null = null;
 let cloneRuntime: { parentPath: string; rootPath: string } | null = null;
@@ -190,6 +203,244 @@ function cacheKey(owner: string, repo: string, ref?: string): string {
 	return ref ? `${owner}/${repo}@${ref}` : `${owner}/${repo}`;
 }
 
+function readLinuxBootId(): string | null {
+	try {
+		const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf-8").trim();
+		return bootId.length > 0 ? bootId : null;
+	} catch {
+		return null;
+	}
+}
+
+async function readLinuxBootIdAsync(): Promise<string | null> {
+	try {
+		const bootId = (await readFileAsync("/proc/sys/kernel/random/boot_id", "utf-8")).trim();
+		return bootId.length > 0 ? bootId : null;
+	} catch {
+		return null;
+	}
+}
+
+interface LinuxProcessInfo {
+	state: string;
+	startTime: string | null;
+	dead: boolean;
+}
+
+function parseLinuxProcessInfo(stat: string): LinuxProcessInfo | null {
+	const closingParen = stat.lastIndexOf(") ");
+	if (closingParen < 0) return null;
+	const fields = stat.slice(closingParen + 2).trim().split(/\s+/);
+	const state = fields[0];
+	const startTime = fields[19];
+	if (!state || !startTime || !/^\d+$/.test(startTime)) return null;
+	return { state, startTime, dead: false };
+}
+
+function readLinuxProcessInfo(pid: number): LinuxProcessInfo | null {
+	try {
+		return parseLinuxProcessInfo(readFileSync(`/proc/${pid}/stat`, "utf-8"));
+	} catch (err) {
+		if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+			return { state: "", startTime: null, dead: true };
+		}
+		return null;
+	}
+}
+
+async function readLinuxProcessInfoAsync(pid: number): Promise<LinuxProcessInfo | null> {
+	try {
+		return parseLinuxProcessInfo(await readFileAsync(`/proc/${pid}/stat`, "utf-8"));
+	} catch (err) {
+		if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+			return { state: "", startTime: null, dead: true };
+		}
+		return null;
+	}
+}
+
+function currentCloneRuntimeOwner(): CloneRuntimeOwner {
+	const owner: CloneRuntimeOwner = {
+		version: CLONE_RUNTIME_OWNER_VERSION,
+		pid: process.pid,
+		platform: process.platform,
+	};
+
+	if (process.platform === "linux") {
+		const bootId = readLinuxBootId();
+		const processInfo = readLinuxProcessInfo(process.pid);
+		if (bootId && processInfo?.startTime) {
+			owner.bootId = bootId;
+			owner.startTime = processInfo.startTime;
+		}
+	}
+
+	return owner;
+}
+
+function writeCloneRuntimeOwner(runtimePath: string): void {
+	const ownerPath = join(runtimePath, CLONE_RUNTIME_OWNER_FILENAME);
+	writeFileSync(ownerPath, JSON.stringify(currentCloneRuntimeOwner()), {
+		encoding: "utf-8",
+		flag: "wx",
+		mode: 0o600,
+	});
+}
+
+function parseCloneRuntimeOwner(text: string): CloneRuntimeOwner | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return null;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+
+	const record = parsed as Record<string, unknown>;
+	if (
+		record.version !== CLONE_RUNTIME_OWNER_VERSION ||
+		typeof record.pid !== "number" ||
+		!Number.isSafeInteger(record.pid) ||
+		record.pid <= 0 ||
+		typeof record.platform !== "string" ||
+		record.platform.length === 0 ||
+		record.platform.length > 32
+	) {
+		return null;
+	}
+
+	const owner: CloneRuntimeOwner = {
+		version: CLONE_RUNTIME_OWNER_VERSION,
+		pid: record.pid,
+		platform: record.platform,
+	};
+	if (record.bootId !== undefined) {
+		if (typeof record.bootId !== "string" || record.bootId.length === 0 || record.bootId.length > 256) return null;
+		owner.bootId = record.bootId;
+	}
+	if (record.startTime !== undefined) {
+		if (typeof record.startTime !== "string" || !/^\d+$/.test(record.startTime)) return null;
+		owner.startTime = record.startTime;
+	}
+	return owner;
+}
+
+async function readCloneRuntimeOwner(runtimePath: string): Promise<CloneRuntimeOwner | null> {
+	const ownerPath = join(runtimePath, CLONE_RUNTIME_OWNER_FILENAME);
+	let file: FileHandle | undefined;
+	try {
+		const entry = await lstatAsync(ownerPath);
+		if (!entry.isFile() || entry.size > MAX_CLONE_RUNTIME_OWNER_BYTES) return null;
+		const noFollow = fsConstants.O_NOFOLLOW ?? 0;
+		file = await openAsync(ownerPath, fsConstants.O_RDONLY | noFollow);
+		const opened = await file.stat();
+		if (!opened.isFile() || opened.size > MAX_CLONE_RUNTIME_OWNER_BYTES) return null;
+		return parseCloneRuntimeOwner(await file.readFile("utf-8"));
+	} catch {
+		return null;
+	} finally {
+		if (file !== undefined) {
+			try {
+				await file.close();
+			} catch {
+				// The handle may already have been closed externally.
+			}
+		}
+	}
+}
+
+function processNonexistenceProven(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return false;
+	} catch (err) {
+		return Boolean(err && typeof err === "object" && "code" in err && err.code === "ESRCH");
+	}
+}
+
+async function cloneRuntimeOwnerIsDead(owner: CloneRuntimeOwner, bootId: string | null): Promise<boolean> {
+	if (owner.platform !== process.platform) return false;
+
+	if (process.platform !== "linux") {
+		return processNonexistenceProven(owner.pid);
+	}
+
+	// Linux PID values can be reused. Require both boot ID and proc start time
+	// before treating a runtime as owned, and preserve it when either check is
+	// unavailable.
+	if (!owner.bootId || !owner.startTime || !bootId) return false;
+	const processInfo = await readLinuxProcessInfoAsync(owner.pid);
+	if (!processInfo) return false;
+	if (processInfo.dead || processInfo.state === "Z" || processInfo.state === "X") return true;
+	return processInfo.startTime !== owner.startTime || bootId !== owner.bootId;
+}
+
+async function removeCloneRuntimeAsync(parentPath: string, runtimePath: string): Promise<void> {
+	const normalizedParentPath = resolvePath(parentPath);
+	const normalizedRuntimePath = resolvePath(runtimePath);
+	if (dirname(normalizedRuntimePath) !== normalizedParentPath || !basename(normalizedRuntimePath).startsWith("runtime-")) return;
+
+	try {
+		const realRuntimePath = await realpathAsync(normalizedRuntimePath);
+		if (dirname(realRuntimePath) !== normalizedParentPath || basename(realRuntimePath) !== basename(normalizedRuntimePath)) return;
+		const entry = await lstatAsync(normalizedRuntimePath);
+		if (entry.isSymbolicLink() || !entry.isDirectory()) return;
+		await rmAsync(normalizedRuntimePath, { recursive: true, force: true });
+	} catch {
+		// The runtime directory may already have been removed externally.
+	}
+}
+
+async function sweepStaleCloneRuntimes(parentPath: string): Promise<void> {
+	const normalizedParentPath = resolvePath(parentPath);
+	const bootId = process.platform === "linux" ? await readLinuxBootIdAsync() : null;
+	let directory: Awaited<ReturnType<typeof opendirAsync>>;
+	try {
+		directory = await opendirAsync(normalizedParentPath);
+	} catch {
+		return;
+	}
+
+	try {
+		for await (const entry of directory) {
+			if (!entry.name.startsWith("runtime-")) continue;
+			try {
+				if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+				const runtimePath = resolvePath(normalizedParentPath, entry.name);
+				if (dirname(runtimePath) !== normalizedParentPath) continue;
+				const runtimeEntry = await lstatAsync(runtimePath);
+				if (!runtimeEntry.isDirectory() || runtimeEntry.isSymbolicLink()) continue;
+				const realRuntimePath = await realpathAsync(runtimePath);
+				if (dirname(realRuntimePath) !== normalizedParentPath || basename(realRuntimePath) !== basename(runtimePath)) continue;
+				const owner = await readCloneRuntimeOwner(runtimePath);
+				if (!owner || !(await cloneRuntimeOwnerIsDead(owner, bootId))) continue;
+				await removeCloneRuntimeAsync(normalizedParentPath, runtimePath);
+			} catch {
+				// A changing or unreadable runtime must not stop the rest of the sweep.
+			}
+		}
+	} catch {
+		// Cleanup is opportunistic. A changing or unreadable cache must not stop
+		// GitHub extraction from falling back to the API.
+	} finally {
+		try {
+			await directory.close();
+		} catch {
+			// The directory may already have been closed externally.
+		}
+	}
+}
+
+function startStaleCloneRuntimeCleanup(parentPath: string): void {
+	const normalizedParentPath = resolvePath(parentPath);
+	if (startedCloneRuntimeCleanups.has(normalizedParentPath)) return;
+	startedCloneRuntimeCleanups.add(normalizedParentPath);
+	// Keep runtime creation synchronous and let the complete sweep run in the background.
+	void sweepStaleCloneRuntimes(normalizedParentPath).catch(() => {
+		// Cleanup is best effort and must never affect extraction.
+	});
+}
+
 function removeCloneRuntime(parentPath: string, runtimePath: string): void {
 	const normalizedParentPath = resolvePath(parentPath);
 	const normalizedRuntimePath = resolvePath(runtimePath);
@@ -213,6 +464,7 @@ function getCloneRuntimeRoot(config: GitHubCloneConfig): string | null {
 		const configuredPath = resolvePath(config.clonePath);
 		mkdirSync(configuredPath, { recursive: true });
 		parentPath = realpathSync(configuredPath);
+		startStaleCloneRuntimeCleanup(parentPath);
 		runtimePath = mkdtempSync(join(parentPath, "runtime-"));
 		chmodSync(runtimePath, 0o700);
 		const rootPath = realpathSync(runtimePath);
@@ -220,6 +472,7 @@ function getCloneRuntimeRoot(config: GitHubCloneConfig): string | null {
 			removeCloneRuntime(parentPath, runtimePath);
 			return null;
 		}
+		writeCloneRuntimeOwner(rootPath);
 		cloneRuntime = { parentPath, rootPath };
 		return rootPath;
 	} catch {

--- a/test/github-extract.test.mjs
+++ b/test/github-extract.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { test } from "node:test";
@@ -68,6 +68,27 @@ async function waitForFile(path, timeoutMs = 5000) {
 		await new Promise((resolve) => setTimeout(resolve, 10));
 	}
 	throw new Error(`Timed out waiting for ${path}`);
+}
+
+async function waitForCondition(condition, description, timeoutMs = 5000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (condition()) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function readJsonWhenReady(path, timeoutMs = 5000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			return JSON.parse(await readFile(path, "utf8"));
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+	}
+	throw new Error(`Timed out waiting for complete JSON in ${path}`);
 }
 
 function processIsAlive(pid) {
@@ -405,6 +426,358 @@ test("runtime cache reuse and cleanup stay isolated across processes", { skip: p
 	} finally {
 		await writeFile(aRelease, "release");
 		if (a?.child.exitCode === null) a.child.kill("SIGKILL");
+	}
+});
+
+test("clone runtime initialization removes a dead runtime after unrelated entries", { skip: process.platform === "win32" }, async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-github-runtime-stale-"));
+	const agentDir = join(root, "agent-dir");
+	const binDir = join(root, "bin");
+	const clonePath = join(root, "repos");
+	const staleReady = join(root, "stale-ready.json");
+	const staleRelease = join(root, "stale-release");
+	const currentReady = join(root, "current-ready.json");
+	const currentRelease = join(root, "current-release");
+	await mkdir(agentDir, { recursive: true });
+	await mkdir(binDir, { recursive: true });
+	await mkdir(clonePath, { recursive: true });
+	for (let i = 0; i < 1024; i++) {
+		await writeFile(join(clonePath, `unrelated-${String(i).padStart(4, "0")}`), "preserve", "utf8");
+	}
+	await writeFile(join(agentDir, "web-search.json"), JSON.stringify({ githubClone: { clonePath } }), "utf8");
+	await writeControlledGh(binDir);
+
+	const commonEnv = {
+		...process.env,
+		PATH: `${binDir}${delimiter}${process.env.PATH || ""}`,
+		PI_CODING_AGENT_DIR: agentDir,
+	};
+	let stale;
+	let current;
+	try {
+		stale = spawnModule(`
+			const { existsSync } = await import("node:fs");
+			const { writeFile } = await import("node:fs/promises");
+			const { dirname } = await import("node:path");
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/owner/repo", undefined, true);
+			const localPath = result?.content.match(/^Repository cloned to: (.+)$/m)?.[1] ?? null;
+			await writeFile(process.env.RUNTIME_READY_FILE, JSON.stringify({ runtimePath: localPath ? dirname(localPath) : null }));
+			while (!existsSync(process.env.RUNTIME_RELEASE_FILE)) await new Promise((resolve) => setTimeout(resolve, 10));
+		`, {
+			...commonEnv,
+			RUNTIME_READY_FILE: staleReady,
+			RUNTIME_RELEASE_FILE: staleRelease,
+		});
+		const staleState = await readJsonWhenReady(staleReady);
+		assert.ok(staleState.runtimePath);
+		assert.equal(existsSync(staleState.runtimePath), true);
+
+		stale.child.kill("SIGKILL");
+		await stale.completed;
+
+		current = spawnModule(`
+			const { existsSync } = await import("node:fs");
+			const { writeFile } = await import("node:fs/promises");
+			const { dirname } = await import("node:path");
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/owner/repo", undefined, true);
+			const localPath = result?.content.match(/^Repository cloned to: (.+)$/m)?.[1] ?? null;
+			await writeFile(process.env.RUNTIME_READY_FILE, JSON.stringify({ runtimePath: localPath ? dirname(localPath) : null }));
+			while (!existsSync(process.env.RUNTIME_RELEASE_FILE)) await new Promise((resolve) => setTimeout(resolve, 10));
+		`, {
+			...commonEnv,
+			RUNTIME_READY_FILE: currentReady,
+			RUNTIME_RELEASE_FILE: currentRelease,
+		});
+		const currentState = await readJsonWhenReady(currentReady);
+		assert.ok(currentState.runtimePath);
+		assert.notEqual(currentState.runtimePath, staleState.runtimePath);
+		await waitForCondition(() => !existsSync(staleState.runtimePath), "dead runtime cleanup");
+		assert.equal(existsSync(currentState.runtimePath), true);
+	} finally {
+		await Promise.allSettled([writeFile(staleRelease, "release"), writeFile(currentRelease, "release")]);
+		if (stale?.child.exitCode === null) stale.child.kill("SIGKILL");
+		if (current?.child.exitCode === null) current.child.kill("SIGKILL");
+	}
+});
+
+test("clone runtime creation proceeds while background cleanup is gated", { skip: process.platform === "win32" }, async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-github-runtime-background-"));
+	const agentDir = join(root, "agent-dir");
+	const binDir = join(root, "bin");
+	const clonePath = join(root, "repos");
+	const cleanupRelease = join(root, "cleanup-release");
+	const ready = join(root, "runtime-ready.json");
+	await mkdir(agentDir, { recursive: true });
+	await mkdir(binDir, { recursive: true });
+	await mkdir(clonePath, { recursive: true });
+	await writeFile(join(clonePath, "runtime-unknown"), "preserve", "utf8");
+	await writeFile(join(agentDir, "web-search.json"), JSON.stringify({ githubClone: { clonePath } }), "utf8");
+	await writeControlledGh(binDir);
+
+	const commonEnv = {
+		...process.env,
+		PATH: `${binDir}${delimiter}${process.env.PATH || ""}`,
+		PI_CODING_AGENT_DIR: agentDir,
+		RUNTIME_CLEANUP_RELEASE_FILE: cleanupRelease,
+	};
+	let child;
+	try {
+		child = spawnModule(`
+			const { existsSync } = await import("node:fs");
+			const { writeFile } = await import("node:fs/promises");
+			const originalAsyncIterator = (await import("node:fs")).Dir.prototype[Symbol.asyncIterator];
+			let cleanupReadStarted = false;
+			(await import("node:fs")).Dir.prototype[Symbol.asyncIterator] = function() {
+				const iterator = originalAsyncIterator.call(this);
+				return {
+					next: async (...args) => {
+						if (!cleanupReadStarted) {
+							cleanupReadStarted = true;
+							while (!existsSync(process.env.RUNTIME_CLEANUP_RELEASE_FILE)) await new Promise((resolve) => setTimeout(resolve, 10));
+						}
+						return iterator.next(...args);
+					},
+					return: (...args) => iterator.return?.(...args),
+					throw: (...args) => iterator.throw?.(...args),
+					[Symbol.asyncIterator]() { return this; },
+				};
+			};
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/owner/repo", undefined, true);
+			const localPath = result?.content.match(/^Repository cloned to: (.+)$/m)?.[1] ?? null;
+			while (!cleanupReadStarted) await new Promise((resolve) => setTimeout(resolve, 10));
+			await writeFile(process.env.RUNTIME_READY_FILE, JSON.stringify({ localPath, cleanupReadStarted }));
+			while (!existsSync(process.env.RUNTIME_CLEANUP_RELEASE_FILE)) await new Promise((resolve) => setTimeout(resolve, 10));
+		`, {
+			...commonEnv,
+			RUNTIME_READY_FILE: ready,
+		});
+		const state = await readJsonWhenReady(ready);
+		assert.ok(state.localPath);
+		assert.equal(state.cleanupReadStarted, true);
+		assert.equal(existsSync(state.localPath), true);
+		assert.equal(existsSync(cleanupRelease), false);
+		await writeFile(cleanupRelease, "release");
+		const result = await child.completed;
+		assert.equal(result.status, 0, result.stderr);
+	} finally {
+		await writeFile(cleanupRelease, "release").catch(() => {});
+		if (child?.child.exitCode === null) child.child.kill("SIGKILL");
+	}
+});
+
+test("background cleanup eventually removes multiple late dead runtimes", { skip: process.platform === "win32" }, async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-github-runtime-background-late-"));
+	const agentDir = join(root, "agent-dir");
+	const binDir = join(root, "bin");
+	const clonePath = join(root, "repos");
+	const staleReady = join(root, "stale-ready.json");
+	const staleRelease = join(root, "stale-release");
+	const currentReady = join(root, "current-ready.json");
+	const currentRelease = join(root, "current-release");
+	await mkdir(agentDir, { recursive: true });
+	await mkdir(binDir, { recursive: true });
+	await mkdir(clonePath, { recursive: true });
+	for (let i = 0; i < 512; i++) {
+		await mkdir(join(clonePath, `runtime-preserved-${String(i).padStart(3, "0")}`), { recursive: true });
+	}
+	await writeFile(join(agentDir, "web-search.json"), JSON.stringify({ githubClone: { clonePath } }), "utf8");
+	await writeControlledGh(binDir);
+
+	const commonEnv = {
+		...process.env,
+		PATH: `${binDir}${delimiter}${process.env.PATH || ""}`,
+		PI_CODING_AGENT_DIR: agentDir,
+	};
+	let stale;
+	let current;
+	try {
+		stale = spawnModule(`
+			const { existsSync } = await import("node:fs");
+			const { mkdir, readFile, writeFile } = await import("node:fs/promises");
+			const { dirname, join } = await import("node:path");
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/owner/repo", undefined, true);
+			const localPath = result?.content.match(/^Repository cloned to: (.+)$/m)?.[1] ?? null;
+			const runtimePath = localPath ? dirname(localPath) : null;
+			if (!runtimePath) process.exit(1);
+			const parentPath = dirname(runtimePath);
+			const owner = await readFile(join(runtimePath, ".owner.json"), "utf8");
+			const stalePaths = [];
+			for (let i = 0; i < 3; i++) {
+				const stalePath = join(parentPath, "runtime-late-dead-" + String(i).padStart(3, "0"));
+				await mkdir(stalePath, { recursive: true });
+				await writeFile(join(stalePath, ".owner.json"), owner, "utf8");
+				stalePaths.push(stalePath);
+			}
+			await writeFile(process.env.RUNTIME_READY_FILE, JSON.stringify({ runtimePath, stalePaths }));
+			while (!existsSync(process.env.RUNTIME_RELEASE_FILE)) await new Promise((resolve) => setTimeout(resolve, 10));
+		`, {
+			...commonEnv,
+			RUNTIME_READY_FILE: staleReady,
+			RUNTIME_RELEASE_FILE: staleRelease,
+		});
+		const staleState = await readJsonWhenReady(staleReady);
+		assert.ok(staleState.stalePaths?.length === 3);
+		stale.child.kill("SIGKILL");
+		await stale.completed;
+
+		current = spawnModule(`
+			const { existsSync } = await import("node:fs");
+			const { writeFile } = await import("node:fs/promises");
+			const { dirname } = await import("node:path");
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/owner/repo", undefined, true);
+			const localPath = result?.content.match(/^Repository cloned to: (.+)$/m)?.[1] ?? null;
+			await writeFile(process.env.RUNTIME_READY_FILE, JSON.stringify({ runtimePath: localPath ? dirname(localPath) : null }));
+			while (!existsSync(process.env.RUNTIME_RELEASE_FILE)) await new Promise((resolve) => setTimeout(resolve, 10));
+		`, {
+			...commonEnv,
+			RUNTIME_READY_FILE: currentReady,
+			RUNTIME_RELEASE_FILE: currentRelease,
+		});
+		const currentState = await readJsonWhenReady(currentReady);
+		assert.ok(currentState.runtimePath);
+		await waitForCondition(() => staleState.stalePaths.every((path) => !existsSync(path)), "late dead runtime cleanup");
+		assert.equal(existsSync(join(clonePath, "runtime-preserved-000")), true);
+		assert.equal(existsSync(join(clonePath, "runtime-preserved-511")), true);
+		await writeFile(currentRelease, "release");
+		const currentResult = await current.completed;
+		assert.equal(currentResult.status, 0, currentResult.stderr);
+	} finally {
+		await Promise.allSettled([writeFile(staleRelease, "release"), writeFile(currentRelease, "release")]);
+		if (stale?.child.exitCode === null) stale.child.kill("SIGKILL");
+		if (current?.child.exitCode === null) current.child.kill("SIGKILL");
+	}
+});
+
+test("oversized malformed owner metadata is preserved during extraction", { skip: process.platform === "win32" }, async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-github-runtime-owner-size-"));
+	const agentDir = join(root, "agent-dir");
+	const binDir = join(root, "bin");
+	const clonePath = join(root, "repos");
+	const malformedRuntime = join(clonePath, "runtime-oversized-owner");
+	const deadRuntime = join(clonePath, "runtime-dead");
+	const ready = join(root, "runtime-ready.json");
+	const release = join(root, "runtime-release");
+	await mkdir(agentDir, { recursive: true });
+	await mkdir(binDir, { recursive: true });
+	await mkdir(malformedRuntime, { recursive: true });
+	await writeFile(join(malformedRuntime, ".owner.json"), "{" + "x".repeat(4095), "utf8");
+	await mkdir(deadRuntime, { recursive: true });
+	await writeFile(join(deadRuntime, ".owner.json"), JSON.stringify({ version: 1, pid: 999999999, platform: process.platform, bootId: "test", startTime: "1" }), "utf8");
+	await writeFile(join(agentDir, "web-search.json"), JSON.stringify({ githubClone: { clonePath } }), "utf8");
+	await writeControlledGh(binDir);
+
+	const commonEnv = {
+		...process.env,
+		PATH: `${binDir}${delimiter}${process.env.PATH || ""}`,
+		PI_CODING_AGENT_DIR: agentDir,
+	};
+	let child;
+	try {
+		child = spawnModule(`
+			const { existsSync } = await import("node:fs");
+			const { writeFile } = await import("node:fs/promises");
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/owner/repo", undefined, true);
+			const localPath = result?.content.match(/^Repository cloned to: (.+)$/m)?.[1] ?? null;
+			await writeFile(process.env.RUNTIME_READY_FILE, JSON.stringify({ localPath }));
+			while (!existsSync(process.env.RUNTIME_RELEASE_FILE)) await new Promise((resolve) => setTimeout(resolve, 10));
+		`, {
+			...commonEnv,
+			RUNTIME_READY_FILE: ready,
+			RUNTIME_RELEASE_FILE: release,
+		});
+		const state = await readJsonWhenReady(ready);
+		assert.ok(state.localPath);
+		await waitForCondition(() => !existsSync(deadRuntime), "dead runtime cleanup");
+		assert.equal(existsSync(state.localPath), true);
+		assert.equal(existsSync(malformedRuntime), true);
+		await writeFile(release, "release");
+		const result = await child.completed;
+		assert.equal(result.status, 0, result.stderr);
+	} finally {
+		await writeFile(release, "release").catch(() => {});
+		if (child?.child.exitCode === null) child.child.kill("SIGKILL");
+	}
+});
+
+
+test("clone runtime initialization preserves live, unknown, and symlink runtimes", { skip: process.platform === "win32" }, async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-github-runtime-preserve-"));
+	const agentDir = join(root, "agent-dir");
+	const binDir = join(root, "bin");
+	const clonePath = join(root, "repos");
+	const unknownRuntime = join(clonePath, "runtime-unknown");
+	const deadRuntime = join(clonePath, "runtime-dead");
+	const outside = join(root, "outside");
+	const symlinkRuntime = join(clonePath, "runtime-symlink");
+	const liveReady = join(root, "live-ready.json");
+	const liveRelease = join(root, "live-release");
+	const currentReady = join(root, "current-ready.json");
+	const currentRelease = join(root, "current-release");
+	await mkdir(agentDir, { recursive: true });
+	await mkdir(binDir, { recursive: true });
+	await mkdir(unknownRuntime, { recursive: true });
+	await mkdir(deadRuntime, { recursive: true });
+	await writeFile(join(deadRuntime, ".owner.json"), JSON.stringify({ version: 1, pid: 999999999, platform: process.platform, bootId: "test", startTime: "1" }), "utf8");
+	await mkdir(outside, { recursive: true });
+	await writeFile(join(outside, "marker.txt"), "preserve", "utf8");
+	await symlink(outside, symlinkRuntime, "dir");
+	await writeFile(join(agentDir, "web-search.json"), JSON.stringify({ githubClone: { clonePath } }), "utf8");
+	await writeControlledGh(binDir);
+
+	const commonEnv = {
+		...process.env,
+		PATH: `${binDir}${delimiter}${process.env.PATH || ""}`,
+		PI_CODING_AGENT_DIR: agentDir,
+	};
+	let live;
+	let current;
+	try {
+		live = spawnModule(`
+			const { existsSync } = await import("node:fs");
+			const { writeFile } = await import("node:fs/promises");
+			const { dirname } = await import("node:path");
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/owner/repo", undefined, true);
+			const localPath = result?.content.match(/^Repository cloned to: (.+)$/m)?.[1] ?? null;
+			await writeFile(process.env.RUNTIME_READY_FILE, JSON.stringify({ runtimePath: localPath ? dirname(localPath) : null }));
+			while (!existsSync(process.env.RUNTIME_RELEASE_FILE)) await new Promise((resolve) => setTimeout(resolve, 10));
+		`, {
+			...commonEnv,
+			RUNTIME_READY_FILE: liveReady,
+			RUNTIME_RELEASE_FILE: liveRelease,
+		});
+		const liveState = await readJsonWhenReady(liveReady);
+		assert.ok(liveState.runtimePath);
+
+		current = spawnModule(`
+			const { existsSync } = await import("node:fs");
+			const { writeFile } = await import("node:fs/promises");
+			const { extractGitHub } = await import(${JSON.stringify(extractModuleUrl)});
+			const result = await extractGitHub("https://github.com/owner/repo", undefined, true);
+			await writeFile(process.env.RUNTIME_READY_FILE, JSON.stringify({ content: result?.content ?? null }));
+			while (!existsSync(process.env.RUNTIME_RELEASE_FILE)) await new Promise((resolve) => setTimeout(resolve, 10));
+		`, {
+			...commonEnv,
+			RUNTIME_READY_FILE: currentReady,
+			RUNTIME_RELEASE_FILE: currentRelease,
+		});
+		await waitForFile(currentReady);
+
+		await waitForCondition(() => !existsSync(deadRuntime), "background cleanup");
+		assert.equal(existsSync(liveState.runtimePath), true);
+		assert.equal(existsSync(unknownRuntime), true);
+		assert.equal(existsSync(symlinkRuntime), true);
+		assert.equal(await readFile(join(outside, "marker.txt"), "utf8"), "preserve");
+	} finally {
+		await Promise.allSettled([writeFile(liveRelease, "release"), writeFile(currentRelease, "release")]);
+		if (live?.child.exitCode === null) live.child.kill("SIGKILL");
+		if (current?.child.exitCode === null) current.child.kill("SIGKILL");
 	}
 });
 


### PR DESCRIPTION
## Summary

- add per-runtime owner metadata for GitHub clone cache directories
- opportunistically remove bounded stale `runtime-*` directories only when the owner process is proven dead
- keep live, unknown, malformed, or symlinked runtime entries intact

Closes #331.

Thanks to [@yazanabuashour](https://github.com/yazanabuashour) for reporting the stale crash-clone cleanup gap.

## Validation

- `node --test test/github-extract.test.mjs`
- `npm run typecheck`
- `npm test`
- `git diff --check origin/main...HEAD`

Release/tag authority was not used.
