### PR TITLE
fix: preserve legacy web search config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Cleaned stale GitHub clone runtime directories after a crashed process when the owner can be proven dead, while preserving runtimes with unknown or live owners. Thanks to [@yazanabuashour](https://github.com/yazanabuashour) for issue #331.
+- Kept an existing legacy `~/.pi/web-search.json` in use when `XDG_CONFIG_HOME` is set but its XDG config file is absent. Thanks to [@hu3rror](https://github.com/hu3rror) for issue #333.
 
 ## [0.27.0] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Toggle with **Ctrl+Shift+W** to see live request/response activity:
 
 ## Configuration
 
-Config defaults to `~/.pi/web-search.json`, or `web-search.json` under `PI_CODING_AGENT_DIR` / `XDG_CONFIG_HOME/pi` when set. Every field is optional.
+Config defaults to `~/.pi/web-search.json`. `PI_CODING_AGENT_DIR` takes precedence when set; with `XDG_CONFIG_HOME`, an existing `XDG_CONFIG_HOME/pi/web-search.json` is preferred, an existing legacy `~/.pi/web-search.json` remains usable, and the XDG path is used as the new-config target when neither file exists. Every field is optional.
 
 ```json
 {

--- a/test/config-path.test.mjs
+++ b/test/config-path.test.mjs
@@ -33,9 +33,12 @@ test("web-search config path uses PI_CODING_AGENT_DIR before XDG_CONFIG_HOME", a
 	const root = await mkdtemp(join(tmpdir(), "pi-web-access-config-path-"));
 	const agentDir = join(root, "agent-dir");
 	const xdgDir = join(root, "xdg");
+	const home = join(root, "home");
 	await mkdir(agentDir, { recursive: true });
+	await mkdir(join(home, ".pi"), { recursive: true });
 	await mkdir(join(xdgDir, "pi"), { recursive: true });
 	await writeFile(join(agentDir, "web-search.json"), JSON.stringify({ perplexityApiKey: "pplx-from-agent" }) + "\n", "utf8");
+	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify({ perplexityApiKey: "pplx-from-legacy" }) + "\n", "utf8");
 	await writeFile(join(xdgDir, "pi", "web-search.json"), JSON.stringify({}) + "\n", "utf8");
 
 	const child = runChild(`
@@ -49,8 +52,8 @@ test("web-search config path uses PI_CODING_AGENT_DIR before XDG_CONFIG_HOME", a
 	`, {
 		PI_CODING_AGENT_DIR: agentDir,
 		XDG_CONFIG_HOME: xdgDir,
-		HOME: join(root, "home"),
-		USERPROFILE: join(root, "home"),
+		HOME: home,
+		USERPROFILE: home,
 	});
 
 	assert.equal(child.status, 0, child.stderr);
@@ -63,8 +66,11 @@ test("web-search config path uses PI_CODING_AGENT_DIR before XDG_CONFIG_HOME", a
 
 test("web-search config path uses XDG_CONFIG_HOME pi directory when agent dir is unset", async () => {
 	const root = await mkdtemp(join(tmpdir(), "pi-web-access-xdg-config-"));
+	const home = join(root, "home");
 	const xdgDir = join(root, "xdg");
+	await mkdir(join(home, ".pi"), { recursive: true });
 	await mkdir(join(xdgDir, "pi"), { recursive: true });
+	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify({ perplexityApiKey: "pplx-from-legacy" }) + "\n", "utf8");
 	await writeFile(join(xdgDir, "pi", "web-search.json"), JSON.stringify({ geminiApiKey: "gemini-from-xdg" }) + "\n", "utf8");
 
 	const child = runChild(`
@@ -78,8 +84,8 @@ test("web-search config path uses XDG_CONFIG_HOME pi directory when agent dir is
 	`, {
 		PI_CODING_AGENT_DIR: undefined,
 		XDG_CONFIG_HOME: xdgDir,
-		HOME: join(root, "home"),
-		USERPROFILE: join(root, "home"),
+		HOME: home,
+		USERPROFILE: home,
 	});
 
 	assert.equal(child.status, 0, child.stderr);
@@ -87,6 +93,99 @@ test("web-search config path uses XDG_CONFIG_HOME pi directory when agent dir is
 		dir: join(xdgDir, "pi"),
 		path: join(xdgDir, "pi", "web-search.json"),
 		available: true,
+	});
+});
+
+test("web-search config path falls back to the existing legacy file when XDG file is absent", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-legacy-config-"));
+	const home = join(root, "home");
+	const xdgDir = join(root, "xdg");
+	await mkdir(join(home, ".pi"), { recursive: true });
+	await mkdir(join(xdgDir, "pi"), { recursive: true });
+	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify({ perplexityApiKey: "pplx-from-legacy" }) + "\n", "utf8");
+
+	const child = runChild(`
+		const { getWebSearchConfigDir, getWebSearchConfigPath } = await import(${JSON.stringify(utilsUrl)});
+		const { isPerplexityAvailable } = await import(${JSON.stringify(perplexityUrl)});
+		console.log(JSON.stringify({
+			dir: getWebSearchConfigDir(),
+			path: getWebSearchConfigPath(),
+			available: isPerplexityAvailable(),
+		}));
+	`, {
+		PI_CODING_AGENT_DIR: undefined,
+		XDG_CONFIG_HOME: xdgDir,
+		HOME: home,
+		USERPROFILE: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout), {
+		dir: join(home, ".pi"),
+		path: join(home, ".pi", "web-search.json"),
+		available: true,
+	});
+});
+
+test("web-search config path keeps the legacy fallback stable after XDG config is created", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-stable-config-"));
+	const home = join(root, "home");
+	const xdgDir = join(root, "xdg");
+	const xdgConfigPath = join(xdgDir, "pi", "web-search.json");
+	await mkdir(join(home, ".pi"), { recursive: true });
+	await mkdir(join(xdgDir, "pi"), { recursive: true });
+	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify({ perplexityApiKey: "pplx-from-legacy" }) + "\n", "utf8");
+
+	const child = runChild(`
+		import { writeFile } from "node:fs/promises";
+		const { getWebSearchConfigDir, getWebSearchConfigPath } = await import(${JSON.stringify(utilsUrl)});
+		const before = { dir: getWebSearchConfigDir(), path: getWebSearchConfigPath() };
+		await writeFile(${JSON.stringify(xdgConfigPath)}, JSON.stringify({ geminiApiKey: "gemini-created-later" }) + "\\n", "utf8");
+		const after = { dir: getWebSearchConfigDir(), path: getWebSearchConfigPath() };
+		console.log(JSON.stringify({ before, after }));
+	`, {
+		PI_CODING_AGENT_DIR: undefined,
+		XDG_CONFIG_HOME: xdgDir,
+		HOME: home,
+		USERPROFILE: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout), {
+		before: {
+			dir: join(home, ".pi"),
+			path: join(home, ".pi", "web-search.json"),
+		},
+		after: {
+			dir: join(home, ".pi"),
+			path: join(home, ".pi", "web-search.json"),
+		},
+	});
+});
+
+test("web-search config path keeps XDG_CONFIG_HOME as the new-config target when both files are absent", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-xdg-new-config-"));
+	const home = join(root, "home");
+	const xdgDir = join(root, "xdg");
+	await mkdir(join(xdgDir, "pi"), { recursive: true });
+
+	const child = runChild(`
+		const { getWebSearchConfigDir, getWebSearchConfigPath } = await import(${JSON.stringify(utilsUrl)});
+		console.log(JSON.stringify({
+			dir: getWebSearchConfigDir(),
+			path: getWebSearchConfigPath(),
+		}));
+	`, {
+		PI_CODING_AGENT_DIR: undefined,
+		XDG_CONFIG_HOME: xdgDir,
+		HOME: home,
+		USERPROFILE: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout), {
+		dir: join(xdgDir, "pi"),
+		path: join(xdgDir, "pi", "web-search.json"),
 	});
 });
 

--- a/test/fetch-cache-storage.test.mjs
+++ b/test/fetch-cache-storage.test.mjs
@@ -3,14 +3,24 @@ import { chmodSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, syml
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { afterEach, test } from "node:test";
-
-import initializeExtension from "../index.ts";
-import { clearResults, deleteResult, getFetchCacheDir, getResult, pruneExpiredFetchCache, restoreFromSession, storeFetchedContentResult } from "../storage.ts";
+import { after, afterEach, test } from "node:test";
 
 const originalFetch = globalThis.fetch;
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 const originalDateNow = Date.now;
+const testAgentDir = await mkdtemp(join(tmpdir(), "pi-web-access-fetch-cache-"));
+process.env.PI_CODING_AGENT_DIR = testAgentDir;
+
+const { default: initializeExtension } = await import("../index.ts");
+const {
+	clearResults,
+	deleteResult,
+	getFetchCacheDir,
+	getResult,
+	pruneExpiredFetchCache,
+	restoreFromSession,
+	storeFetchedContentResult,
+} = await import("../storage.ts");
 
 afterEach(() => {
 	globalThis.fetch = originalFetch;
@@ -20,10 +30,16 @@ afterEach(() => {
 	clearResults();
 });
 
+after(() => {
+	if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+	rmSync(testAgentDir, { recursive: true, force: true });
+});
+
 async function useTempAgentDir() {
-	const dir = await mkdtemp(join(tmpdir(), "pi-web-access-fetch-cache-"));
-	process.env.PI_CODING_AGENT_DIR = dir;
-	return dir;
+	process.env.PI_CODING_AGENT_DIR = testAgentDir;
+	rmSync(join(testAgentDir, "web-search-cache"), { recursive: true, force: true });
+	return testAgentDir;
 }
 
 function registerTools() {
@@ -154,7 +170,6 @@ test("missing cache files return an actionable fetched-content error", async () 
 	const missing = await getContentTool.execute("call", { responseId: result.details.responseId, urlIndex: 0 });
 	assert.equal(missing.details.error, "Cached fetched content is missing or expired");
 	assert.match(missing.content[0].text, /Cached fetched content is missing or expired/);
-	rmSync(agentDir, { recursive: true, force: true });
 });
 
 test("cache pruning evicts the oldest entries by count and bytes", async () => {

--- a/test/proxy-transport.test.mjs
+++ b/test/proxy-transport.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,9 +10,22 @@ import { getActiveProxy, installGlobalProxyFetch, runWithProxy } from "../utils.
 
 const originalFetch = globalThis.fetch;
 const originalPath = process.env.PATH;
-const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 const originalNoProxy = process.env.NO_PROXY;
 const originalNoProxyLower = process.env.no_proxy;
+const utilsUrl = new URL("../utils.ts", import.meta.url).href;
+
+function runConfigProbe(dir, script) {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { getActiveProxy, runWithProxy } = await import(${JSON.stringify(utilsUrl)});
+			${script}
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PI_CODING_AGENT_DIR: dir },
+	});
+	assert.equal(child.status, 0, child.stderr);
+	return JSON.parse(child.stdout);
+}
 
 async function withFakeCurl(t, routes, fn) {
 	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-test-"));
@@ -130,29 +144,39 @@ test("proxy curl redirects strip caller headers across origins", async (t) => {
 test("omitted proxy uses global config while empty string forces direct access", async (t) => {
 	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-config-test-"));
 	await writeFile(join(dir, "web-search.json"), JSON.stringify({ proxy: "http://global-proxy.example:8080" }));
-	process.env.PI_CODING_AGENT_DIR = dir;
 	t.after(async () => {
-		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
 		await rm(dir, { recursive: true, force: true });
 	});
 
-	assert.equal(runWithProxy(undefined, () => getActiveProxy()), "http://global-proxy.example:8080/");
-	assert.equal(runWithProxy("", () => getActiveProxy()), null);
-	assert.equal(runWithProxy("http://call-proxy.example:8080", () => getActiveProxy()), "http://call-proxy.example:8080/");
+	assert.deepEqual(runConfigProbe(dir, `
+		console.log(JSON.stringify([
+			runWithProxy(undefined, () => getActiveProxy()),
+			runWithProxy("", () => getActiveProxy()),
+			runWithProxy("http://call-proxy.example:8080", () => getActiveProxy()),
+		]));
+	`), [
+		"http://global-proxy.example:8080/",
+		null,
+		"http://call-proxy.example:8080/",
+	]);
 });
 
 test("invalid configured proxy fails closed instead of direct fetching", async (t) => {
 	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-invalid-config-test-"));
 	await writeFile(join(dir, "web-search.json"), JSON.stringify({ proxy: "socks5://proxy.example:1080" }));
-	process.env.PI_CODING_AGENT_DIR = dir;
 	t.after(async () => {
-		if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
-		else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
 		await rm(dir, { recursive: true, force: true });
 	});
 
-	assert.throws(() => getActiveProxy(), /proxy.*must use the http:\/\/ or https:\/\/ scheme/);
+	assert.match(runConfigProbe(dir, `
+		let message = "";
+		try {
+			getActiveProxy();
+		} catch (error) {
+			message = error.message;
+		}
+		console.log(JSON.stringify(message));
+	`), /proxy.*must use the http:\/\/ or https:\/\/ scheme/);
 });
 
 test("proxy transport does not spawn curl for pre-aborted requests", async (t) => {

--- a/utils.ts
+++ b/utils.ts
@@ -5,10 +5,24 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir, hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 
+let cachedWebSearchConfigDir: string | undefined;
+
 export function getWebSearchConfigDir(): string {
-	if (process.env.PI_CODING_AGENT_DIR) return process.env.PI_CODING_AGENT_DIR;
-	if (process.env.XDG_CONFIG_HOME) return join(process.env.XDG_CONFIG_HOME, "pi");
-	return join(homedir(), ".pi");
+	if (cachedWebSearchConfigDir) return cachedWebSearchConfigDir;
+
+	const explicitDir = process.env.PI_CODING_AGENT_DIR;
+	if (explicitDir) return cachedWebSearchConfigDir = explicitDir;
+
+	const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+	if (xdgConfigHome) {
+		const xdgDir = join(xdgConfigHome, "pi");
+		if (existsSync(join(xdgDir, "web-search.json"))) return cachedWebSearchConfigDir = xdgDir;
+
+		const legacyDir = join(homedir(), ".pi");
+		if (existsSync(join(legacyDir, "web-search.json"))) return cachedWebSearchConfigDir = legacyDir;
+		return cachedWebSearchConfigDir = xdgDir;
+	}
+	return cachedWebSearchConfigDir = join(homedir(), ".pi");
 }
 
 export function getWebSearchConfigPath(): string {


### PR DESCRIPTION
Closes #333.

## Summary
- keep `PI_CODING_AGENT_DIR` as the explicit highest-priority config root
- when `XDG_CONFIG_HOME` is set, use an existing XDG config first, then an existing legacy `~/.pi/web-search.json`, otherwise keep XDG as the new-config target
- document the migration behavior and credit the reporter

## Validation
- `node --test test/config-path.test.mjs`
- `npm run typecheck`
- `npm test`
- `git diff --check origin/main...HEAD`

Thanks to [@hu3rror](https://github.com/hu3rror) for issue #333.
