### PR TITLE
Add optional pdf.outputDir config for PDF extraction output path

### DIFF
--- a/extract.ts
+++ b/extract.ts
@@ -1234,7 +1234,10 @@ async function extractViaHttp(
 			try {
 				const buffer = await readPDFResponseBuffer(response, pdfConfig.maxSizeMB);
 				if (signal?.aborted) return abortedResult(url);
-				const result = await extractPDFToMarkdown(buffer, url, { signal });
+				const result = await extractPDFToMarkdown(buffer, url, {
+				signal,
+				outputDir: pdfConfig.outputDir,
+			});
 				activityMonitor.logComplete(activityId, response.status);
 				return {
 					url,

--- a/pdf-extract.ts
+++ b/pdf-extract.ts
@@ -55,6 +55,8 @@ export interface PDFConfig {
 	provider: PDFProvider;
 	datalabMode: DatalabMode;
 	datalabTimeoutMs: number;
+	/** Directory where extracted PDF markdown files are written. Defaults to a per-session temp directory. */
+	outputDir?: string;
 }
 
 export const DEFAULT_PDF_MAX_SIZE_MB = 20;
@@ -123,8 +125,13 @@ export function loadPDFConfig(): PDFConfig {
 		typeof configuredTimeout === "number" &&
 		Number.isFinite(configuredTimeout) &&
 		configuredTimeout > 0
-			? Math.min(configuredTimeout, MAX_DATALAB_TIMEOUT_MS)
-			: DEFAULT_DATALAB_TIMEOUT_MS;
+		? Math.min(configuredTimeout, MAX_DATALAB_TIMEOUT_MS)
+		: DEFAULT_DATALAB_TIMEOUT_MS;
+	const configuredOutputDir = pdf.outputDir;
+	const outputDir =
+		typeof configuredOutputDir === "string" && configuredOutputDir.trim()
+			? configuredOutputDir.trim()
+			: undefined;
 
 	return {
 		enabled,
@@ -133,6 +140,7 @@ export function loadPDFConfig(): PDFConfig {
 		provider,
 		datalabMode,
 		datalabTimeoutMs,
+		outputDir,
 	};
 }
 

--- a/test/pdf-config.test.mjs
+++ b/test/pdf-config.test.mjs
@@ -83,6 +83,16 @@ test("pdf.datalabTimeoutMs defaults to 120000 and caps at 300000", () => {
 	);
 });
 
+test("pdf.outputDir defaults to undefined and accepts trimmed string values", () => {
+	assert.equal(readConfig(undefined).outputDir, undefined);
+	assert.equal(
+		readConfig({ pdf: { outputDir: "  /tmp/out  " } }).outputDir,
+		"/tmp/out",
+	);
+	assert.equal(readConfig({ pdf: { outputDir: "   " } }).outputDir, undefined);
+	assert.equal(readConfig({ pdf: { outputDir: 42 } }).outputDir, undefined);
+});
+
 test("PDF streamed byte enforcement allows the exact limit", async () => {
 	const bytes = Uint8Array.from([1, 2]);
 	const maxSizeMB = bytes.byteLength / 1024 / 1024;


### PR DESCRIPTION
## Summary
PDF-to-markdown extraction always writes to a per-session temp directory, so the extracted files are gone after a restart. This adds an optional `pdf.outputDir` setting that controls where the markdown files are written.

## Config
```json
{ "pdf": { "outputDir": "/absolute/path/to/dir" } }
```
(placed in `web-search.json` next to the other `pdf.*` options)

## Behavior
- **Unset** (default): unchanged — per-session temp directory.
- **Set**: files are written to the given directory (created if missing); empty/whitespace strings are treated as unset. Non-strings are ignored.
- The `outputPath` reported back to the user already points to the real location, so no other code paths are affected.

## Tests
- New case in `test/pdf-config.test.mjs` covering default, trimmed value, whitespace-only, and non-string input.
- Full pdf test files pass (pdf-config, pdf-extract, datalab-pdf-extract, gemini-pdf-extract: 47 tests, 0 failures). `tsc` clean.