### PR TITLE
fix: scope config-level proxy to extension-initiated requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ Raw and direct-image HTTP requests use the same SSRF validation, hostname domain
 
 An empty string (`""`) forces a direct connection even when a config-level proxy is set. Omitting the parameter falls back to the global `proxy` in `~/.pi/web-search.json`.
 
+The config-level `proxy` applies only to requests made by this extension's tools. Other traffic in the host process — such as the coding agent's own model API calls — is never routed through it, so a configured proxy that is temporarily down cannot break unrelated requests.
+
 ```jsonc
 // ~/.pi/web-search.json — global proxy for all tools
 {

--- a/test/proxy-transport.test.mjs
+++ b/test/proxy-transport.test.mjs
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 import initializeExtension from "../index.ts";
-import { getActiveProxy, installGlobalProxyFetch, runWithProxy } from "../utils.ts";
+import { getActiveProxy, installGlobalProxyFetch, runInExtensionScope, runWithProxy } from "../utils.ts";
 
 const originalFetch = globalThis.fetch;
 const originalPath = process.env.PATH;
@@ -17,7 +17,7 @@ const utilsUrl = new URL("../utils.ts", import.meta.url).href;
 function runConfigProbe(dir, script) {
 	const child = spawnSync(process.execPath, ["--input-type=module"], {
 		input: `
-			const { getActiveProxy, runWithProxy } = await import(${JSON.stringify(utilsUrl)});
+			const { getActiveProxy, runInExtensionScope, runWithProxy } = await import(${JSON.stringify(utilsUrl)});
 			${script}
 		`,
 		encoding: "utf8",
@@ -171,7 +171,7 @@ test("invalid configured proxy fails closed instead of direct fetching", async (
 	assert.match(runConfigProbe(dir, `
 		let message = "";
 		try {
-			getActiveProxy();
+			runWithProxy(undefined, () => getActiveProxy());
 		} catch (error) {
 			message = error.message;
 		}
@@ -292,4 +292,75 @@ test("fetch_content passes the explicit proxy through queued extraction", async 
 		assert.ok(pageCall);
 		assert.ok(["http://call-proxy.example:8080", "http://call-proxy.example:8080/"].includes(proxyArg(pageCall)));
 	});
+});
+
+test("getActiveProxy ignores config-level proxy outside extension scope", async (t) => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-scope-probe-test-"));
+	await writeFile(join(dir, "web-search.json"), JSON.stringify({ proxy: "http://global-proxy.example:8080" }));
+	t.after(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	assert.deepEqual(runConfigProbe(dir, `
+		console.log(JSON.stringify([
+			getActiveProxy(),
+			runInExtensionScope(() => getActiveProxy()),
+			runWithProxy(undefined, () => getActiveProxy()),
+			runWithProxy("", () => getActiveProxy()),
+		]));
+	`), [
+		null,
+		"http://global-proxy.example:8080/",
+		"http://global-proxy.example:8080/",
+		null,
+	]);
+});
+
+test("config-level proxy does not hijack fetches made outside the extension", async (t) => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-scope-config-test-"));
+	// Port 1 refuses connections instantly, so a proxied attempt fails fast.
+	await writeFile(join(dir, "web-search.json"), JSON.stringify({ proxy: "http://127.0.0.1:1" }));
+	t.after(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// Runs in a child process: PI_CODING_AGENT_DIR must be set before the
+	// extension modules are imported (getWebSearchConfigDir caches its result).
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { installGlobalProxyFetch, runWithProxy } = await import(${JSON.stringify(utilsUrl)});
+			installGlobalProxyFetch();
+			const nativeCalls = [];
+			globalThis.fetch = async (input) => {
+				nativeCalls.push(String(input?.url ?? input));
+				return new Response("direct");
+			};
+			installGlobalProxyFetch();
+			const results = {};
+			const direct = await fetch("https://origin.example/proxied");
+			results.directBody = await direct.text();
+			results.nativeCallsAfterDirect = nativeCalls.length;
+			let proxiedError = null;
+			try {
+				await runWithProxy(undefined, () => fetch("https://origin.example/proxied"));
+			} catch (error) {
+				proxiedError = error.message;
+			}
+			results.proxiedError = proxiedError;
+			results.nativeCallsAfterProxied = nativeCalls.length;
+			console.log(JSON.stringify(results));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PI_CODING_AGENT_DIR: dir, NO_PROXY: "", no_proxy: "" },
+	});
+	assert.equal(child.status, 0, child.stderr);
+
+	// Outside extension scope: the wrapper delegates to the native fetch.
+	// Inside extension scope: the config-level proxy routes through curl (the
+	// refused port makes the attempt fail fast, proving the proxy path ran).
+	const results = JSON.parse(child.stdout);
+	assert.equal(results.directBody, "direct");
+	assert.equal(results.nativeCallsAfterDirect, 1);
+	assert.ok(results.proxiedError, "proxied attempt should fail against the refused port");
+	assert.equal(results.nativeCallsAfterProxied, 1);
 });

--- a/utils.ts
+++ b/utils.ts
@@ -205,6 +205,7 @@ export function mapFfmpegError(err: unknown): string {
 }
 
 const proxyStorage = new AsyncLocalStorage<string | null>();
+const extensionScope = new AsyncLocalStorage<true>();
 
 export function normalizeProxyUrl(value: unknown, source: string): string | null {
 	if (value === undefined || value === null) return null;
@@ -250,15 +251,30 @@ function loadConfiguredProxy(): string | null {
 	return normalizeProxyUrl(configured, `proxy in ${getWebSearchConfigPath()}`);
 }
 
+/**
+ * Marks async work initiated by this extension.
+ *
+ * installGlobalProxyFetch() wraps the host process's global fetch, so the
+ * config-level `proxy` fallback must never apply to unscoped callers —
+ * otherwise unrelated traffic in the host process (e.g. the coding agent's
+ * own LLM API calls) would be routed through the configured proxy.
+ */
+export function runInExtensionScope<T>(fn: () => T): T {
+	if (extensionScope.getStore()) return fn();
+	return extensionScope.run(true, fn);
+}
+
 export function runWithProxy<T>(proxy: string | undefined, fn: () => T): T {
-	if (proxy === undefined) return fn();
+	if (proxy === undefined) return runInExtensionScope(fn);
 	const normalized = normalizeProxyUrl(proxy, "proxy");
-	return proxyStorage.run(normalized, fn);
+	return runInExtensionScope(() => proxyStorage.run(normalized, fn));
 }
 
 export function getActiveProxy(): string | null {
 	const scoped = proxyStorage.getStore();
-	return scoped !== undefined ? scoped : loadConfiguredProxy();
+	if (scoped !== undefined) return scoped;
+	if (!extensionScope.getStore()) return null;
+	return loadConfiguredProxy();
 }
 
 export function hasScopedProxyDecision(): boolean {


### PR DESCRIPTION
## Problem

`installGlobalProxyFetch()` wraps `globalThis.fetch` process-wide so tool requests can go through the curl transport. But when a request comes from outside any `runWithProxy` scope, `getActiveProxy()` falls back to the config-level `proxy` from `~/.pi/web-search.json`.

Since the wrapper is global, that fallback also captures fetches made by the **host process itself** — e.g. the coding agent's own LLM API calls. With `"proxy": "http://127.0.0.1:4444"` configured, every model request was routed through `curl -x http://127.0.0.1:4444`. When the proxy client is stopped, all of those requests fail with connection errors — even endpoints that are directly reachable and never needed the proxy.

## Fix

Mark extension-initiated async work with an `AsyncLocalStorage` scope:

- `runWithProxy(undefined, fn)` (the "fall back to config-level proxy" path) also marks the context as extension-initiated.
- `getActiveProxy()` returns the config-level `proxy` only inside that scope. Everywhere else it returns `null`, so the global wrapper becomes a transparent pass-through for unrelated callers.

Per-call semantics are unchanged: explicit proxy URL → that proxy; `""` → direct; omitted → config-level proxy, but only for requests made by this extension's own tools.

## Tests

- outside the extension scope, `getActiveProxy()` ignores the config-level proxy; inside it, the proxy applies
- with a config-level proxy set, an unscoped `fetch` delegates to the native fetch (no curl spawn), while a scoped one goes through the curl transport

Also documented in the README that the config-level proxy only applies to this extension's requests.
