### PR TITLE
fix(web_search): surface the stored responseId so get_search_content is reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Surfaced the stored `responseId` in `web_search` output so the model can call `get_search_content` on search results; previously the id lived only in `details`, which the model never sees.
 - Retained citations referenced in Perplexity answers even when they fall beyond `numResults`, while preserving the result-count limit for answers without citation markers. Thanks to [@schlessera](https://github.com/schlessera) for issue #340 and PR #341.
 - Scoped configured proxy transport to web-tool operations so unrelated Pi requests retain their existing transport. Thanks to [@alexei-ciobanu](https://github.com/alexei-ciobanu) for PR #339 and [@mystery4f](https://github.com/mystery4f) for PR #343.
 - Cleaned stale GitHub clone runtime directories after a crashed process when the owner can be proven dead, while preserving runtimes with unknown or live owners. Thanks to [@yazanabuashour](https://github.com/yazanabuashour) for issue #331.

--- a/index.ts
+++ b/index.ts
@@ -1416,6 +1416,11 @@ export default function (pi: ExtensionAPI) {
 
 		const searchId = storeAndPublishSearch(opts.results);
 		const isBackgroundFetch = fetchId !== null && !hasInlineReady;
+		// The model only sees `content`, not `details`: surface the id it needs to
+		// call get_search_content, the same way fetch_content does.
+		if (getSearchContentEnabled && !hasApprovedSummary) {
+			output += `\n---\nResults stored as responseId "${searchId}". Use ${toolNames.getSearchContent}({ responseId: "${searchId}", queryIndex: 0 }) to retrieve them.`;
+		}
 
 		return {
 			content: [{ type: "text", text: output.trim() }],

--- a/test/web-search-response-id.test.mjs
+++ b/test/web-search-response-id.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const indexUrl = new URL("../index.ts", import.meta.url).href;
+
+// web_search and get_search_content are exercised through the real tool
+// objects in a child process with an isolated config dir and a mocked fetch.
+function runWebSearchThenRetrieve(config, { retrieveWith }) {
+	const dir = mkdtempSync(join(tmpdir(), "pi-web-access-response-id-"));
+	writeFileSync(join(dir, "web-search.json"), JSON.stringify(config));
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: `
+			globalThis.fetch = async (url) => {
+				if (String(url) !== "https://api.openai.com/v1/responses") throw new Error("Unexpected fetch: " + url);
+				return new Response(JSON.stringify({ output: [
+					{ type: "web_search_call", action: { sources: [{ title: "Source", url: "https://example.com/source" }] } },
+					{ type: "message", content: [{ type: "output_text", text: "Search answer" }] },
+				] }), { status: 200, headers: { "content-type": "application/json" } });
+			};
+			const tools = [];
+			const handlers = new Map();
+			const pi = {
+				registerTool(tool) { tools.push(tool); },
+				registerCommand() {}, registerShortcut() {},
+				on(event, handler) { handlers.set(event, handler); },
+				appendEntry() {}, sendMessage() {},
+			};
+			const initializeExtension = (await import(${JSON.stringify(indexUrl)})).default;
+			initializeExtension(pi);
+			await handlers.get("session_start")({}, { sessionManager: { getBranch: () => [] } });
+			const search = tools.find((t) => t.name === "web_search");
+			const result = await search.execute("t", { query: "response id", provider: "openai", workflow: "none" });
+			const text = result.content[0].text;
+			const retrieve = tools.find((t) => t.name === "get_search_content");
+			let retrieved = null;
+			if (retrieve) {
+				const id = ${retrieveWith};
+				const r = await retrieve.execute("t2", { responseId: id, queryIndex: 0 });
+				retrieved = { isError: r.isError ?? false, text: r.content[0].text };
+			}
+			console.log(JSON.stringify({ text, searchId: result.details.searchId, retrieved, hasRetrieveTool: Boolean(retrieve) }));
+		`,
+		encoding: "utf8",
+		timeout: 30_000,
+		env: { ...process.env, PI_CODING_AGENT_DIR: dir, OPENAI_API_KEY: "response-id-test-key" },
+	});
+	assert.equal(child.status, 0, child.stderr);
+	return JSON.parse(child.stdout.trim().split("\n").at(-1));
+}
+
+test("web_search output tells the model the responseId that get_search_content accepts", () => {
+	// Parse the id out of the human-readable output, exactly as a model would.
+	const out = runWebSearchThenRetrieve({ provider: "openai" }, {
+		retrieveWith: `text.match(/responseId "([^"]+)"/)[1]`,
+	});
+	assert.ok(out.hasRetrieveTool);
+	assert.match(out.text, /Results stored as responseId "[a-z0-9]+"\. Use get_search_content\(\{ responseId: "[a-z0-9]+", queryIndex: 0 \}\)/);
+	assert.equal(out.text.match(/responseId "([^"]+)"/)[1], out.searchId, "printed id must be the stored searchId");
+	assert.equal(out.retrieved.isError, false, out.retrieved.text);
+	assert.match(out.retrieved.text, /Search answer|example\.com\/source/);
+});
+
+test("web_search output honours a renamed get_search_content tool", () => {
+	const out = runWebSearchThenRetrieve(
+		{ provider: "openai", toolNames: { getSearchContent: "grab_content" } },
+		{ retrieveWith: `null` },
+	);
+	assert.match(out.text, /Use grab_content\(\{ responseId: "/);
+	assert.doesNotMatch(out.text, /get_search_content\(/);
+});
+
+test("web_search output omits the retrieval hint when get_search_content is disabled", () => {
+	const out = runWebSearchThenRetrieve(
+		{ provider: "openai", tools: { getSearchContent: { enabled: false } } },
+		{ retrieveWith: `null` },
+	);
+	assert.equal(out.hasRetrieveTool, false);
+	assert.doesNotMatch(out.text, /responseId/);
+	assert.ok(out.searchId, "results are still stored in details");
+});

--- a/test/web-search-response-id.test.mjs
+++ b/test/web-search-response-id.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -11,6 +11,14 @@ const indexUrl = new URL("../index.ts", import.meta.url).href;
 // objects in a child process with an isolated config dir and a mocked fetch.
 function runWebSearchThenRetrieve(config, { retrieveWith }) {
 	const dir = mkdtempSync(join(tmpdir(), "pi-web-access-response-id-"));
+	try {
+		return runInConfigDir(dir, config, retrieveWith);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+function runInConfigDir(dir, config, retrieveWith) {
 	writeFileSync(join(dir, "web-search.json"), JSON.stringify(config));
 	const child = spawnSync(process.execPath, ["--input-type=module"], {
 		input: `


### PR DESCRIPTION
**Found**
- `web_search` stores results under `searchId` but returns it only in `details`, which the model never sees. The output text prints no id (with `includeContent: true` it prints the *fetchId*, a different store).
- `get_search_content` has a full `type === "search"` branch (`query` / `queryIndex`) and its not-found message says "use a responseId returned by web_search" — but nothing ever tells the model that id.
- Observed live: the model guessed `responseId: "latest"` → `No stored results`.

**Fixed**
- Append one line to `web_search` output, mirroring what `fetch_content` already does:
  `Results stored as responseId "<id>". Use get_search_content({ responseId: "<id>", queryIndex: 0 }) to retrieve them.`
- Honours `toolNames.getSearchContent`; omitted when that tool is disabled or when an approved curator summary replaces the raw output.

**Verified**
- New `test/web-search-response-id.test.mjs` (3): printed id === stored `searchId` and retrieval with it succeeds; renamed tool is respected; hint omitted when disabled.
- All 12 existing test files touching `web_search` + `get-search-content`: 89/89.
- `tsc` clean. CHANGELOG entry under Unreleased → Fixed.
