### PR TITLE
docs: add xdg-utils as system dependency for curator browser launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ brew install yt-dlp   # YouTube stream URLs for frame extraction
 
 Without these, video content analysis (transcripts, visual descriptions via Gemini) still works. The binaries are only needed for extracting individual frames as images.
 
+System dependencies for curator browser launch:
+
+| Package | Purpose | Install |
+|---------|---------|---------|
+| `xdg-utils` | Opens the curator UI in your default browser | Debian/Ubuntu: `sudo apt install -y xdg-utils` · Fedora/RHEL: `sudo dnf install -y xdg-utils` · Arch: `sudo pacman -S xdg-utils` |
+
+Without `xdg-utils`, the curator URL is printed to the tool output so you can copy it into a browser. On WSL, `xdg-open` auto-detects the environment and delegates to `explorer.exe` under the hood.
+
 Requires Pi v0.37.3+.
 
 ## Quick Start


### PR DESCRIPTION
## Problem

When `web_search` uses the default `summary-review` workflow, the curator UI tries to open in the default browser via `spawn('xdg-open', [url])`. On Linux/WSL without `xdg-utils` installed, this fails with:

```
Failed to open curator UI: spawn xdg-open ENOENT
Search curator is running, but the browser did not open automatically.
```

The tool output shows the curator URL, so users can manually copy-paste it, but a missing system dependency silently breaks the auto-open behavior.

## Reproduction

```bash
# Without xdg-utils (exit code 1):
node -e "const {spawn}=require('child_process');const c=spawn('xdg-open',['http://localhost:9999'],{stdio:'ignore'});c.once('error',e=>console.error('ERROR:',e.message));"

# With xdg-utils installed (exit code 0):
sudo apt install -y xdg-utils
node -e "const {spawn}=require('child_process');const c=spawn('xdg-open',['http://localhost:9999'],{stdio:'ignore'});c.once('error',e=>console.error('ERROR:',e.message));c.once('exit',c=>console.log('exit:',c));"
```

## Changes

Adds a **System dependencies** section to the README after the existing "Optional dependencies for video frame extraction" block:

```markdown
System dependencies for curator browser launch:

| Package | Purpose | Install |
|---------|---------|---------|
| `xdg-utils` | Opens the curator UI in your default browser | Debian/Ubuntu: `sudo apt install -y xdg-utils` · Fedora/RHEL: `sudo dnf install -y xdg-utils` · Arch: `sudo pacman -S xdg-utils` |

Without `xdg-utils`, the curator URL is printed to the tool output so you can copy it into a browser. On WSL, `xdg-open` auto-detects the environment and delegates to `explorer.exe` under the hood.
```

This mirrors the existing optional dependencies section (ffmpeg/yt-dlp) and documents the implicit system requirement.

## Related

Closes #336
