### PR TITLE
fix: scope configured proxy to extension traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Retained citations referenced in Perplexity answers even when they fall beyond `numResults`, while preserving the result-count limit for answers without citation markers. Thanks to [@schlessera](https://github.com/schlessera) for issue #340 and PR #341.
+- Scoped configured proxy transport to web-tool operations so unrelated Pi requests retain their existing transport. Thanks to [@alexei-ciobanu](https://github.com/alexei-ciobanu) for PR #339 and [@mystery4f](https://github.com/mystery4f) for PR #343.
 - Cleaned stale GitHub clone runtime directories after a crashed process when the owner can be proven dead, while preserving runtimes with unknown or live owners. Thanks to [@yazanabuashour](https://github.com/yazanabuashour) for issue #331.
 - Kept an existing legacy `~/.pi/web-search.json` in use when `XDG_CONFIG_HOME` is set but its XDG config file is absent. Thanks to [@hu3rror](https://github.com/hu3rror) for issue #333.
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Raw and direct-image HTTP requests use the same SSRF validation, hostname domain
 
 An empty string (`""`) forces a direct connection even when a config-level proxy is set. Omitting the parameter falls back to the global `proxy` in `~/.pi/web-search.json`.
 
+The config-level `proxy` applies only to requests made by this extension's tools. Other traffic in the host process — such as the coding agent's own model API calls — is never routed through it, so a configured proxy that is temporarily down cannot break unrelated requests.
+
 ```jsonc
 // ~/.pi/web-search.json — global proxy for all tools
 {

--- a/index.ts
+++ b/index.ts
@@ -1087,7 +1087,8 @@ export default function (pi: ExtensionAPI) {
 		const fetchId = generateId();
 		const controller = new AbortController();
 		pendingFetches.set(fetchId, controller);
-		runWithProxy(proxy, () => fetchAllContent(urls, controller.signal, withRegisteredFetchOptions(undefined, registeredToolNames, proxy)))
+		Promise.resolve()
+			.then(() => runWithProxy(proxy, () => fetchAllContent(urls, controller.signal, withRegisteredFetchOptions(undefined, registeredToolNames, proxy))))
 			.then((fetched) => {
 				if (!sessionActive || !pendingFetches.has(fetchId)) return;
 				const data = {
@@ -3289,19 +3290,21 @@ export default function (pi: ExtensionAPI) {
 							}
 						},
 						async onAddSearch(query, provider) {
-							if (commandHandle && !isCommandActive()) {
-								throw new Error("Curator session is no longer active.");
-							}
-							const requestedProvider = resolveCuratorSearchProvider(provider, currentSearchProvider);
-							const response = await search(query, {
-								provider: requestedProvider,
-								signal: searchAbort.signal,
-								extensionContext: ctx,
+							return runWithProxy(undefined, async () => {
+								if (commandHandle && !isCommandActive()) {
+									throw new Error("Curator session is no longer active.");
+								}
+								const requestedProvider = resolveCuratorSearchProvider(provider, currentSearchProvider);
+								const response = await search(query, {
+									provider: requestedProvider,
+									signal: searchAbort.signal,
+									extensionContext: ctx,
+								});
+								if (commandHandle && !isCommandActive()) {
+									throw new Error("Curator session is no longer active.");
+								}
+								return toCuratorSearchEntries(response);
 							});
-							if (commandHandle && !isCommandActive()) {
-								throw new Error("Curator session is no longer active.");
-							}
-							return toCuratorSearchEntries(response);
 						},
 						onAddSearchResults(entries) {
 							if (commandHandle && !isCommandActive()) return;
@@ -3364,11 +3367,11 @@ export default function (pi: ExtensionAPI) {
 							if (aborted || !isCommandActive()) return;
 							const requestedProvider = currentSearchProvider;
 							try {
-								const response = await search(query, {
+								const response = await runWithProxy(undefined, () => search(query, {
 									provider: requestedProvider,
 									signal: searchAbort.signal,
 									extensionContext: ctx,
-								});
+								}));
 								if (aborted || !isCommandActive()) return;
 								const entries = toCuratorSearchEntries(response);
 								for (let entryIndex = 0; entryIndex < entries.length; entryIndex++) {

--- a/test/proxy-transport.test.mjs
+++ b/test/proxy-transport.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { test } from "node:test";
 
 import initializeExtension from "../index.ts";
@@ -13,11 +13,14 @@ const originalPath = process.env.PATH;
 const originalNoProxy = process.env.NO_PROXY;
 const originalNoProxyLower = process.env.no_proxy;
 const utilsUrl = new URL("../utils.ts", import.meta.url).href;
+const ssrfProtectionUrl = new URL("../ssrf-protection.ts", import.meta.url).href;
+const indexUrl = new URL("../index.ts", import.meta.url).href;
 
 function runConfigProbe(dir, script) {
 	const child = spawnSync(process.execPath, ["--input-type=module"], {
 		input: `
-			const { getActiveProxy, runWithProxy } = await import(${JSON.stringify(utilsUrl)});
+			const { getActiveProxy, hasScopedProxyDecision, runWithProxy } = await import(${JSON.stringify(utilsUrl)});
+			const { validateRemoteUrl } = await import(${JSON.stringify(ssrfProtectionUrl)});
 			${script}
 		`,
 		encoding: "utf8",
@@ -141,7 +144,7 @@ test("proxy curl redirects strip caller headers across origins", async (t) => {
 	});
 });
 
-test("omitted proxy uses global config while empty string forces direct access", async (t) => {
+test("configured proxy is scoped to web operations while empty string forces direct access", async (t) => {
 	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-config-test-"));
 	await writeFile(join(dir, "web-search.json"), JSON.stringify({ proxy: "http://global-proxy.example:8080" }));
 	t.after(async () => {
@@ -150,15 +153,42 @@ test("omitted proxy uses global config while empty string forces direct access",
 
 	assert.deepEqual(runConfigProbe(dir, `
 		console.log(JSON.stringify([
+			getActiveProxy(),
 			runWithProxy(undefined, () => getActiveProxy()),
 			runWithProxy("", () => getActiveProxy()),
 			runWithProxy("http://call-proxy.example:8080", () => getActiveProxy()),
+			getActiveProxy(),
 		]));
 	`), [
+		null,
 		"http://global-proxy.example:8080/",
 		null,
 		"http://call-proxy.example:8080/",
+		null,
 	]);
+});
+
+test("omitted proxy preserves trusted environment proxy routing when no proxy is configured", async (t) => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-env-trust-test-"));
+	t.after(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	assert.deepEqual(runConfigProbe(dir, `
+		for (const key of ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy"]) {
+			delete process.env[key];
+		}
+		process.env.HTTPS_PROXY = "http://env-proxy.example:8080";
+		let lookups = 0;
+		await runWithProxy(undefined, () => validateRemoteUrl("https://public.example.test/", {
+			trustEnvProxy: true,
+			lookup: async () => {
+				lookups++;
+				return [{ address: "10.0.0.10", family: 4 }];
+			},
+		}));
+		console.log(JSON.stringify({ lookups, scoped: hasScopedProxyDecision() }));
+	`), { lookups: 0, scoped: false });
 });
 
 test("invalid configured proxy fails closed instead of direct fetching", async (t) => {
@@ -171,12 +201,72 @@ test("invalid configured proxy fails closed instead of direct fetching", async (
 	assert.match(runConfigProbe(dir, `
 		let message = "";
 		try {
-			getActiveProxy();
+			runWithProxy(undefined, () => getActiveProxy());
 		} catch (error) {
 			message = error.message;
 		}
 		console.log(JSON.stringify(message));
 	`), /proxy.*must use the http:\/\/ or https:\/\/ scheme/);
+});
+
+test("invalid configured proxy reaches background fetch rejection handling", async (t) => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-background-config-test-"));
+	const configPath = join(dir, "web-search.json");
+	await writeFile(configPath, JSON.stringify({ provider: "openai" }));
+	t.after(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			const { writeFileSync } = await import("node:fs");
+			const configPath = ${JSON.stringify(configPath)};
+			const messages = [];
+			globalThis.fetch = async (url) => {
+				if (String(url) !== "https://api.openai.com/v1/responses") {
+					throw new Error("Unexpected fetch: " + url);
+				}
+				writeFileSync(configPath, JSON.stringify({ provider: "openai", proxy: "socks5://proxy.example:1080" }));
+				return new Response(JSON.stringify({ output: [
+					{ type: "web_search_call", action: { sources: [{ title: "Source", url: "https://example.com/source" }] } },
+					{ type: "message", content: [{ type: "output_text", text: "Search answer" }] },
+				] }), { status: 200, headers: { "content-type": "application/json" } });
+			};
+			const tools = [];
+			const handlers = new Map();
+			const pi = {
+				registerTool(tool) { tools.push(tool); },
+				registerCommand() {},
+				registerShortcut() {},
+				on(event, handler) { handlers.set(event, handler); },
+				appendEntry() {},
+				sendMessage(message) { messages.push(message); },
+			};
+			const initializeExtension = (await import(${JSON.stringify(indexUrl)})).default;
+			initializeExtension(pi);
+			await handlers.get("session_start")({}, { sessionManager: { getBranch: () => [] } });
+			const tool = tools.find((candidate) => candidate.name === "web_search");
+			const result = await tool.execute("background-proxy-test", {
+				query: "proxy cleanup",
+				provider: "openai",
+				workflow: "none",
+				includeContent: true,
+			});
+			await new Promise((resolve) => setImmediate(resolve));
+			console.log(JSON.stringify({
+				result: result.content[0].text,
+				errors: messages.filter((message) => message.customType === "web-search-error").map((message) => message.content),
+			}));
+		`,
+		encoding: "utf8",
+		env: { ...process.env, PI_CODING_AGENT_DIR: dir, OPENAI_API_KEY: "proxy-background-test-key" },
+		maxBuffer: 2 * 1024 * 1024,
+	});
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.match(output.result, /Content fetching in background/);
+	assert.equal(output.errors.length, 1, JSON.stringify(output));
+	assert.match(output.errors[0], /proxy.*must use the http:\/\/ or https:\/\/ scheme/);
 });
 
 test("proxy transport does not spawn curl for pre-aborted requests", async (t) => {
@@ -291,5 +381,126 @@ test("fetch_content passes the explicit proxy through queued extraction", async 
 		const pageCall = (await readCurlCalls(logPath)).find((args) => args.at(-1) === "https://example.com/page");
 		assert.ok(pageCall);
 		assert.ok(["http://call-proxy.example:8080", "http://call-proxy.example:8080/"].includes(proxyArg(pageCall)));
+	});
+});
+
+test("websearch command scopes searches but not model callbacks to configured proxy", async (t) => {
+	await withFakeCurl(t, {
+		"https://run.xcrawl.com/v1/serp": {
+			status: 200,
+			statusText: "OK",
+			body: JSON.stringify({
+				search_metadata: { status: "completed" },
+				organic_results: [{ title: "Result", link: "https://example.com/result", snippet: "Answer" }],
+			}),
+		},
+	}, async (logPath) => {
+		const configDir = dirname(logPath);
+		await writeFile(join(configDir, "web-search.json"), JSON.stringify({
+			provider: "xcrawl",
+			xcrawlApiKey: "xc-test-key",
+			proxy: "http://configured-proxy.example:8080",
+			autoOpenBrowser: false,
+			curatorTimeoutSeconds: 5,
+		}) + "\n", "utf8");
+
+		const child = spawnSync(process.execPath, ["--input-type=module"], {
+			input: `
+				const { setTimeout: delay } = await import("node:timers/promises");
+				const { hasScopedProxyDecision } = await import(${JSON.stringify(utilsUrl)});
+				const commands = new Map();
+				const notifications = [];
+				const modelScoped = [];
+				const model = { provider: "openai", id: "gpt-5-mini" };
+				const modelRegistry = {
+					getAvailable() { return [model]; },
+					find(provider, id) { return provider === model.provider && id === model.id ? model : undefined; },
+					async getApiKeyAndHeaders() { return { ok: true, apiKey: "summary-test-key" }; },
+					async complete(_model, request, options) {
+						modelScoped.push(hasScopedProxyDecision());
+						if (options.signal?.aborted) throw new Error("summary signal aborted");
+						const prompt = String(request.messages?.[0]?.content?.[0]?.text ?? "");
+						return {
+							stopReason: "stop",
+							content: [{ type: "text", text: prompt.includes("Rewrite this") ? "rewritten query" : "summarized results" }],
+						};
+					},
+				};
+				const pi = {
+					registerTool() {},
+					registerCommand(name, command) { commands.set(name, command); },
+					registerShortcut() {},
+					on() {},
+					appendEntry() {},
+					sendMessage() {},
+				};
+				const initializeExtension = (await import(${JSON.stringify(indexUrl)})).default;
+				initializeExtension(pi);
+				const ctx = {
+					model: undefined,
+					modelRegistry,
+					cwd: process.cwd(),
+					isProjectTrusted() { return true; },
+					ui: { notify(message, level) { notifications.push({ message, level }); } },
+				};
+				await commands.get("websearch").handler("initial command query", ctx);
+				const urlText = notifications
+					.map(note => note.message.match(/http:\\/\\/[^ ]+/)?.[0])
+					.find(Boolean);
+				if (!urlText) throw new Error("websearch command did not report a curator URL");
+				const curatorUrl = new URL(urlText);
+				const token = curatorUrl.searchParams.get("session");
+				async function request(path, body) {
+					const url = new URL(path, curatorUrl.origin);
+					if (!body) url.searchParams.set("session", token);
+					const response = await fetch(url, body ? {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({ token, ...body }),
+					} : undefined);
+					return { status: response.status, body: await response.json() };
+				}
+				let state;
+				for (let attempt = 0; attempt < 100; attempt++) {
+					state = (await request("/state")).body;
+					if (state.done) break;
+					await delay(10);
+				}
+				if (!state?.done) throw new Error("initial websearch command did not finish");
+				const added = await request("/search", { query: "added command query" });
+				if (added.status !== 200 || added.body.error) throw new Error("command add-search failed");
+				const rewritten = await request("/rewrite", { query: "rewrite this query" });
+				if (rewritten.status !== 200 || rewritten.body.query !== "rewritten query") throw new Error("command rewrite failed");
+				const summarized = await request("/summarize", { selected: [0] });
+				if (summarized.status !== 200 || summarized.body.summary !== "summarized results") throw new Error("command summarize failed");
+				const submitted = await request("/submit", { selected: [0], summary: "finished" });
+				console.log(JSON.stringify({
+					initialDone: state.done,
+					addSearchStatus: added.status,
+					rewriteStatus: rewritten.status,
+					summarizeStatus: summarized.status,
+					submitStatus: submitted.status,
+					modelScoped,
+				}));
+				await delay(50);
+			`,
+			encoding: "utf8",
+			env: { ...process.env, PI_CODING_AGENT_DIR: configDir },
+			maxBuffer: 2 * 1024 * 1024,
+		});
+
+		assert.equal(child.status, 0, child.stderr);
+		assert.deepEqual(JSON.parse(child.stdout.trim()), {
+			initialDone: true,
+			addSearchStatus: 200,
+			rewriteStatus: 200,
+			summarizeStatus: 200,
+			submitStatus: 200,
+			modelScoped: [false, false],
+		});
+		const calls = await readCurlCalls(logPath);
+		assert.equal(calls.length, 2);
+		assert.equal(calls.filter((args) => args.at(-1) === "https://run.xcrawl.com/v1/serp").length, 2);
+		assert.ok(calls.every((args) => ["http://configured-proxy.example:8080", "http://configured-proxy.example:8080/"].includes(proxyArg(args))));
 	});
 });

--- a/utils.ts
+++ b/utils.ts
@@ -251,14 +251,17 @@ function loadConfiguredProxy(): string | null {
 }
 
 export function runWithProxy<T>(proxy: string | undefined, fn: () => T): T {
-	if (proxy === undefined) return fn();
+	if (proxy === undefined) {
+		const configured = loadConfiguredProxy();
+		if (configured === null) return fn();
+		return proxyStorage.run(configured, fn);
+	}
 	const normalized = normalizeProxyUrl(proxy, "proxy");
 	return proxyStorage.run(normalized, fn);
 }
 
 export function getActiveProxy(): string | null {
-	const scoped = proxyStorage.getStore();
-	return scoped !== undefined ? scoped : loadConfiguredProxy();
+	return proxyStorage.getStore() ?? null;
 }
 
 export function hasScopedProxyDecision(): boolean {


### PR DESCRIPTION
Owner replacement for the overlapping proxy-scope PRs #339 and #343.

Source-of-truth decision:
- Use #339 as the code/test implementation source because it is smaller and covers the Greptile edge cases around environment proxy routing and background rejection cleanup.
- Preserve #343's useful README clarification that config-level proxy applies only to extension tool traffic, not host/model traffic.
- Credit both contributors in the changelog.

Changes:
- Scope configured proxy transport to web-tool operations so unrelated Pi/host requests retain their existing transport.
- Keep explicit proxy and empty-string direct override behavior.
- Ensure invalid configured proxy errors from background content fetches reach existing rejection/cleanup handling.
- Add README clarification and changelog credit for [@alexei-ciobanu](https://github.com/alexei-ciobanu) and [@mystery4f](https://github.com/mystery4f).

Validation:
- `node --test test/proxy-transport.test.mjs` — 11/11 passed.
- `node --test test/ssrf-protection.test.mjs` — 25/25 passed.
- `npm run typecheck` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh exact-head review found no issues.

Supersedes #339 and #343 after merge.
