### PR TITLE
test: fix Node startup races and credit contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Improved Node-startup race test reliability by widening cold-boot test timeouts. Thanks to [@axelbaumlisto](https://github.com/axelbaumlisto) for PR #353.
 - Retained citations referenced in Perplexity answers even when they fall beyond `numResults`, while preserving the result-count limit for answers without citation markers. Thanks to [@schlessera](https://github.com/schlessera) for issue #340 and PR #341.
 - Scoped configured proxy transport to web-tool operations so unrelated Pi requests retain their existing transport. Thanks to [@alexei-ciobanu](https://github.com/alexei-ciobanu) for PR #339 and [@mystery4f](https://github.com/mystery4f) for PR #343.
 - Cleaned stale GitHub clone runtime directories after a crashed process when the owner can be proven dead, while preserving runtimes with unknown or live owners. Thanks to [@yazanabuashour](https://github.com/yazanabuashour) for issue #331.

--- a/test/config-path.test.mjs
+++ b/test/config-path.test.mjs
@@ -254,8 +254,10 @@ test("Gemini command source is lazy, overrides stale env, rotates, and uses head
 		const { isGeminiApiAvailable, queryGeminiApiWithVideo } = await import(${JSON.stringify(geminiApiUrl)});
 		const available = isGeminiApiAvailable();
 		const lazy = !existsSync(${JSON.stringify(counterPath)});
-		await queryGeminiApiWithVideo("first", "files/one", { timeoutMs: 1000 });
-		await queryGeminiApiWithVideo("second", "files/two", { timeoutMs: 1000 });
+		// fetch is mocked, so timeoutMs only bounds the two "!command" shell spawns;
+		// keep it generous so a slow CI host cannot abort credential resolution.
+		await queryGeminiApiWithVideo("first", "files/one", { timeoutMs: 15_000 });
+		await queryGeminiApiWithVideo("second", "files/two", { timeoutMs: 15_000 });
 		console.log(JSON.stringify({ available, lazy, requests }));
 	`, {
 		PI_CODING_AGENT_DIR: agentDir,

--- a/test/github-extract.test.mjs
+++ b/test/github-extract.test.mjs
@@ -971,7 +971,8 @@ test("GitHub clone timeout force-kills the SIGTERM-resistant process group", { s
 			console.log(JSON.stringify(result));
 		`,
 		encoding: "utf8",
-		timeout: 10000,
+		// Allow the clone timeout, kill grace, and cold Node/fake gh startups.
+		timeout: 15_000,
 		env: {
 			...process.env,
 			CLONE_PROCESS_PID_FILE: processPidFile,

--- a/test/github-extract.test.mjs
+++ b/test/github-extract.test.mjs
@@ -875,7 +875,9 @@ test("GitHub clones disable interactive credential prompts", { skip: process.pla
 	await mkdir(binDir, { recursive: true });
 	await writeFile(
 		join(agentDir, "web-search.json"),
-		JSON.stringify({ githubClone: { clonePath, cloneTimeoutSeconds: 1 } }),
+		// Not a timeout test: the fake git (a Node shim) must *finish* its fake
+		// clone. Give it room for a cold Node boot on a slow CI host.
+		JSON.stringify({ githubClone: { clonePath, cloneTimeoutSeconds: 4 } }),
 		"utf8",
 	);
 	await writeFakeExecutable(binDir, "gh", "process.exit(1);");
@@ -930,7 +932,10 @@ test("GitHub clone timeout force-kills the SIGTERM-resistant process group", { s
 	await mkdir(binDir, { recursive: true });
 	await writeFile(
 		join(agentDir, "web-search.json"),
-		JSON.stringify({ githubClone: { clonePath: join(root, "repos"), cloneTimeoutSeconds: 0.5 } }),
+		// The fake git is a "#!/usr/bin/env node" shim: the timeout must outlast a
+		// cold Node boot on a slow CI host, or the tree is killed before the shim
+		// has recorded its pids (ENOENT below). 3 s is still a fast test.
+		JSON.stringify({ githubClone: { clonePath: join(root, "repos"), cloneTimeoutSeconds: 3 } }),
 		"utf8",
 	);
 	await writeFakeExecutable(binDir, "gh", "process.exit(1);");
@@ -939,17 +944,20 @@ test("GitHub clone timeout force-kills the SIGTERM-resistant process group", { s
 		"git",
 		`
 			const { spawn } = require("node:child_process");
+			const { writeFileSync } = require("node:fs");
 			process.on("SIGTERM", () => {});
 			const helperSource = ${JSON.stringify(`
-				const { writeFileSync } = require("node:fs");
 				process.on("SIGTERM", () => {});
-				writeFileSync(process.env.CLONE_PROCESS_PID_FILE, JSON.stringify({
-					rootPid: process.ppid,
-					helperPid: process.pid,
-				}));
 				setInterval(() => {}, 1000);
 			`)};
-			spawn(process.execPath, ["-e", helperSource], { stdio: "ignore" });
+			const helper = spawn(process.execPath, ["-e", helperSource], { stdio: "ignore" });
+			// Record both pids from the parent, synchronously after spawn: the helper's
+			// pid exists before its Node runtime boots, so the pid file is guaranteed to
+			// be present even if the clone timeout fires before the helper is ready.
+			writeFileSync(process.env.CLONE_PROCESS_PID_FILE, JSON.stringify({
+				rootPid: process.pid,
+				helperPid: helper.pid,
+			}));
 			setInterval(() => {}, 1000);
 		`,
 	);

--- a/test/github-extract.test.mjs
+++ b/test/github-extract.test.mjs
@@ -905,7 +905,9 @@ test("GitHub clones disable interactive credential prompts", { skip: process.pla
 			console.log(JSON.stringify(result !== null));
 		`,
 		encoding: "utf8",
-		timeout: 5000,
+		// Outer budget must cover child Node boot + fake gh probe boot + fake git boot
+		// + the 4 s clone ceiling with real margin (each shim boot is ~1 s on a loaded host).
+		timeout: 15_000,
 		env: {
 			...process.env,
 			CLONE_ENV_FILE: envFile,


### PR DESCRIPTION
Preserves @axelbaumlisto's PR #353 commits unchanged and adds linked contributor credit in `CHANGELOG.md`. The maintainer delta is documentation only; the original fork is not modified.

The tests now allow cold Node startup without prematurely timing out. The clone-timeout fixture records both process IDs from the parent, preserving the process-tree cleanup assertions.

Initial exact-head review, a separate cleanup pass, and fresh final review found no issues. The focused 27-test suite passes. Full local test and typecheck results are recorded in the publication gate; this repository has no configured test Actions workflow. Greptile is checked separately on the published head before landing.

Thanks to [@axelbaumlisto](https://github.com/axelbaumlisto) for the implementation and regression coverage. Original commits: `87bfa5f`, `2e5b37c`. Supersedes #353; no release or tag is part of this change.
