### PR TITLE
perf: run batch web searches with bounded concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Documented the Linux `xdg-utils` dependency for automatic curator browser launch and the manual URL fallback. Thanks to [@wickedTangent](https://github.com/wickedTangent) for issue #336 and PR #337.
 
+### Changed
+
+- Run batch `web_search` queries with bounded concurrency while preserving query order and sequential provider fallback within each query.
+
 ### Fixed
 
 - Cleaned stale GitHub clone runtime directories after a crashed process when the owner can be proven dead, while preserving runtimes with unknown or live owners. Thanks to [@yazanabuashour](https://github.com/yazanabuashour) for issue #331.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Run batch `web_search` queries with bounded concurrency while preserving query order and sequential provider fallback within each query.
+- Run batch `web_search` queries with bounded concurrency while preserving query order and sequential provider fallback within each query. Thanks to [@Noir-Lime](https://github.com/Noir-Lime) for PR #345.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ web_search({ queries: ["query 1", "query 2"], workflow: "auto-summary" })
 | `includeContent` | Fetch full page content from sources in background |
 | `workflow` | `none` (skip curator), `summary-review` (open curator and auto-generate a summary draft, default), or `auto-summary` (generate a summary without opening the curator) |
 
+Batch searches run up to three queries concurrently. Provider routing and fallback within each query remain sequential.
+
 ### fetch_content
 
 Fetch URL(s) as readable markdown, exact textual HTTP bodies, direct images, or page-grounded answers. Automatically detects and handles GitHub repos, GitHub PRs and issues, YouTube videos, PDFs, local video files, images, and regular web pages.

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -17,6 +17,8 @@ type CuratorStoredEvent =
 
 export interface CuratorServerOptions {
 	queries: string[];
+	/** First index available to searches added while initial results are still streaming. */
+	initialResultIndexCapacity?: number;
 	sessionToken: string;
 	timeout: number;
 	availableProviders: ProviderAvailability;
@@ -194,6 +196,7 @@ export function startCuratorServer(
 ): Promise<CuratorServerHandle> {
 	const {
 		queries,
+		initialResultIndexCapacity,
 		sessionToken,
 		timeout,
 		availableProviders,
@@ -213,7 +216,7 @@ export function startCuratorServer(
 	let sseResponse: ServerResponse | null = null;
 	const streamedEventsByResultIndex = new Map<number, CuratorStoredEvent>();
 	let searchStreamDone = queries.length === 0;
-	let nextQueryIndex = queries.length;
+	let nextQueryIndex = Math.max(queries.length, initialResultIndexCapacity ?? queries.length);
 	let summarizeAbortController: AbortController | null = null;
 	let summarizeRequestSeq = 0;
 

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import type { AgentToolResult, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Box, Text, truncateToWidth, type KeyId } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import pLimit from "p-limit";
 import { StringEnum, type ImageContent, type TextContent } from "@earendil-works/pi-ai/compat";
 import type { ExtractedContent, ExtractOptions } from "./extract.ts";
 import { normalizeFetchContentParams } from "./fetch-params.ts";
@@ -229,6 +230,19 @@ const DEFAULT_CURATOR_TIMEOUT_SECONDS = 20;
 const DEFAULT_REMOTE_CURATOR_TIMEOUT_SECONDS = 60;
 const MAX_CURATOR_TIMEOUT_SECONDS = 600;
 const MAX_SUMMARY_GENERATION_DEADLINE_MS = 600_000;
+const SEARCH_QUERY_CONCURRENCY = 3;
+
+// Limit each batch independently so separate Pi tool calls can still run in parallel.
+function runSearchQueries<T>(queries: string[], run: (query: string, index: number) => Promise<T>): Promise<T[]> {
+	const limit = pLimit(SEARCH_QUERY_CONCURRENCY);
+	return Promise.all(queries.map((query, index) => limit(() => run(query, index))));
+}
+
+// Keep primary query indexes stable for curator slots, then interleave additional
+// provider entries deterministically instead of assigning by completion order.
+function curatorResultIndex(queryIndex: number, entryIndex: number, queryCount: number): number {
+	return entryIndex === 0 ? queryIndex : entryIndex * queryCount + queryIndex;
+}
 
 function searchProviderSchema(description: string) {
 	return Type.Union([
@@ -1340,7 +1354,7 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		const selected = filterByQueryIndices(payload.selectedQueryIndices, resultsByIndex).results;
-		const fallbackResults = selected.length > 0 ? selected : [...resultsByIndex.values()];
+		const fallbackResults = selected.length > 0 ? selected : orderedSearchResults(resultsByIndex);
 		const deterministic = buildDeterministicSummary(fallbackResults);
 		return {
 			approvedSummary: deterministic.summary,
@@ -1452,8 +1466,14 @@ export default function (pi: ExtensionAPI) {
 		return { results: filteredResults, urls: filteredUrls };
 	}
 
+	function orderedSearchResults(resultsByIndex: Map<number, QueryResultData>): QueryResultData[] {
+		return [...resultsByIndex.entries()]
+			.sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
+			.map(([, result]) => result);
+	}
+
 	function collectAllResultsAndUrls(resultsByIndex: Map<number, QueryResultData>) {
-		const results = [...resultsByIndex.values()];
+		const results = orderedSearchResults(resultsByIndex);
 		const urls: string[] = [];
 		for (const result of results) {
 			for (const source of result.results) {
@@ -1573,7 +1593,7 @@ export default function (pi: ExtensionAPI) {
 						} else {
 							const conn = activeCurators.get(callId)?.getConnectionState();
 							pc.finish(buildCurationCancelledReturn(reason, {
-								queries: Array.from(pc.searchResults.values()),
+								queries: orderedSearchResults(pc.searchResults),
 								queryCount: pc.queryList.length,
 								browserConnected: conn?.browserConnected,
 								lastHeartbeatAgeMs: conn?.lastHeartbeatAgeMs,
@@ -1809,7 +1829,6 @@ export default function (pi: ExtensionAPI) {
 				const searchResults = new Map<number, QueryResultData>();
 				const resultSlots = new Map<number, number>();
 				const allInlineContent: ExtractedContent[] = [];
-				let nextResultIndex = queryList.length;
 				const searchAbort = new AbortController();
 				const searchSignal = signal
 					? AbortSignal.any([signal, searchAbort.signal])
@@ -1876,7 +1895,7 @@ export default function (pi: ExtensionAPI) {
 					if (cancelled) return;
 					const conn = activeCurators.get(callId)?.getConnectionState();
 					finish(buildCurationCancelledReturn(reason, {
-						queries: Array.from(searchResults.values()),
+						queries: orderedSearchResults(searchResults),
 						queryCount: queryList.length,
 						browserConnected: conn?.browserConnected,
 						lastHeartbeatAgeMs: conn?.lastHeartbeatAgeMs,
@@ -1893,15 +1912,16 @@ export default function (pi: ExtensionAPI) {
 				signal?.addEventListener("abort", onAbort, { once: true });
 				pc.browserPromise = openCuratorBrowser(callId, pc, ctx, false);
 
-				for (let qi = 0; qi < queryList.length; qi++) {
-					if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
+				let completedSearches = 0;
+				await runSearchQueries(queryList, async (query, qi) => {
+					if (signal?.aborted || cancelled || searchAbort.signal.aborted) return;
 					onUpdate?.({
-						content: [{ type: "text", text: `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...` }],
-						details: { phase: "searching", progress: qi / queryList.length, currentQuery: queryList[qi] },
+						content: [{ type: "text", text: `Searching "${query}" (${completedSearches}/${queryList.length} complete)...` }],
+						details: { phase: "searching", progress: completedSearches / queryList.length, currentQuery: query },
 					});
 					const requestedProvider = pc.searchProvider;
 					try {
-						const response = await search(queryList[qi], {
+						const response = await search(query, {
 							provider: requestedProvider,
 							numResults: params.numResults,
 							recencyFilter,
@@ -1910,40 +1930,48 @@ export default function (pi: ExtensionAPI) {
 							signal: searchSignal,
 							extensionContext: ctx,
 						});
-						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
+						if (signal?.aborted || cancelled || searchAbort.signal.aborted) return;
 						if (response.inlineContent) allInlineContent.push(...response.inlineContent);
 						const entries = toCuratorSearchEntries(response);
 						const curator = activeCurators.get(callId);
 						for (let entryIndex = 0; entryIndex < entries.length; entryIndex++) {
 							const entry = entries[entryIndex];
-							const resultIndex = entryIndex === 0 ? qi : nextResultIndex++;
+							const resultIndex = curatorResultIndex(qi, entryIndex, queryList.length);
 							const indexedEntry: IndexedCuratorSearchEntry = {
 								...entry,
 								queryIndex: resultIndex,
-								query: queryList[qi],
+								query,
 							};
 							searchResults.set(resultIndex, indexedCuratorEntryToQueryResult(indexedEntry));
 							resultSlots.set(resultIndex, qi);
 							if (curator) {
 								if (entry.error) {
-									curator.pushError(resultIndex, entry.error, entry.provider, { query: queryList[qi], slotIndex: qi });
+									curator.pushError(resultIndex, entry.error, entry.provider, { query, slotIndex: qi });
 								} else {
-									curator.pushResult(resultIndex, { ...entry, query: queryList[qi], slotIndex: qi });
+									curator.pushResult(resultIndex, { ...entry, query, slotIndex: qi });
 								}
 							}
 						}
 					} catch (err) {
-						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
+						if (signal?.aborted || cancelled || searchAbort.signal.aborted) return;
 						const message = err instanceof Error ? err.message : String(err);
 						const failedProvider = toCuratorProvider(requestedProvider);
-						searchResults.set(qi, { query: queryList[qi], answer: "", results: [], error: message, provider: failedProvider });
+						searchResults.set(qi, { query, answer: "", results: [], error: message, provider: failedProvider });
 						resultSlots.set(qi, qi);
 						const curator = activeCurators.get(callId);
 						if (curator) {
-							curator.pushError(qi, message, failedProvider, { query: queryList[qi], slotIndex: qi });
+							curator.pushError(qi, message, failedProvider, { query, slotIndex: qi });
+						}
+					} finally {
+						completedSearches++;
+						if (!signal?.aborted && !cancelled && !searchAbort.signal.aborted) {
+							onUpdate?.({
+								content: [{ type: "text", text: `Completed ${completedSearches}/${queryList.length} searches.` }],
+								details: { phase: "searching", progress: completedSearches / queryList.length, currentQuery: query },
+							});
 						}
 					}
-				}
+				});
 
 				if (signal?.aborted || cancelled || searchAbort.signal.aborted) {
 					cancel();
@@ -1983,17 +2011,16 @@ export default function (pi: ExtensionAPI) {
 				return promise;
 			}
 
-			const searchResults: QueryResultData[] = [];
+			let completedSearches = 0;
 			const allUrls: string[] = [];
 			const allInlineContent: ExtractedContent[] = [];
 			const resolvedProvider = resolveRequestedProvider(params.provider);
 
-			for (let i = 0; i < queryList.length; i++) {
-				const query = queryList[i];
-
+			const queryResponses = await runSearchQueries(queryList, async (query) => {
+				signal?.throwIfAborted();
 				onUpdate?.({
-					content: [{ type: "text", text: `Searching ${i + 1}/${queryList.length}: "${query}"...` }],
-					details: { phase: "search", progress: i / queryList.length, currentQuery: query },
+					content: [{ type: "text", text: `Searching "${query}" (${completedSearches}/${queryList.length} complete)...` }],
+					details: { phase: "search", progress: completedSearches / queryList.length, currentQuery: query },
 				});
 
 				try {
@@ -2007,19 +2034,31 @@ export default function (pi: ExtensionAPI) {
 						extensionContext: ctx,
 					});
 
-					searchResults.push({ query, answer, results, error: null, provider });
-					for (const r of results) {
-						if (!allUrls.includes(r.url)) {
-							allUrls.push(r.url);
-						}
-					}
-					if (inlineContent) allInlineContent.push(...inlineContent);
+					return { result: { query, answer, results, error: null, provider } satisfies QueryResultData, inlineContent };
 				} catch (err) {
 					if (signal?.aborted || isAbortError(err)) throw err;
 					const message = err instanceof Error ? err.message : String(err);
 					const requestedProvider = toCuratorProvider(resolvedProvider);
-					searchResults.push({ query, answer: "", results: [], error: message, provider: requestedProvider });
+					return {
+						result: { query, answer: "", results: [], error: message, provider: requestedProvider } satisfies QueryResultData,
+						inlineContent: undefined,
+					};
+				} finally {
+					completedSearches++;
+					if (!signal?.aborted) {
+						onUpdate?.({
+							content: [{ type: "text", text: `Completed ${completedSearches}/${queryList.length} searches.` }],
+							details: { phase: "search", progress: completedSearches / queryList.length, currentQuery: query },
+						});
+					}
 				}
+			});
+			const searchResults = queryResponses.map(response => response.result);
+			for (const response of queryResponses) {
+				for (const result of response.result.results) {
+					if (!allUrls.includes(result.url)) allUrls.push(result.url);
+				}
+				if (response.inlineContent) allInlineContent.push(...response.inlineContent);
 			}
 
 			let approvedSummary: string | undefined;
@@ -3315,41 +3354,40 @@ export default function (pi: ExtensionAPI) {
 
 				if (queries.length > 0) {
 					(async () => {
-						let nextResultIndex = queries.length;
-						for (let qi = 0; qi < queries.length; qi++) {
-							if (aborted || !isCommandActive()) break;
+						await runSearchQueries(queries, async (query, qi) => {
+							if (aborted || !isCommandActive()) return;
 							const requestedProvider = currentSearchProvider;
 							try {
-								const response = await search(queries[qi], {
+								const response = await search(query, {
 									provider: requestedProvider,
 									signal: searchAbort.signal,
 									extensionContext: ctx,
 								});
-								if (aborted || !isCommandActive()) break;
+								if (aborted || !isCommandActive()) return;
 								const entries = toCuratorSearchEntries(response);
 								for (let entryIndex = 0; entryIndex < entries.length; entryIndex++) {
 									const entry = entries[entryIndex];
-									const resultIndex = entryIndex === 0 ? qi : nextResultIndex++;
+									const resultIndex = curatorResultIndex(qi, entryIndex, queries.length);
 									const indexedEntry: IndexedCuratorSearchEntry = {
 										...entry,
 										queryIndex: resultIndex,
-										query: queries[qi],
+										query,
 									};
 									collected.set(resultIndex, indexedCuratorEntryToQueryResult(indexedEntry));
 									if (entry.error) {
-										handle.pushError(resultIndex, entry.error, entry.provider, { query: queries[qi], slotIndex: qi });
+										handle.pushError(resultIndex, entry.error, entry.provider, { query, slotIndex: qi });
 									} else {
-										handle.pushResult(resultIndex, { ...entry, query: queries[qi], slotIndex: qi });
+										handle.pushResult(resultIndex, { ...entry, query, slotIndex: qi });
 									}
 								}
 							} catch (err) {
-								if (aborted || !isCommandActive()) break;
+								if (aborted || !isCommandActive()) return;
 								const message = err instanceof Error ? err.message : String(err);
 								const failedProvider = toCuratorProvider(requestedProvider);
-								handle.pushError(qi, message, failedProvider, { query: queries[qi], slotIndex: qi });
-								collected.set(qi, { query: queries[qi], answer: "", results: [], error: message, provider: failedProvider });
+								handle.pushError(qi, message, failedProvider, { query, slotIndex: qi });
+								collected.set(qi, { query, answer: "", results: [], error: message, provider: failedProvider });
 							}
-						}
+						});
 						if (!aborted && isCommandActive()) handle.searchesDone();
 					})();
 				} else {

--- a/index.ts
+++ b/index.ts
@@ -244,6 +244,10 @@ function curatorResultIndex(queryIndex: number, entryIndex: number, queryCount: 
 	return entryIndex === 0 ? queryIndex : entryIndex * queryCount + queryIndex;
 }
 
+function curatorResultIndexCapacity(queryCount: number): number {
+	return queryCount * RESOLVED_SEARCH_PROVIDERS.length;
+}
+
 function searchProviderSchema(description: string) {
 	return Type.Union([
 		StringEnum([...SEARCH_PROVIDERS]),
@@ -1512,6 +1516,7 @@ export default function (pi: ExtensionAPI) {
 			handle = await startCuratorServer(
 				{
 					queries: pc.queryList,
+					initialResultIndexCapacity: curatorResultIndexCapacity(pc.queryList.length),
 					sessionToken,
 					timeout: pc.timeoutSeconds,
 					availableProviders: pc.availableProviders,
@@ -1775,7 +1780,7 @@ export default function (pi: ExtensionAPI) {
 			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage. Omit provider unless explicitly overriding the configured default.",
 		parameters: Type.Object({
 			query: Type.Optional(Type.String({ description: "Single search query. For research tasks, prefer 'queries' with multiple varied angles instead." })),
-			queries: Type.Optional(Type.Array(Type.String(), { description: "Multiple queries searched in sequence, each returning its own synthesized answer. Prefer this for research — vary phrasing, scope, and angle across 2-4 queries to maximize coverage. Good: ['React vs Vue performance benchmarks 2026', 'React vs Vue developer experience comparison', 'React ecosystem size vs Vue ecosystem']. Bad: ['React vs Vue', 'React vs Vue comparison', 'React vs Vue review'] (too similar, redundant results)." })),
+			queries: Type.Optional(Type.Array(Type.String(), { description: "Multiple queries searched concurrently (up to three at a time), each returning its own synthesized answer. Prefer this for research — vary phrasing, scope, and angle across 2-4 queries to maximize coverage. Good: ['React vs Vue performance benchmarks 2026', 'React vs Vue developer experience comparison', 'React ecosystem size vs Vue ecosystem']. Bad: ['React vs Vue', 'React vs Vue comparison', 'React vs Vue review'] (too similar, redundant results)." })),
 			numResults: Type.Optional(Type.Integer({ minimum: 1, maximum: 20, description: "Results per query (default: 5, max: 20)" })),
 			includeContent: Type.Optional(Type.Boolean({ description: "Fetch full page content (async)" })),
 			recencyFilter: Type.Optional(
@@ -3202,6 +3207,7 @@ export default function (pi: ExtensionAPI) {
 				const handle = await startCuratorServer(
 					{
 						queries,
+						initialResultIndexCapacity: curatorResultIndexCapacity(queries.length),
 						sessionToken,
 						timeout: curatorTimeoutSeconds,
 						availableProviders,

--- a/test/curator-server-timeout.test.mjs
+++ b/test/curator-server-timeout.test.mjs
@@ -122,6 +122,45 @@ test("curator replays search events after SSE reconnect", async () => {
 	}
 });
 
+test("curator add-search indexes do not collide with reserved initial provider results", async () => {
+	const { startCuratorServer } = await loadServer();
+	const handle = await startCuratorServer({
+		...baseOptions(20),
+		queries: ["initial one", "initial two"],
+		initialResultIndexCapacity: 6,
+	}, baseCallbacks(() => {}));
+
+	try {
+		const searchResponse = await fetch(new URL("/search", handle.url), {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ token: "test-token", query: "added search" }),
+		});
+		assert.equal(searchResponse.status, 200);
+		const added = await searchResponse.json();
+		assert.equal(added.queryIndex, 6);
+		assert.notEqual(added.queryIndex, 2);
+
+		// Index 2 is a later provider result for the first initial query. Before
+		// reserving the initial range, the added search also received index 2.
+		handle.pushResult(2, {
+			query: "initial one",
+			slotIndex: 0,
+			answer: "late provider answer",
+			results: [],
+			provider: "brave",
+		});
+		handle.searchesDone();
+
+		const eventsUrl = new URL("/events", handle.url);
+		eventsUrl.searchParams.set("session", "test-token");
+		const events = await readEventStreamUntil(await fetch(eventsUrl), "event: done", "reserved-index replay");
+		assert.match(events, /"query":"initial one"[\s\S]*"queryIndex":2/);
+	} finally {
+		handle.close();
+	}
+});
+
 test("curator submit rejects contradictory summary metadata", async () => {
 	const { startCuratorServer } = await loadServer();
 	const handle = await startCuratorServer(baseOptions(20), baseCallbacks(() => {}));

--- a/test/provider-precedence.test.mjs
+++ b/test/provider-precedence.test.mjs
@@ -218,7 +218,7 @@ test("non-curated search stops after caller cancellation", async () => {
 	});
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());
-	assert.equal(output.calls, 1);
+	assert.equal(output.calls, 0);
 	assert.match(output.error, /abort/i);
 });
 

--- a/test/web-search-concurrency.test.mjs
+++ b/test/web-search-concurrency.test.mjs
@@ -83,7 +83,8 @@ test("web_search bounds batch concurrency and preserves query order", async () =
 				completed,
 				queries: curatedResult.details.curatedQueries.map(entry => entry.query),
 			};
-			console.log(JSON.stringify({ raw, curated }));
+			const queriesDescription = webSearch.parameters.properties.queries.description;
+			console.log(JSON.stringify({ raw, curated, queriesDescription }));
 		`,
 		encoding: "utf8",
 		env: childEnv,
@@ -91,7 +92,7 @@ test("web_search bounds batch concurrency and preserves query order", async () =
 	});
 
 	assert.equal(child.status, 0, child.stderr);
-	const { raw, curated } = JSON.parse(child.stdout.trim());
+	const { raw, curated, queriesDescription } = JSON.parse(child.stdout.trim());
 	assert.equal(raw.maxActive, 3);
 	assert.deepEqual(raw.started, ["q1", "q2", "q3", "q4", "q5"]);
 	assert.notDeepEqual(raw.completed, raw.started);
@@ -106,4 +107,5 @@ test("web_search bounds batch concurrency and preserves query order", async () =
 	assert.deepEqual(curated.started, raw.started);
 	assert.notDeepEqual(curated.completed, curated.started);
 	assert.deepEqual(curated.queries, raw.started);
+	assert.match(queriesDescription, /concurrently \(up to three at a time\)/);
 });

--- a/test/web-search-concurrency.test.mjs
+++ b/test/web-search-concurrency.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const indexUrl = new URL("../index.ts", import.meta.url).href;
+
+test("web_search bounds batch concurrency and preserves query order", async () => {
+	const home = await mkdtemp(join(tmpdir(), "pi-web-access-concurrency-"));
+	await writeFile(join(home, "web-search.json"), JSON.stringify({
+		xcrawlApiKey: "xc-test-key",
+		autoOpenBrowser: false,
+		curatorTimeoutSeconds: 1,
+	}) + "\n", "utf8");
+	const childEnv = { ...process.env, PI_CODING_AGENT_DIR: home };
+	for (const key of [
+		"OPENAI_API_KEY", "BRAVE_API_KEY", "PARALLEL_API_KEY", "TINYFISH_API_KEY",
+		"TAVILY_API_KEY", "JINA_API_KEY", "EXA_API_KEY", "PERPLEXITY_API_KEY", "GEMINI_API_KEY",
+	]) {
+		delete childEnv[key];
+	}
+
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			let active = 0;
+			let maxActive = 0;
+			let started = [];
+			let completed = [];
+			const delays = new Map([["q1", 90], ["q2", 70], ["q3", 50], ["q4", 30], ["q5", 10]]);
+			globalThis.fetch = async (_url, init) => {
+				const query = JSON.parse(init.body).q;
+				started.push(query);
+				active++;
+				maxActive = Math.max(maxActive, active);
+				await new Promise(resolve => setTimeout(resolve, delays.get(query)));
+				active--;
+				completed.push(query);
+				return new Response(JSON.stringify({
+					search_metadata: { status: "completed" },
+					total_credits_used: 1,
+					organic_results: [{ position: 1, title: query, link: "https://example.com/" + query, snippet: query }],
+				}), { status: 200 });
+			};
+			const tools = [];
+			const { default: initializeExtension } = await import(${JSON.stringify(indexUrl)});
+			initializeExtension({
+				registerTool(tool) { tools.push(tool); },
+				registerCommand() {}, registerShortcut() {}, on() {}, appendEntry() {}, sendMessage() {},
+			});
+			const webSearch = tools.find(tool => tool.name === "web_search");
+			const updates = [];
+			const rawResult = await webSearch.execute(
+				"concurrency-test",
+				{ queries: ["q1", "q2", "q3", "q4", "q5"], provider: "xcrawl", workflow: "none" },
+				undefined,
+				update => updates.push(update.details),
+			);
+			const raw = { maxActive, started, completed, updates, text: rawResult.content[0].text };
+
+			active = 0;
+			maxActive = 0;
+			started = [];
+			completed = [];
+			const curatedResult = await webSearch.execute(
+				"curator-concurrency-test",
+				{ queries: ["q1", "q2", "q3", "q4", "q5"], provider: "xcrawl", workflow: "summary-review" },
+				undefined,
+				undefined,
+				{
+					hasUI: true,
+					model: undefined,
+					modelRegistry: { getAvailable() { return []; }, find() { return undefined; } },
+					cwd: process.cwd(),
+					isProjectTrusted() { return true; },
+					ui: { notify() {} },
+				},
+			);
+			const curated = {
+				maxActive,
+				started,
+				completed,
+				queries: curatedResult.details.curatedQueries.map(entry => entry.query),
+			};
+			console.log(JSON.stringify({ raw, curated }));
+		`,
+		encoding: "utf8",
+		env: childEnv,
+		maxBuffer: 2 * 1024 * 1024,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const { raw, curated } = JSON.parse(child.stdout.trim());
+	assert.equal(raw.maxActive, 3);
+	assert.deepEqual(raw.started, ["q1", "q2", "q3", "q4", "q5"]);
+	assert.notDeepEqual(raw.completed, raw.started);
+	let previous = -1;
+	for (const query of raw.started) {
+		const position = raw.text.indexOf(`## Query: "${query}"`);
+		assert.ok(position > previous, `${query} was returned out of order`);
+		previous = position;
+	}
+	assert.equal(raw.updates.at(-1).progress, 1);
+	assert.equal(curated.maxActive, 3);
+	assert.deepEqual(curated.started, raw.started);
+	assert.notDeepEqual(curated.completed, curated.started);
+	assert.deepEqual(curated.queries, raw.started);
+});


### PR DESCRIPTION
Owner replacement for #345, preserving @Noir-Lime's batch concurrency implementation and adding required changelog credit.

Changes:
- Run batch `web_search` queries with bounded concurrency of three.
- Preserve input-order output and sequential provider fallback within each query.
- Reserve curator result indexes so user-added searches cannot collide with delayed initial results.
- Credit [@Noir-Lime](https://github.com/Noir-Lime) in the changelog.

Validation:
- `node --test test/web-search-concurrency.test.mjs test/curator-server-timeout.test.mjs test/provider-precedence.test.mjs` — 20/20 passed.
- `npm test` — 643/643 passed.
- `npm run typecheck` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh high-risk exact-head review found no issues.

Supersedes #345 after merge.
