### PR TITLE
feat: add opt-in xAI X search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Documented the Linux `xdg-utils` dependency for automatic curator browser launch and the manual URL fallback. Thanks to [@wickedTangent](https://github.com/wickedTangent) for issue #336 and PR #337.
+- Added opt-in xAI Agent Tools `x_search` support alongside `web_search`, with validated `xaiSearchTools` configuration and defensive citation handling. Thanks to [@Jerry2003sky](https://github.com/Jerry2003sky) for issue #342.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ Config defaults to `~/.pi/web-search.json`. `PI_CODING_AGENT_DIR` takes preceden
   "serperApiKey": "$SERPER_API_KEY",
   "brightdataApiKey": "$BRIGHTDATA_API_KEY",
   "brightdataSerpZone": "pi_serp",
+  "xaiApiKey": "xai-...",
+  "xaiSearchTools": ["web_search"],
   "searxngBaseUrl": "https://search.example.com",
   "searxngHeaders": {
     "CF-Access-Client-Id": "xxxxxxxx.access",
@@ -657,13 +659,21 @@ XCrawl is an explicit-only provider: it is never included in zero-config `auto` 
 
 xAI is an explicit-only provider: it is never included in zero-config `auto` fallback or in `provider: "all"`, but it can be selected with `provider: "xai"`, configured as the named provider, or placed in `searchRouting`.
 
-It calls xAI's Agent Tools API — the hosted `web_search` tool on `https://api.x.ai/v1/responses` — so the search runs inside Grok's own inference rather than here. Auth resolves through Pi's model registry first, which means a **SuperGrok or X Premium subscription pays for its own searches** and no `xaiApiKey` has to be configured at all; `xaiApiKey` / `XAI_API_KEY` are the fallback for pay-as-you-go API keys.
+It calls xAI's Agent Tools API — the hosted `web_search` tool, with opt-in `x_search`, on `https://api.x.ai/v1/responses` — so the search runs inside Grok's own inference rather than here. Auth resolves through Pi's model registry first, which means a **SuperGrok or X Premium subscription pays for its own searches** and no `xaiApiKey` has to be configured at all; `xaiApiKey` / `XAI_API_KEY` are the fallback for pay-as-you-go API keys.
 
-Explicit-only is deliberate. A single question typically fans out to roughly a dozen `web_search` tool calls, billed at xAI's per-call tool rate on top of tokens and drawn from the same allowance the account uses for chatting. Letting `auto` or `all` reach for it would spend a subscription the user only meant to talk to.
+Explicit-only is deliberate. A single question typically fans out to roughly a dozen `web_search` tool calls, billed at xAI's per-call tool rate on top of tokens and drawn from the same allowance the account uses for chatting. Letting `auto` or `all` reach for it would spend a subscription the user only meant to talk to. X Search is an additional opt-in because it sends the query to xAI's X search surface and may incur its own tool-call charges.
 
-The model is chosen for you: the registry path walks a best-first candidate list and uses the first id Pi actually knows, so a retired model is skipped rather than sent. The API-key path has no registry to consult and starts at `grok-4.5`. `xaiSearchModel` pins the id explicitly on either path, which is the escape hatch if xAI retires a model before a release ships.
+The model is chosen for you: the registry path walks a best-first candidate list and uses the first id Pi actually knows, so a retired model is skipped rather than sent. The API-key path has no registry to consult and starts at `grok-4.5` for the default web-only request. When `x_search` is enabled, the current xAI docs' `grok-4.6` example is preferred instead. `xaiSearchModel` pins the id explicitly on either path, which is the escape hatch if xAI retires a model before a release ships.
 
-Requests send only `{ model, input, tools }`, the shape verified against a live subscription account. `recencyFilter`, `domainFilter`, and `numResults` are folded into the prompt text rather than sent as tool parameters, so an unrecognized field can never turn a search into a 400. Sources are read from `url_citation` annotations on the answer and from each `web_search_call`'s own sources; there is no top-level `citations` array on this API.
+Requests send only `{ model, input, tools }`, the shape verified against a live subscription account. The default `xaiSearchTools` value is `["web_search"]`, preserving the existing behavior. To opt into X Search, set it to `["x_search"]` for X-only searches or `["web_search", "x_search"]` to expose both tools:
+
+```json
+{
+  "xaiSearchTools": ["web_search", "x_search"]
+}
+```
+
+The value must be a non-empty array containing each of `web_search` and `x_search` at most once. This intentionally does not expose per-call X handle, date, or media-understanding parameters until their request contract is stable. `recencyFilter`, `domainFilter`, and `numResults` remain prompt guidance rather than tool parameters, so an unrecognized field cannot turn a search into a 400. Sources are read in annotation-first order from `url_citation` annotations, raw `web_search_call`/`x_search_call` source lists when present, and xAI's response-level `citations` URL list.
 
 xAI's older Live Search (`search_parameters` on `/v1/chat/completions`) is deprecated and now answers HTTP 410.
 
@@ -934,7 +944,7 @@ Rate limits: Perplexity is capped at 10 requests/minute (client-side). Jina Sear
 | `anysearch.ts` | Explicit-only AnySearch search provider |
 | `xcrawl.ts` | Explicit-only XCrawl search provider |
 | `valyu.ts` | Explicit-only Valyu research search provider |
-| `xai-search.ts` | Explicit-only xAI (Grok) hosted web_search provider |
+| `xai-search.ts` | Explicit-only xAI (Grok) hosted web/X search provider |
 | `kimi-search.ts` | Explicit-only Kimi Code Plan search provider |
 | `searxng.ts` | Self-hosted SearXNG JSON API search provider |
 | `duckduckgo.ts` | Explicit-only keyless DuckDuckGo HTML search provider |

--- a/test/xai-provider.test.mjs
+++ b/test/xai-provider.test.mjs
@@ -31,10 +31,8 @@ function runChild(script, env) {
 	});
 }
 
-// The shape a live SuperGrok account actually returns: sources are split across
-// `url_citation` annotations on the answer and the raw `web_search_call` sources.
-// There is deliberately no top-level `citations` array — reading one is the bug
-// this fixture exists to catch.
+// Responses API sources are split across `url_citation` annotations on the
+// answer, raw search-call sources, and the response-level citations URL list.
 function successBody() {
 	return JSON.stringify({
 		output: [
@@ -48,11 +46,45 @@ function successBody() {
 				}],
 			},
 		],
-		citations: ["https://wrong.example.com/never-read-this"],
+		citations: ["https://x.ai/news/grok-imagine", "https://x.ai/citation-only"],
 	});
 }
 
-test("xAI posts the verified minimal Responses body and reads both source shapes", async () => {
+function xSearchBody() {
+	return JSON.stringify({
+		output: [
+			{
+				type: "x_search_call",
+				action: {
+					sources: [
+						{ url: "https://x.com/i/status/raw", title: "Raw X post" },
+						{ url: "https://x.com/i/status/annotated", title: "Raw duplicate" },
+						{ ignored: true },
+					],
+				},
+				sources: ["https://x.com/i/status/source-string"],
+			},
+			{
+				type: "message",
+				content: [{
+					type: "output_text",
+					text: "People are discussing the release on X.",
+					annotations: [
+						{ type: "url_citation", url: "https://x.com/i/status/annotated", title: "Annotated X post", start_index: 0, end_index: 6 },
+						{ type: "url_citation", url: "https://x.com/i/status/answer", title: "Answer citation", start_index: 7, end_index: 15 },
+					],
+				}],
+			},
+		],
+		citations: [
+			"https://x.com/i/status/citation-only",
+			{ url: "https://x.com/i/status/citation-object", title: "Citation object" },
+			42,
+		],
+	});
+}
+
+test("xAI posts the verified minimal Responses body and reads citation source shapes", async () => {
 	const home = await createHome({ xaiApiKey: "xai-key" });
 	const child = runChild(`
 		let captured;
@@ -78,10 +110,37 @@ test("xAI posts the verified minimal Responses body and reads both source shapes
 	assert.match(captured.body.input, /what shipped\?$/);
 
 	assert.match(result.answer, /Grok Imagine v1\.5 shipped/);
-	// Annotations carry titles, so they win the dedupe and come first; the
-	// web_search_call sources fill in what they missed.
-	assert.deepEqual(result.results.map((r) => r.url), ["https://x.ai/news/grok-imagine", "https://x.ai/news"]);
+	// Annotations carry titles, so they win the dedupe and come first; raw
+	// sources and response-level citations fill in what they missed.
+	assert.deepEqual(result.results.map((r) => r.url), ["https://x.ai/news/grok-imagine", "https://x.ai/news", "https://x.ai/citation-only"]);
 	assert.equal(result.results[0].title, "Grok Imagine");
+});
+
+test("xAI opts into web and X tools and keeps annotation sources first", async () => {
+	const home = await createHome({ xaiApiKey: "xai-key", xaiSearchTools: ["web_search", "x_search"] });
+	const child = runChild(`
+		let captured;
+		globalThis.fetch = async (_url, init) => { captured = JSON.parse(init.body); return new Response(${JSON.stringify(xSearchBody())}, { status: 200 }); };
+		const { searchWithXai } = await import(${JSON.stringify(xaiModuleUrl)});
+		const result = await searchWithXai("what are people saying?");
+		console.log(JSON.stringify({ captured, result }));
+	`, { PI_CODING_AGENT_DIR: home });
+	assert.equal(child.status, 0, child.stderr);
+	const { captured, result } = JSON.parse(child.stdout.trim());
+
+	assert.equal(captured.model, "grok-4.6");
+	assert.deepEqual(captured.tools, [{ type: "web_search" }, { type: "x_search" }]);
+	assert.match(captured.input, /Search the web and X/);
+	assert.deepEqual(result.results.map((r) => r.url), [
+		"https://x.com/i/status/annotated",
+		"https://x.com/i/status/answer",
+		"https://x.com/i/status/raw",
+		"https://x.com/i/status/source-string",
+		"https://x.com/i/status/citation-only",
+		"https://x.com/i/status/citation-object",
+	]);
+	assert.equal(result.results[0].title, "Annotated X post");
+	assert.equal(result.results.at(-1).title, "Citation object");
 });
 
 test("xAI folds recency and domain filters into the prompt rather than tool params", async () => {
@@ -102,10 +161,10 @@ test("xAI folds recency and domain filters into the prompt rather than tool para
 	assert.match(body.input, /around 4 distinct sources/);
 });
 
-// The registry path survives model retirement by walking AUTH_MODEL_CANDIDATES
-// against models pi actually knows. The api-key path can't — nothing tells it
-// which ids are live — so `xaiSearchModel` is its escape hatch, the same one
-// `openaiSearchModel` gives the OpenAI backend.
+// The registry path survives model retirement by walking the appropriate
+// model-candidate list against models pi actually knows. The api-key path
+// can't — nothing tells it which ids are live — so `xaiSearchModel` is its
+// escape hatch, the same one `openaiSearchModel` gives the OpenAI backend.
 test("xaiSearchModel pins the model id on the api-key path", async () => {
 	const home = await createHome({ xaiApiKey: "xai-key", xaiSearchModel: "  grok-5  " });
 	const child = runChild(`
@@ -149,6 +208,41 @@ test("a non-string or empty xaiSearchModel is rejected rather than silently igno
 		const { threw, message } = JSON.parse(child.stdout.trim());
 		assert.equal(threw, true, `xaiSearchModel ${JSON.stringify(bad)} should be rejected`);
 		assert.match(message, /xaiSearchModel .* must be a non-empty string/);
+	}
+});
+
+test("xaiSearchTools is validated and may opt into X-only search", async () => {
+	const home = await createHome({ xaiApiKey: "xai-key", xaiSearchTools: ["x_search"] });
+	const child = runChild(`
+		let captured;
+		globalThis.fetch = async (_url, init) => { captured = JSON.parse(init.body); return new Response(${JSON.stringify(xSearchBody())}, { status: 200 }); };
+		const { searchWithXai } = await import(${JSON.stringify(xaiModuleUrl)});
+		const result = await searchWithXai("x only");
+		console.log(JSON.stringify({ captured, result }));
+	`, { PI_CODING_AGENT_DIR: home });
+	assert.equal(child.status, 0, child.stderr);
+	const { captured } = JSON.parse(child.stdout.trim());
+	assert.deepEqual(captured.tools, [{ type: "x_search" }]);
+	assert.match(captured.input, /^Search X and answer/);
+
+	for (const bad of [null, "x_search", [], ["x_search", "x_search"], ["x_search", "unknown"], ["web_search", 42]]) {
+		const badHome = await createHome({ xaiApiKey: "xai-key", xaiSearchTools: bad });
+		const badChild = runChild(`
+			globalThis.fetch = async () => { throw new Error("must not reach the network"); };
+			const { isXaiSearchAvailable, searchWithXai } = await import(${JSON.stringify(xaiModuleUrl)});
+			const available = await isXaiSearchAvailable();
+			try {
+				await searchWithXai("bad tools");
+				console.log(JSON.stringify({ available, threw: false }));
+			} catch (err) {
+				console.log(JSON.stringify({ available, threw: true, message: err.message }));
+			}
+		`, { PI_CODING_AGENT_DIR: badHome });
+		assert.equal(badChild.status, 0, badChild.stderr);
+		const { available, threw, message } = JSON.parse(badChild.stdout.trim());
+		assert.equal(available, false, `xaiSearchTools ${JSON.stringify(bad)} should only make xAI unavailable`);
+		assert.equal(threw, true, `xaiSearchTools ${JSON.stringify(bad)} should be rejected`);
+		assert.match(message, /xaiSearchTools .* (?:non-empty array|web_search or x_search|duplicates)/);
 	}
 });
 

--- a/xai-search.ts
+++ b/xai-search.ts
@@ -5,8 +5,8 @@ import type { SearchOptions, SearchResponse, SearchResult } from "./perplexity.t
 import { hasCredentialSource, redactCredential, resolveCredential } from "./credential-source.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
 
-// xAI's Agent Tools API: a hosted `web_search` tool on an OpenAI-compatible
-// Responses endpoint. The search runs inside xAI's own inference, so — unlike
+// xAI's Agent Tools API: hosted `web_search` and opt-in `x_search` tools on an
+// OpenAI-compatible Responses endpoint. The search runs inside xAI's own inference, so — unlike
 // every keyed backend here — it is paid for by whatever credential answers for
 // the model, including a SuperGrok / X Premium subscription resolved through
 // pi's model registry.
@@ -19,8 +19,8 @@ import { getWebSearchConfigPath } from "./utils.ts";
 // is the shape verified against a live subscription account. `stream`,
 // `include`, `tool_choice` and `parallel_tool_calls` are all sent by the OpenAI
 // backend but were NOT verified here, and a 400 from an unsupported field would
-// cost the user their search. Sources come back in `web_search_call.action.sources`
-// without asking for them via `include`.
+// cost the user their search. Responses API inline citations are enabled by
+// default; sources may also come back in a search call's `action.sources`.
 
 const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
 const CONFIG_PATH = getWebSearchConfigPath();
@@ -29,11 +29,19 @@ const SEARCH_TIMEOUT_MS = 60_000;
 // Ordered best-first. pi's builtin xai catalog is small and xAI retires models
 // briskly, so this is a preference list, not an assumption: the first one the
 // registry actually knows wins, and an unknown id is skipped rather than sent.
-const AUTH_MODEL_CANDIDATES = ["grok-4.5", "grok-4.3", "grok-build-0.1"] as const;
+// xAI's current X Search docs use grok-4.6. Keep the existing web-only default
+// unchanged, while preferring the documented model when X Search is opted in.
+const WEB_SEARCH_AUTH_MODEL_CANDIDATES = ["grok-4.5", "grok-4.3", "grok-build-0.1"] as const;
+const X_SEARCH_AUTH_MODEL_CANDIDATES = ["grok-4.6", ...WEB_SEARCH_AUTH_MODEL_CANDIDATES] as const;
+
+const XAI_SEARCH_TOOL_NAMES = ["web_search", "x_search"] as const;
+type XaiSearchTool = typeof XAI_SEARCH_TOOL_NAMES[number];
+const DEFAULT_XAI_SEARCH_TOOLS = ["web_search"] as const satisfies readonly XaiSearchTool[];
 
 interface WebSearchConfig {
 	xaiApiKey?: unknown;
 	xaiSearchModel?: unknown;
+	xaiSearchTools?: unknown;
 }
 
 type ProviderHeaders = Record<string, string | null>;
@@ -71,6 +79,30 @@ function resolveConfiguredSearchModel(value: unknown): string | undefined {
 	return value.trim();
 }
 
+function resolveConfiguredSearchTools(value: unknown): XaiSearchTool[] {
+	if (value === undefined) return [...DEFAULT_XAI_SEARCH_TOOLS];
+	if (!Array.isArray(value) || value.length === 0) {
+		throw new Error(`xaiSearchTools in ${CONFIG_PATH} must be a non-empty array containing only web_search or x_search`);
+	}
+
+	const tools: XaiSearchTool[] = [];
+	for (const tool of value) {
+		if (typeof tool !== "string" || !XAI_SEARCH_TOOL_NAMES.includes(tool as XaiSearchTool)) {
+			throw new Error(`xaiSearchTools in ${CONFIG_PATH} may only contain web_search or x_search`);
+		}
+		const toolName = tool as XaiSearchTool;
+		if (tools.includes(toolName)) {
+			throw new Error(`xaiSearchTools in ${CONFIG_PATH} must not contain duplicates: ${toolName}`);
+		}
+		tools.push(toolName);
+	}
+	return tools;
+}
+
+function modelCandidatesForTools(tools: readonly XaiSearchTool[]): readonly string[] {
+	return tools.includes("x_search") ? X_SEARCH_AUTH_MODEL_CANDIDATES : WEB_SEARCH_AUTH_MODEL_CANDIDATES;
+}
+
 function toRequestHeaders(headers: ProviderHeaders): Record<string, string> {
 	const requestHeaders: Record<string, string> = {};
 	for (const [name, value] of Object.entries(headers)) {
@@ -84,8 +116,12 @@ function toRequestHeaders(headers: ProviderHeaders): Record<string, string> {
  * its own searches and no api key has to be configured at all. Mirrors how the
  * OpenAI backend picks up a Codex sign-in.
  */
-async function resolvePiAuth(ctx: ExtensionContext, modelOverride?: string): Promise<XaiAuth | undefined> {
-	for (const modelId of AUTH_MODEL_CANDIDATES) {
+async function resolvePiAuth(
+	ctx: ExtensionContext,
+	modelOverride: string | undefined,
+	tools: readonly XaiSearchTool[],
+): Promise<XaiAuth | undefined> {
+	for (const modelId of modelCandidatesForTools(tools)) {
 		try {
 			const model = ctx.modelRegistry.find("xai", modelId);
 			if (!model) continue;
@@ -102,8 +138,9 @@ async function resolvePiAuth(ctx: ExtensionContext, modelOverride?: string): Pro
 export async function resolveXaiAuth(ctx?: ExtensionContext, signal?: AbortSignal): Promise<XaiAuth | undefined> {
 	const config = loadConfig();
 	const modelOverride = resolveConfiguredSearchModel(config.xaiSearchModel);
+	const tools = resolveConfiguredSearchTools(config.xaiSearchTools);
 	if (ctx) {
-		const auth = await resolvePiAuth(ctx, modelOverride);
+		const auth = await resolvePiAuth(ctx, modelOverride, tools);
 		if (auth) return auth;
 	}
 
@@ -119,12 +156,19 @@ export async function resolveXaiAuth(ctx?: ExtensionContext, signal?: AbortSigna
 		environmentValue: process.env.XAI_API_KEY,
 		signal,
 	});
-	return apiKey ? { apiKey, model: modelOverride ?? AUTH_MODEL_CANDIDATES[0], headers: {} } : undefined;
+	return apiKey ? { apiKey, model: modelOverride ?? modelCandidatesForTools(tools)[0], headers: {} } : undefined;
 }
 
 export async function isXaiSearchAvailable(ctx?: ExtensionContext): Promise<boolean> {
-	if (ctx && await resolvePiAuth(ctx)) return true;
-	const config = loadConfig();
+	let config: WebSearchConfig;
+	let tools: XaiSearchTool[];
+	try {
+		config = loadConfig();
+		tools = resolveConfiguredSearchTools(config.xaiSearchTools);
+	} catch {
+		return false;
+	}
+	if (ctx && await resolvePiAuth(ctx, undefined, tools)) return true;
 	return hasCredentialSource({
 		provider: "xAI",
 		configuredValue: config.xaiApiKey,
@@ -153,9 +197,17 @@ function normalizeDomain(value: string): string | null {
  * an unknown field risks a 400 that costs the whole search; steering through
  * the instruction text degrades to "the model ignored it" instead.
  */
-function buildInput(query: string, options: SearchOptions): string {
+function buildInput(query: string, options: SearchOptions, tools: readonly XaiSearchTool[]): string {
+	let searchInstruction: string;
+	if (tools.includes("x_search") && tools.includes("web_search")) {
+		searchInstruction = "Search the web and X and answer using only what the search results say.";
+	} else if (tools.includes("x_search")) {
+		searchInstruction = "Search X and answer using only what the X results say.";
+	} else {
+		searchInstruction = "Search the web and answer using only what the web results say.";
+	}
 	const lines = [
-		"Search the web and answer using only what the web results say.",
+		searchInstruction,
 		"Cite your sources inline.",
 	];
 
@@ -198,6 +250,21 @@ function addResult(results: SearchResult[], seen: Set<string>, url: unknown, tit
 	});
 }
 
+function addSource(results: SearchResult[], seen: Set<string>, source: unknown): void {
+	if (typeof source === "string") {
+		addResult(results, seen, source, undefined);
+		return;
+	}
+	if (!source || typeof source !== "object") return;
+	const record = source as Record<string, unknown>;
+	addResult(results, seen, record.url ?? record.source_website_url, record.title ?? record.caption);
+}
+
+function addSources(results: SearchResult[], seen: Set<string>, sources: unknown): void {
+	if (!Array.isArray(sources)) return;
+	for (const source of sources) addSource(results, seen, source);
+}
+
 function extractSnippetAround(text: string, start: unknown, end: unknown): string {
 	if (typeof start !== "number" || typeof end !== "number" || !text) return "";
 	const before = Math.max(0, start - 100);
@@ -222,13 +289,13 @@ function extractAnswer(output: unknown[]): string {
 }
 
 /**
- * Sources live in two places and neither is a top-level `citations` array:
- * `url_citation` annotations on the answer text (these carry titles and offsets,
- * so they go first and win the dedupe), and the raw `sources` each
- * `web_search_call` visited. A third-party extension that reads `data.citations`
- * silently returns answers with no sources at all — hence both paths here.
+ * Keep annotation sources first because they carry titles and offsets and must
+ * win URL deduplication. Raw source lists from web/X search calls are next,
+ * followed by xAI's response-level `citations` URL list. The latter is usually
+ * strings, but object entries are tolerated when a compatible gateway adds
+ * metadata.
  */
-function extractSearchResults(output: unknown[], numResults: number | undefined): SearchResult[] {
+function extractSearchResults(output: unknown[], citations: unknown, numResults: number | undefined): SearchResult[] {
 	const results: SearchResult[] = [];
 	const seenUrls = new Set<string>();
 
@@ -256,20 +323,17 @@ function extractSearchResults(output: unknown[], numResults: number | undefined)
 	}
 
 	for (const item of output) {
-		if (!item || typeof item !== "object" || (item as { type?: unknown }).type !== "web_search_call") continue;
+		if (!item || typeof item !== "object") continue;
+		const type = (item as { type?: unknown }).type;
+		if (type !== "web_search_call" && type !== "x_search_call") continue;
 		const value = item as { action?: unknown; sources?: unknown; results?: unknown };
 		const actionSources = value.action && typeof value.action === "object"
 			? (value.action as { sources?: unknown }).sources
 			: undefined;
-		for (const group of [actionSources, value.sources, value.results]) {
-			if (!Array.isArray(group)) continue;
-			for (const source of group) {
-				if (!source || typeof source !== "object") continue;
-				const record = source as Record<string, unknown>;
-				addResult(results, seenUrls, record.url ?? record.source_website_url, record.title ?? record.caption);
-			}
-		}
+		for (const group of [actionSources, value.sources, value.results]) addSources(results, seenUrls, group);
 	}
+
+	addSources(results, seenUrls, citations);
 
 	if (typeof numResults === "number" && Number.isFinite(numResults) && numResults > 0) {
 		return results.slice(0, Math.min(Math.floor(numResults), 20));
@@ -282,10 +346,11 @@ export async function searchWithXai(
 	options: SearchOptions = {},
 	ctx?: ExtensionContext,
 ): Promise<SearchResponse> {
+	const tools = resolveConfiguredSearchTools(loadConfig().xaiSearchTools);
 	const auth = await resolveXaiAuth(ctx, options.signal);
 	if (!auth) {
 		throw new Error(
-			"xAI web search unavailable. Either:\n" +
+			"xAI search unavailable. Either:\n" +
 			"  1. Use /login to sign in with a SuperGrok or X Premium subscription\n" +
 			`  2. Create ${CONFIG_PATH} with { "xaiApiKey": "your-key" }\n` +
 			"  3. Set XAI_API_KEY environment variable",
@@ -303,8 +368,8 @@ export async function searchWithXai(
 			},
 			body: JSON.stringify({
 				model: auth.model,
-				input: buildInput(query, options),
-				tools: [{ type: "web_search" }],
+				input: buildInput(query, options, tools),
+				tools: tools.map((type) => ({ type })),
 			}),
 			signal: options.signal
 				? AbortSignal.any([AbortSignal.timeout(SEARCH_TIMEOUT_MS), options.signal])
@@ -326,10 +391,10 @@ export async function searchWithXai(
 		}
 		const output = Array.isArray(parsed.output) ? parsed.output : [];
 		const answer = extractAnswer(output);
-		const results = extractSearchResults(output, options.numResults);
+		const results = extractSearchResults(output, parsed.citations, options.numResults);
 
 		if (!answer && results.length === 0) {
-			throw new Error("xAI web_search returned no answer or sources");
+			throw new Error(`xAI ${tools.join("+")} returned no answer or sources`);
 		}
 
 		activityMonitor.logComplete(activityId, response.status);


### PR DESCRIPTION
Implements opt-in xAI X Search support for #342.

Changes:
- Adds validated `xaiSearchTools` config with default `[`"web_search"`]` so existing explicit `provider: "xai"` behavior remains web-only.
- Supports opt-in `[`"x_search"`]` and combined `[`"web_search", "x_search"`]` requests using the documented Responses-compatible Agent Tools names.
- Prefers the current docs' `grok-4.6` candidate when X Search is enabled, while keeping the existing web-only default model behavior unless `xaiSearchModel` pins a model.
- Parses `x_search_call` sources and response-level citations defensively after annotation sources, preserving annotation-first URL ordering and dedupe.
- Keeps xAI excluded from `auto` and `provider: "all"`.
- Documents privacy/billing implications, the opt-in config contract, and the unsupported deprecated Live Search path.
- Credits [@Jerry2003sky](https://github.com/Jerry2003sky) in the changelog.

Validation:
- `node --test test/xai-provider.test.mjs test/search-providers.test.mjs test/all-provider.test.mjs test/provider-precedence.test.mjs` — 61/61 passed.
- `npm test` — 649/649 passed in the writer lane.
- `npm run typecheck` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Deletion-first challenge found no safe deletion.
- Simplification cleanup amended the candidate and reran focused gates.
- Fresh exact-head review found no issues.

Residual API note: no live xAI account request was made in this lane. The request and citation behavior follow current xAI docs and are covered with mocked fixtures.

Closes #342.
