### PR TITLE
fix: preserve cited Perplexity sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Retained citations referenced in Perplexity answers even when they fall beyond `numResults`, while preserving the result-count limit for answers without citation markers. Thanks to [@schlessera](https://github.com/schlessera) for issue #340 and PR #341.
 - Cleaned stale GitHub clone runtime directories after a crashed process when the owner can be proven dead, while preserving runtimes with unknown or live owners. Thanks to [@yazanabuashour](https://github.com/yazanabuashour) for issue #331.
 - Kept an existing legacy `~/.pi/web-search.json` in use when `XDG_CONFIG_HOME` is set but its XDG config file is absent. Thanks to [@hu3rror](https://github.com/hu3rror) for issue #333.
 

--- a/perplexity.ts
+++ b/perplexity.ts
@@ -105,6 +105,27 @@ export function isPerplexityAvailable(): boolean {
 	});
 }
 
+/** Hard ceiling on kept citations, matching the `numResults` clamp. */
+const MAX_CITATIONS = 20;
+
+/**
+ * How many citations to keep.
+ *
+ * Perplexity's citations are the answer's footnotes, not a result list: sonar
+ * numbers its `[n]` markers against the full array, so cutting the array to
+ * `numResults` leaves the prose referencing sources that were dropped. Keep
+ * every citation the answer actually cites, and let `numResults` govern only
+ * the unreferenced remainder.
+ */
+function citationsToKeep(answer: string, available: number, numResults: number): number {
+	let highestCited = 0;
+	for (const match of answer.matchAll(/\[(\d{1,3})\]/g)) {
+		const index = Number(match[1]);
+		if (Number.isFinite(index) && index > highestCited) highestCited = index;
+	}
+	return Math.min(available, MAX_CITATIONS, Math.max(numResults, highestCited));
+}
+
 export async function searchWithPerplexity(query: string, options: SearchOptions = {}): Promise<SearchResponse> {
 	checkRateLimit();
 
@@ -184,7 +205,8 @@ export async function searchWithPerplexity(query: string, options: SearchOptions
 	const citations = Array.isArray(data.citations) ? data.citations : [];
 
 	const results: SearchResult[] = [];
-	for (let i = 0; i < Math.min(citations.length, numResults); i++) {
+	const citationCount = citationsToKeep(answer, citations.length, numResults);
+	for (let i = 0; i < citationCount; i++) {
 		const citation = citations[i];
 		if (typeof citation === "string") {
 			results.push({ title: `Source ${i + 1}`, url: citation, snippet: "" });

--- a/test/search-providers.test.mjs
+++ b/test/search-providers.test.mjs
@@ -116,6 +116,39 @@ test("Perplexity normalizes invalid result counts", async () => {
 	assert.deepEqual(JSON.parse(child.stdout.trim()).counts, [1, 5, 3]);
 });
 
+test("Perplexity retains cited sources beyond numResults", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-perplexity-citations-"));
+	const child = runChild(`
+		globalThis.fetch = async (_url, init) => {
+			const query = JSON.parse(init.body).messages[0].content;
+			const answer = query === "cited" ? "The answer cites [13]." : "The answer has no citations.";
+			return new Response(JSON.stringify({
+				choices: [{ message: { content: answer } }],
+				citations: Array.from({ length: 13 }, (_, index) => "https://example.com/source-" + (index + 1)),
+			}), { status: 200, headers: { "content-type": "application/json" } });
+		};
+
+		const { searchWithPerplexity } = await import(${JSON.stringify(perplexityModuleUrl)});
+		const cited = await searchWithPerplexity("cited", { numResults: 8 });
+		const uncited = await searchWithPerplexity("uncited", { numResults: 8 });
+		console.log(JSON.stringify({ cited: cited.results, uncitedCount: uncited.results.length }));
+	`, {
+		HOME: home,
+		USERPROFILE: home,
+		PERPLEXITY_API_KEY: "pplx-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.cited.length, 13);
+	assert.deepEqual(output.cited[12], {
+		title: "Source 13",
+		url: "https://example.com/source-13",
+		snippet: "",
+	});
+	assert.equal(output.uncitedCount, 8);
+});
+
 test("Tavily search uses bearer auth and maps filters/content", async () => {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-tavily-"));
 	const child = runChild(`


### PR DESCRIPTION
Owner replacement for #341, preserving @schlessera's fix and adding the required regression and changelog credit.

Changes:
- Keep Perplexity citations that the answer actually references, up to the existing 20-result ceiling.
- Preserve `numResults` behavior for answers without citation markers.
- Add a mocked Perplexity regression for `[13]` with `numResults: 8`.
- Credit [@schlessera](https://github.com/schlessera) for issue #340 and PR #341 in the changelog.

Validation:
- `node --test test/search-providers.test.mjs` — 29/29 passed.
- `npm run typecheck` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh exact-head review found no issues.

Closes #340.
Supersedes #341 after merge.
