### PR TITLE
fix(perplexity): keep the citations the answer references

### DIFF
--- a/perplexity.ts
+++ b/perplexity.ts
@@ -105,6 +105,27 @@ export function isPerplexityAvailable(): boolean {
 	});
 }
 
+/** Hard ceiling on kept citations, matching the `numResults` clamp. */
+const MAX_CITATIONS = 20;
+
+/**
+ * How many citations to keep.
+ *
+ * Perplexity's citations are the answer's footnotes, not a result list: sonar
+ * numbers its `[n]` markers against the full array, so cutting the array to
+ * `numResults` leaves the prose referencing sources that were dropped. Keep
+ * every citation the answer actually cites, and let `numResults` govern only
+ * the unreferenced remainder.
+ */
+function citationsToKeep(answer: string, available: number, numResults: number): number {
+	let highestCited = 0;
+	for (const match of answer.matchAll(/\[(\d{1,3})\]/g)) {
+		const index = Number(match[1]);
+		if (Number.isFinite(index) && index > highestCited) highestCited = index;
+	}
+	return Math.min(available, MAX_CITATIONS, Math.max(numResults, highestCited));
+}
+
 export async function searchWithPerplexity(query: string, options: SearchOptions = {}): Promise<SearchResponse> {
 	checkRateLimit();
 
@@ -184,7 +205,8 @@ export async function searchWithPerplexity(query: string, options: SearchOptions
 	const citations = Array.isArray(data.citations) ? data.citations : [];
 
 	const results: SearchResult[] = [];
-	for (let i = 0; i < Math.min(citations.length, numResults); i++) {
+	const citationCount = citationsToKeep(answer, citations.length, numResults);
+	for (let i = 0; i < citationCount; i++) {
 		const citation = citations[i];
 		if (typeof citation === "string") {
 			results.push({ title: `Source ${i + 1}`, url: citation, snippet: "" });


### PR DESCRIPTION
Fixes #340.

Perplexity's citations aren't a result list — they're the footnotes for the synthesis. `sonar` numbers its `[n]` markers against the full citations array, so cutting that array to `numResults` leaves the prose pointing at sources that were dropped. `numResults` means "how many results" for the link-list providers; here it's trimming the answer's own bibliography.

This keeps every citation the answer actually references, capped at 20 (matching the existing `numResults` clamp), and lets `numResults` govern only the unreferenced remainder. So a default call still returns 5 unless the answer cites more.

I think this is the right direction, but it's a judgement call on principle that's yours to make — the alternative reading is that `numResults` should cap Perplexity too and the answer text should be renumbered to match. Happy to switch to that, or add a test, if you'd rather go the other way.

Typecheck and `npm test` show no new failures (3 pre-existing `tsc` errors in `content-find.ts` / `openai-search.ts`, and one pre-existing `chrome-cookie-extraction` failure, all present on `main` without this change).