### PR TITLE
docs: document Linux curator browser dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Documented the Linux `xdg-utils` dependency for automatic curator browser launch and the manual URL fallback. Thanks to [@wickedTangent](https://github.com/wickedTangent) for issue #336 and PR #337.
+
 ### Fixed
 
 - Cleaned stale GitHub clone runtime directories after a crashed process when the owner can be proven dead, while preserving runtimes with unknown or live owners. Thanks to [@yazanabuashour](https://github.com/yazanabuashour) for issue #331.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ brew install yt-dlp   # YouTube stream URLs for frame extraction
 
 Without these, video content analysis (transcripts, visual descriptions via Gemini) still works. The binaries are only needed for extracting individual frames as images.
 
+System dependency for curator browser launch on Linux:
+
+| Package | Purpose | Install |
+|---------|---------|---------|
+| `xdg-utils` | Opens the curator UI in your default browser | Debian/Ubuntu: `sudo apt install -y xdg-utils` · Fedora/RHEL: `sudo dnf install -y xdg-utils` · Arch: `sudo pacman -S xdg-utils` |
+
+Without `xdg-utils`, the curator URL is printed to the tool output so you can copy it into a browser.
+
 Requires Pi v0.37.3+.
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- documents `xdg-utils` as the Linux system dependency for automatic curator browser launch
- documents the existing manual curator URL fallback when auto-open is unavailable
- credits [@wickedTangent](https://github.com/wickedTangent) for issue #336 and PR #337

Closes #336.
Supersedes #337.

## Validation
- `git diff --check`
- `git diff --check origin/main...HEAD`
- fresh read-only review: No issues found
