### PR TITLE
fix: scope configured proxy to web operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Scoped configured proxy transport to web-tool operations so unrelated Pi requests retain their existing transport. Thanks to [@alexei-ciobanu](https://github.com/alexei-ciobanu).
 - Cleaned stale GitHub clone runtime directories after a crashed process when the owner can be proven dead, while preserving runtimes with unknown or live owners. Thanks to [@yazanabuashour](https://github.com/yazanabuashour) for issue #331.
 - Kept an existing legacy `~/.pi/web-search.json` in use when `XDG_CONFIG_HOME` is set but its XDG config file is absent. Thanks to [@hu3rror](https://github.com/hu3rror) for issue #333.
 

--- a/index.ts
+++ b/index.ts
@@ -1069,7 +1069,8 @@ export default function (pi: ExtensionAPI) {
 		const fetchId = generateId();
 		const controller = new AbortController();
 		pendingFetches.set(fetchId, controller);
-		runWithProxy(proxy, () => fetchAllContent(urls, controller.signal, withRegisteredFetchOptions(undefined, registeredToolNames, proxy)))
+		Promise.resolve()
+			.then(() => runWithProxy(proxy, () => fetchAllContent(urls, controller.signal, withRegisteredFetchOptions(undefined, registeredToolNames, proxy))))
 			.then((fetched) => {
 				if (!sessionActive || !pendingFetches.has(fetchId)) return;
 				const data = {

--- a/test/proxy-transport.test.mjs
+++ b/test/proxy-transport.test.mjs
@@ -13,11 +13,14 @@ const originalPath = process.env.PATH;
 const originalNoProxy = process.env.NO_PROXY;
 const originalNoProxyLower = process.env.no_proxy;
 const utilsUrl = new URL("../utils.ts", import.meta.url).href;
+const ssrfProtectionUrl = new URL("../ssrf-protection.ts", import.meta.url).href;
+const indexUrl = new URL("../index.ts", import.meta.url).href;
 
 function runConfigProbe(dir, script) {
 	const child = spawnSync(process.execPath, ["--input-type=module"], {
 		input: `
-			const { getActiveProxy, runWithProxy } = await import(${JSON.stringify(utilsUrl)});
+			const { getActiveProxy, hasScopedProxyDecision, runWithProxy } = await import(${JSON.stringify(utilsUrl)});
+			const { validateRemoteUrl } = await import(${JSON.stringify(ssrfProtectionUrl)});
 			${script}
 		`,
 		encoding: "utf8",
@@ -165,6 +168,29 @@ test("configured proxy is scoped to web operations while empty string forces dir
 	]);
 });
 
+test("omitted proxy preserves trusted environment proxy routing when no proxy is configured", async (t) => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-env-trust-test-"));
+	t.after(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	assert.deepEqual(runConfigProbe(dir, `
+		for (const key of ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy"]) {
+			delete process.env[key];
+		}
+		process.env.HTTPS_PROXY = "http://env-proxy.example:8080";
+		let lookups = 0;
+		await runWithProxy(undefined, () => validateRemoteUrl("https://public.example.test/", {
+			trustEnvProxy: true,
+			lookup: async () => {
+				lookups++;
+				return [{ address: "10.0.0.10", family: 4 }];
+			},
+		}));
+		console.log(JSON.stringify({ lookups, scoped: hasScopedProxyDecision() }));
+	`), { lookups: 0, scoped: false });
+});
+
 test("invalid configured proxy fails closed instead of direct fetching", async (t) => {
 	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-invalid-config-test-"));
 	await writeFile(join(dir, "web-search.json"), JSON.stringify({ proxy: "socks5://proxy.example:1080" }));
@@ -181,6 +207,66 @@ test("invalid configured proxy fails closed instead of direct fetching", async (
 		}
 		console.log(JSON.stringify(message));
 	`), /proxy.*must use the http:\/\/ or https:\/\/ scheme/);
+});
+
+test("invalid configured proxy reaches background fetch rejection handling", async (t) => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-background-config-test-"));
+	const configPath = join(dir, "web-search.json");
+	await writeFile(configPath, JSON.stringify({ provider: "openai" }));
+	t.after(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { writeFileSync } = await import("node:fs");
+			const configPath = ${JSON.stringify(configPath)};
+			const messages = [];
+			globalThis.fetch = async (url) => {
+				if (String(url) !== "https://api.openai.com/v1/responses") {
+					throw new Error("Unexpected fetch: " + url);
+				}
+				writeFileSync(configPath, JSON.stringify({ provider: "openai", proxy: "socks5://proxy.example:1080" }));
+				return new Response(JSON.stringify({ output: [
+					{ type: "web_search_call", action: { sources: [{ title: "Source", url: "https://example.com/source" }] } },
+					{ type: "message", content: [{ type: "output_text", text: "Search answer" }] },
+				] }), { status: 200, headers: { "content-type": "application/json" } });
+			};
+			const tools = [];
+			const handlers = new Map();
+			const pi = {
+				registerTool(tool) { tools.push(tool); },
+				registerCommand() {},
+				registerShortcut() {},
+				on(event, handler) { handlers.set(event, handler); },
+				appendEntry() {},
+				sendMessage(message) { messages.push(message); },
+			};
+			const initializeExtension = (await import(${JSON.stringify(indexUrl)})).default;
+			initializeExtension(pi);
+			await handlers.get("session_start")({}, { sessionManager: { getBranch: () => [] } });
+			const tool = tools.find((candidate) => candidate.name === "web_search");
+			const result = await tool.execute("background-proxy-test", {
+				query: "proxy cleanup",
+				provider: "openai",
+				workflow: "none",
+				includeContent: true,
+			});
+			await new Promise((resolve) => setImmediate(resolve));
+			console.log(JSON.stringify({
+				result: result.content[0].text,
+				errors: messages.filter((message) => message.customType === "web-search-error").map((message) => message.content),
+			}));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PI_CODING_AGENT_DIR: dir, OPENAI_API_KEY: "proxy-background-test-key" },
+		maxBuffer: 2 * 1024 * 1024,
+	});
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.match(output.result, /Content fetching in background/);
+	assert.equal(output.errors.length, 1, JSON.stringify(output));
+	assert.match(output.errors[0], /proxy.*must use the http:\/\/ or https:\/\/ scheme/);
 });
 
 test("proxy transport does not spawn curl for pre-aborted requests", async (t) => {

--- a/test/proxy-transport.test.mjs
+++ b/test/proxy-transport.test.mjs
@@ -141,7 +141,7 @@ test("proxy curl redirects strip caller headers across origins", async (t) => {
 	});
 });
 
-test("omitted proxy uses global config while empty string forces direct access", async (t) => {
+test("configured proxy is scoped to web operations while empty string forces direct access", async (t) => {
 	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-config-test-"));
 	await writeFile(join(dir, "web-search.json"), JSON.stringify({ proxy: "http://global-proxy.example:8080" }));
 	t.after(async () => {
@@ -150,14 +150,18 @@ test("omitted proxy uses global config while empty string forces direct access",
 
 	assert.deepEqual(runConfigProbe(dir, `
 		console.log(JSON.stringify([
+			getActiveProxy(),
 			runWithProxy(undefined, () => getActiveProxy()),
 			runWithProxy("", () => getActiveProxy()),
 			runWithProxy("http://call-proxy.example:8080", () => getActiveProxy()),
+			getActiveProxy(),
 		]));
 	`), [
+		null,
 		"http://global-proxy.example:8080/",
 		null,
 		"http://call-proxy.example:8080/",
+		null,
 	]);
 });
 
@@ -171,7 +175,7 @@ test("invalid configured proxy fails closed instead of direct fetching", async (
 	assert.match(runConfigProbe(dir, `
 		let message = "";
 		try {
-			getActiveProxy();
+			runWithProxy(undefined, () => getActiveProxy());
 		} catch (error) {
 			message = error.message;
 		}

--- a/utils.ts
+++ b/utils.ts
@@ -251,14 +251,14 @@ function loadConfiguredProxy(): string | null {
 }
 
 export function runWithProxy<T>(proxy: string | undefined, fn: () => T): T {
-	if (proxy === undefined) return fn();
-	const normalized = normalizeProxyUrl(proxy, "proxy");
+	const normalized = proxy === undefined
+		? loadConfiguredProxy()
+		: normalizeProxyUrl(proxy, "proxy");
 	return proxyStorage.run(normalized, fn);
 }
 
 export function getActiveProxy(): string | null {
-	const scoped = proxyStorage.getStore();
-	return scoped !== undefined ? scoped : loadConfiguredProxy();
+	return proxyStorage.getStore() ?? null;
 }
 
 export function hasScopedProxyDecision(): boolean {

--- a/utils.ts
+++ b/utils.ts
@@ -251,9 +251,12 @@ function loadConfiguredProxy(): string | null {
 }
 
 export function runWithProxy<T>(proxy: string | undefined, fn: () => T): T {
-	const normalized = proxy === undefined
-		? loadConfiguredProxy()
-		: normalizeProxyUrl(proxy, "proxy");
+	if (proxy === undefined) {
+		const configured = loadConfiguredProxy();
+		if (configured === null) return fn();
+		return proxyStorage.run(configured, fn);
+	}
+	const normalized = normalizeProxyUrl(proxy, "proxy");
 	return proxyStorage.run(normalized, fn);
 }
 


### PR DESCRIPTION
## Summary

- resolve the config-level proxy when entering a web operation's async context
- keep the global fetch wrapper in pass-through mode outside web operations
- preserve explicit per-call proxies and the empty-string direct override
- add regression coverage for proxy scope entry and cleanup

## Problem

`installGlobalProxyFetch()` wraps `globalThis.fetch` so web-access requests can use the curl-backed proxy transport. Previously, `getActiveProxy()` fell back to the config-level proxy whenever no AsyncLocalStorage scope existed.

That allowed unrelated Pi components using global fetch, including model providers, to inherit the web-tools proxy.

This change moves config fallback resolution into `runWithProxy()`. The configured proxy therefore remains active for web operations and their async work, while fetch calls outside those operations retain their existing transport.

## Validation

- `node --test test/proxy-transport.test.mjs test/ssrf-protection.test.mjs` — 36/36 passed
- `npm run typecheck`
- manual integration:
  - configured web operation used the proxy
  - unscoped fetch retained its normal transport
  - unrelated model-provider requests retained their normal transport
- `npm test` on Linux — 642/643 passed; the remaining Chrome cookie password lookup test fails identically on an unchanged upstream checkout
- `git diff --check upstream/main...HEAD`