### PR TITLE
fix: use Pi agent directory for default web config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed no-environment web-search config lookup to use Pi's agent directory (`~/.pi/agent/web-search.json`) without implicitly falling back to the legacy `~/.pi/web-search.json`. Existing `PI_CODING_AGENT_DIR` and XDG compatibility behavior remain unchanged. Thanks to [@lJoublanc](https://github.com/lJoublanc) for issue #360.
+
 ## [0.28.0] - 2026-09-04
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 pi install npm:pi-web-access
 ```
 
-Works immediately with no API keys — Exa MCP provides zero-config search. If Pi has Codex auth from `/login`, OpenAI search can also work without a separate key. For more providers or direct API access, add keys to `~/.pi/web-search.json`:
+Works immediately with no API keys — Exa MCP provides zero-config search. If Pi has Codex auth from `/login`, OpenAI search can also work without a separate key. For more providers or direct API access, add keys to `~/.pi/agent/web-search.json`:
 
 ```json
 {
@@ -285,18 +285,18 @@ Env vars: `DATALAB_API_KEY` (or `datalabApiKey` in config), `DATALAB_PROCESSING_
 
 Raw and direct-image HTTP requests use the same SSRF validation, hostname domain policy, redirect checks, timeout, and 5MB streamed response bound as normal extraction. Raw mode returns textual bodies even for non-2xx responses and exposes the HTTP status in tool details; it does not run readability or hosted extraction fallbacks.
 
-`fetch_content` can opt into local browser-cookie auth with `auth: "profile"`, or `auth: true` when exactly one `authFetch` profile exists. Configure profiles in `~/.pi/web-search.json`, for example `{ "authFetch": { "social": ["x.com", "instagram.com"], "work": { "hosts": ["docs.company.com"], "chromeProfile": "Profile 2", "cache": "off" } } }`. Auth fetch uses only the local direct HTTP path, requires HTTPS, allows only configured hosts and their subdomains, refuses cross-origin redirects, and never sends cookies or authenticated content to hosted extraction providers. Browser cookie extraction remains opt-in through `allowBrowserCookies: true` or `PI_ALLOW_BROWSER_COOKIES=1`.
+`fetch_content` can opt into local browser-cookie auth with `auth: "profile"`, or `auth: true` when exactly one `authFetch` profile exists. Configure profiles in `~/.pi/agent/web-search.json`, for example `{ "authFetch": { "social": ["x.com", "instagram.com"], "work": { "hosts": ["docs.company.com"], "chromeProfile": "Profile 2", "cache": "off" } } }`. Auth fetch uses only the local direct HTTP path, requires HTTPS, allows only configured hosts and their subdomains, refuses cross-origin redirects, and never sends cookies or authenticated content to hosted extraction providers. Browser cookie extraction remains opt-in through `allowBrowserCookies: true` or `PI_ALLOW_BROWSER_COOKIES=1`.
 
 #### Proxy (`proxy`)
 
 `web_search`, `source_check`, and `fetch_content` all accept an optional `proxy` string (e.g. `"http://mcr:4444"`). When provided, every outbound HTTP(S) request is routed through `curl` instead of Node's built-in fetch — this works around Node fetch ignoring `HTTP(S)_PROXY` env vars and undici `ProxyAgent` failing the TLS handshake against several common HTTP proxies (ERR_SSL_WRONG_VERSION_NUMBER).
 
-An empty string (`""`) forces a direct connection even when a config-level proxy is set. Omitting the parameter falls back to the global `proxy` in `~/.pi/web-search.json`.
+An empty string (`""`) forces a direct connection even when a config-level proxy is set. Omitting the parameter falls back to the global `proxy` in `~/.pi/agent/web-search.json`.
 
 The config-level `proxy` applies only to requests made by this extension's tools. Other traffic in the host process — such as the coding agent's own model API calls — is never routed through it, so a configured proxy that is temporarily down cannot break unrelated requests.
 
 ```jsonc
-// ~/.pi/web-search.json — global proxy for all tools
+// ~/.pi/agent/web-search.json — global proxy for all tools
 {
   "proxy": "http://mcr:4444"
 }
@@ -345,7 +345,7 @@ Toggle or configure the curator workflow at runtime.
 /curator summary-review     # explicit workflow
 ```
 
-Persists to `~/.pi/web-search.json` and takes effect on the next `web_search` call. When disabled, `web_search` returns raw results without opening the curator window.
+Persists to `~/.pi/agent/web-search.json` and takes effect on the next `web_search` call. When disabled, `web_search` returns raw results without opening the curator window.
 
 ### /search
 
@@ -369,7 +369,7 @@ Toggle with **Ctrl+Shift+W** to see live request/response activity:
 
 ## Configuration
 
-Config defaults to `~/.pi/web-search.json`. `PI_CODING_AGENT_DIR` takes precedence when set; with `XDG_CONFIG_HOME`, an existing `XDG_CONFIG_HOME/pi/web-search.json` is preferred, an existing legacy `~/.pi/web-search.json` remains usable, and the XDG path is used as the new-config target when neither file exists. Every field is optional.
+Config defaults to `~/.pi/agent/web-search.json` when neither `PI_CODING_AGENT_DIR` nor `XDG_CONFIG_HOME` is set. `PI_CODING_AGENT_DIR` takes precedence when set; with `XDG_CONFIG_HOME`, an existing `XDG_CONFIG_HOME/pi/web-search.json` is preferred, an existing legacy `~/.pi/web-search.json` remains usable for compatibility, and the XDG path is used as the new-config target when neither file exists. The no-environment default does not fall back to the legacy root. Every field is optional.
 
 ```json
 {
@@ -912,7 +912,7 @@ When `false`, the extension never tries to open a Glimpse window or a browser an
 
 ### Shortcuts
 
-Both shortcuts are configurable via `~/.pi/web-search.json`:
+Both shortcuts are configurable via `~/.pi/agent/web-search.json`:
 
 ```json
 {

--- a/test/brightdata-serp.test.mjs
+++ b/test/brightdata-serp.test.mjs
@@ -12,12 +12,12 @@ const activityModuleUrl = new URL("../activity.ts", import.meta.url).href;
 
 // Every child starts from a config-less HOME. Deleting PI_CODING_AGENT_DIR and
 // XDG_CONFIG_HOME is not enough: getWebSearchConfigDir() then falls through to
-// join(homedir(), ".pi"), i.e. the developer's real ~/.pi/web-search.json — which is
-// exactly the file the README tells a reviewer to create. Without this, a maintainer
-// with brightdataApiKey configured sees unrelated failures, and if that key is a
-// `!command` source (`!op read …`, `!pass show …`) their secret manager is invoked by
-// `npm test`. Tests that need a config point PI_CODING_AGENT_DIR at a temp dir; the
-// two variables below only decide where "no config at all" resolves to.
+// join(homedir(), ".pi", "agent"), the Pi agent config directory. Without an
+// isolated HOME, a maintainer with brightdataApiKey configured sees unrelated
+// failures, and if that key is a `!command` source (`!op read …`, `!pass show …`)
+// their secret manager is invoked by `npm test`. Tests that need a config point
+// PI_CODING_AGENT_DIR at a temp dir; the two variables below only decide where
+// "no config at all" resolves to.
 const EMPTY_HOME = mkdtempSync(join(tmpdir(), "pi-web-access-brightdata-empty-"));
 
 function runChild(script, env = {}) {

--- a/test/brightdata-unlocker.test.mjs
+++ b/test/brightdata-unlocker.test.mjs
@@ -13,7 +13,7 @@ const brightdataModuleUrl = new URL(
 const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
 
 // Scrubbing the env vars is not enough on its own: a `brightdataApiKey` written
-// as an explicit `$VAR`/`!command` source in the real `~/.pi/web-search.json`
+// as an explicit `$VAR`/`!command` source in the real `~/.pi/agent/web-search.json`
 // overrides the environment by design, so a maintainer with one configured
 // would resolve their own credential (and run their own resolver command)
 // inside these tests. Every child therefore starts from an empty home unless a

--- a/test/config-path.test.mjs
+++ b/test/config-path.test.mjs
@@ -64,6 +64,37 @@ test("web-search config path uses PI_CODING_AGENT_DIR before XDG_CONFIG_HOME", a
 	});
 });
 
+test("web-search config path defaults to the Pi agent directory without a legacy fallback", async () => {
+	const root = await mkdtemp(join(tmpdir(), "pi-web-access-agent-config-path-"));
+	const home = join(root, "home");
+	const agentDir = join(home, ".pi", "agent");
+	await mkdir(agentDir, { recursive: true });
+	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify({ perplexityApiKey: "pplx-from-legacy" }) + "\n", "utf8");
+	await writeFile(join(agentDir, "web-search.json"), JSON.stringify({ geminiApiKey: "gemini-from-agent" }) + "\n", "utf8");
+
+	const child = runChild(`
+		const { getWebSearchConfigDir, getWebSearchConfigPath } = await import(${JSON.stringify(utilsUrl)});
+		const { isGeminiApiAvailable } = await import(${JSON.stringify(geminiApiUrl)});
+		console.log(JSON.stringify({
+			dir: getWebSearchConfigDir(),
+			path: getWebSearchConfigPath(),
+			available: isGeminiApiAvailable(),
+		}));
+	`, {
+		PI_CODING_AGENT_DIR: undefined,
+		XDG_CONFIG_HOME: undefined,
+		HOME: home,
+		USERPROFILE: home,
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	assert.deepEqual(JSON.parse(child.stdout), {
+		dir: agentDir,
+		path: join(agentDir, "web-search.json"),
+		available: true,
+	});
+});
+
 test("web-search config path uses XDG_CONFIG_HOME pi directory when agent dir is unset", async () => {
 	const root = await mkdtemp(join(tmpdir(), "pi-web-access-xdg-config-"));
 	const home = join(root, "home");

--- a/test/gemini-web-cookie-opt-in.test.mjs
+++ b/test/gemini-web-cookie-opt-in.test.mjs
@@ -123,8 +123,8 @@ test("browser cookie access is disabled unless explicitly allowed", async () => 
 	assert.equal(child.status, 0, child.stderr);
 	assert.equal(child.stdout.trim(), "false");
 
-	await mkdir(join(home, ".pi"), { recursive: true });
-	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify({ allowBrowserCookies: true }) + "\n", "utf8");
+	await mkdir(join(home, ".pi", "agent"), { recursive: true });
+	await writeFile(join(home, ".pi", "agent", "web-search.json"), JSON.stringify({ allowBrowserCookies: true }) + "\n", "utf8");
 
 	child = runCookieAccessCheck(home);
 	assert.equal(child.status, 0, child.stderr);
@@ -138,8 +138,8 @@ test("browser cookie access is disabled unless explicitly allowed", async () => 
 
 test("disabled browser cookie access does not validate legacy profile selection", async () => {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-cookie-legacy-disabled-"));
-	await mkdir(join(home, ".pi"), { recursive: true });
-	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify({ chromeProfile: "Profile 1" }) + "\n", "utf8");
+	await mkdir(join(home, ".pi", "agent"), { recursive: true });
+	await writeFile(join(home, ".pi", "agent", "web-search.json"), JSON.stringify({ chromeProfile: "Profile 1" }) + "\n", "utf8");
 
 	const child = runCookieAccessCheck(home);
 	assert.equal(child.status, 0, child.stderr);
@@ -148,8 +148,8 @@ test("disabled browser cookie access does not validate legacy profile selection"
 
 test("browser cookie config validates presets and rejects arbitrary profile paths", async () => {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-browser-cookie-config-"));
-	await mkdir(join(home, ".pi"), { recursive: true });
-	const configPath = join(home, ".pi", "web-search.json");
+	await mkdir(join(home, ".pi", "agent"), { recursive: true });
+	const configPath = join(home, ".pi", "agent", "web-search.json");
 	await writeFile(configPath, JSON.stringify({ browserCookies: { browser: "Helium", profile: "Profile 1" } }) + "\n", "utf8");
 
 	let child = runBrowserCookieConfig(home);

--- a/test/jina-search.test.mjs
+++ b/test/jina-search.test.mjs
@@ -42,8 +42,8 @@ const PROVIDER_ENV_KEYS = [
 
 async function createHome(config = {}) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-jina-search-"));
-	await mkdir(join(home, ".pi"), { recursive: true });
-	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	await mkdir(join(home, ".pi", "agent"), { recursive: true });
+	await writeFile(join(home, ".pi", "agent", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
 	return home;
 }
 
@@ -249,7 +249,7 @@ test("configured routing treats Jina's own timeout as transient rather than call
 	`, {
 		HOME: home,
 		USERPROFILE: home,
-		PI_CODING_AGENT_DIR: join(home, ".pi"),
+		PI_CODING_AGENT_DIR: join(home, ".pi", "agent"),
 		JINA_API_KEY: "synthetic-jina-test-key",
 		TAVILY_API_KEY: "synthetic-tavily-test-key",
 	});
@@ -292,7 +292,7 @@ test("configured routing treats a Jina response-body timeout as transient", asyn
 	`, {
 		HOME: home,
 		USERPROFILE: home,
-		PI_CODING_AGENT_DIR: join(home, ".pi"),
+		PI_CODING_AGENT_DIR: join(home, ".pi", "agent"),
 		JINA_API_KEY: "synthetic-jina-test-key",
 		TAVILY_API_KEY: "synthetic-tavily-test-key",
 	});
@@ -320,7 +320,7 @@ test("Jina envelope failures are recorded as activity errors", async () => {
 	`, {
 		HOME: home,
 		USERPROFILE: home,
-		PI_CODING_AGENT_DIR: join(home, ".pi"),
+		PI_CODING_AGENT_DIR: join(home, ".pi", "agent"),
 		JINA_API_KEY: "synthetic-jina-test-key",
 	});
 
@@ -353,7 +353,7 @@ test("configured routing preserves Jina envelope status codes", async () => {
 	`, {
 		HOME: home,
 		USERPROFILE: home,
-		PI_CODING_AGENT_DIR: join(home, ".pi"),
+		PI_CODING_AGENT_DIR: join(home, ".pi", "agent"),
 		JINA_API_KEY: "synthetic-jina-test-key",
 		TAVILY_API_KEY: "synthetic-tavily-test-key",
 	});
@@ -377,7 +377,7 @@ test("configured searchRouting can select Jina Search", async () => {
 		const { search } = await import(${JSON.stringify(searchModuleUrl)});
 		const result = await search("route", { provider: "auto" });
 		console.log(JSON.stringify({ provider: result.provider, results: result.results }));
-	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: join(home, ".pi"), JINA_API_KEY: "synthetic-jina-test-key" });
+	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: join(home, ".pi", "agent"), JINA_API_KEY: "synthetic-jina-test-key" });
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());

--- a/test/parallel.test.mjs
+++ b/test/parallel.test.mjs
@@ -11,9 +11,9 @@ const extractModuleUrl = new URL("../extract.ts", import.meta.url).href;
 
 async function createHome(config = {}) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-parallel-"));
-	await mkdir(join(home, ".pi"), { recursive: true });
+	await mkdir(join(home, ".pi", "agent"), { recursive: true });
 	await writeFile(
-		join(home, ".pi", "web-search.json"),
+		join(home, ".pi", "agent", "web-search.json"),
 		JSON.stringify(config) + "\n",
 		"utf8",
 	);

--- a/test/querit-provider.test.mjs
+++ b/test/querit-provider.test.mjs
@@ -39,9 +39,9 @@ const PROVIDER_ENV_KEYS = [
 
 async function createHome(config = {}) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-querit-"));
-	await mkdir(join(home, ".pi"), { recursive: true });
+	await mkdir(join(home, ".pi", "agent"), { recursive: true });
 	await writeFile(
-		join(home, ".pi", "web-search.json"),
+		join(home, ".pi", "agent", "web-search.json"),
 		JSON.stringify(config) + "\n",
 		"utf8",
 	);
@@ -409,7 +409,7 @@ test("configured search routing can select Querit", async () => {
 		{
 			HOME: home,
 			USERPROFILE: home,
-			PI_CODING_AGENT_DIR: join(home, ".pi"),
+			PI_CODING_AGENT_DIR: join(home, ".pi", "agent"),
 			QUERIT_API_KEY: "synthetic-querit-test-key",
 		},
 	);

--- a/test/search1api.test.mjs
+++ b/test/search1api.test.mjs
@@ -39,9 +39,9 @@ const PROVIDER_ENV_KEYS = [
 
 async function createHome(config = {}) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-search1api-"));
-	await mkdir(join(home, ".pi"), { recursive: true });
+	await mkdir(join(home, ".pi", "agent"), { recursive: true });
 	await writeFile(
-		join(home, ".pi", "web-search.json"),
+		join(home, ".pi", "agent", "web-search.json"),
 		JSON.stringify(config) + "\n",
 		"utf8",
 	);
@@ -385,7 +385,7 @@ test("configured searchRouting can select Search1API", async () => {
 		{
 			HOME: home,
 			USERPROFILE: home,
-			PI_CODING_AGENT_DIR: join(home, ".pi"),
+			PI_CODING_AGENT_DIR: join(home, ".pi", "agent"),
 			SEARCH1API_KEY: "synthetic-search1api-test-key",
 		},
 	);

--- a/test/searchinfinity.test.mjs
+++ b/test/searchinfinity.test.mjs
@@ -33,8 +33,8 @@ const PROVIDER_ENV_KEYS = [
 
 async function createHome(config = {}) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-searchinfinity-"));
-	await mkdir(join(home, ".pi"), { recursive: true });
-	await writeFile(join(home, ".pi", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
+	await mkdir(join(home, ".pi", "agent"), { recursive: true });
+	await writeFile(join(home, ".pi", "agent", "web-search.json"), JSON.stringify(config) + "\n", "utf8");
 	return home;
 }
 
@@ -210,7 +210,7 @@ test("configured searchRouting can select Searchinfinity", async () => {
 		const { search } = await import(${JSON.stringify(searchModuleUrl)});
 		const result = await search("route", { provider: "auto" });
 		console.log(JSON.stringify({ provider: result.provider, results: result.results }));
-	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: join(home, ".pi"), SEARCHINFINITY_API_KEY: "synthetic-searchinfinity-test-key" });
+	`, { HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: join(home, ".pi", "agent"), SEARCHINFINITY_API_KEY: "synthetic-searchinfinity-test-key" });
 
 	assert.equal(child.status, 0, child.stderr);
 	const output = JSON.parse(child.stdout.trim());

--- a/test/tinyfish.test.mjs
+++ b/test/tinyfish.test.mjs
@@ -38,9 +38,9 @@ const PROVIDER_ENV_KEYS = [
 
 async function createHome(config = {}) {
 	const home = await mkdtemp(join(tmpdir(), "pi-web-access-tinyfish-"));
-	await mkdir(join(home, ".pi"), { recursive: true });
+	await mkdir(join(home, ".pi", "agent"), { recursive: true });
 	await writeFile(
-		join(home, ".pi", "web-search.json"),
+		join(home, ".pi", "agent", "web-search.json"),
 		JSON.stringify(config) + "\n",
 		"utf8",
 	);
@@ -373,7 +373,7 @@ test("configured searchRouting can select TinyFish", async () => {
 		{
 			HOME: home,
 			USERPROFILE: home,
-			PI_CODING_AGENT_DIR: join(home, ".pi"),
+			PI_CODING_AGENT_DIR: join(home, ".pi", "agent"),
 			TINYFISH_API_KEY: "synthetic-tinyfish-test-key",
 		},
 	);

--- a/utils.ts
+++ b/utils.ts
@@ -22,7 +22,7 @@ export function getWebSearchConfigDir(): string {
 		if (existsSync(join(legacyDir, "web-search.json"))) return cachedWebSearchConfigDir = legacyDir;
 		return cachedWebSearchConfigDir = xdgDir;
 	}
-	return cachedWebSearchConfigDir = join(homedir(), ".pi");
+	return cachedWebSearchConfigDir = join(homedir(), ".pi", "agent");
 }
 
 export function getWebSearchConfigPath(): string {


### PR DESCRIPTION
## Summary
Fixes #360.

Use `~/.pi/agent/web-search.json` by default when neither `PI_CODING_AGENT_DIR` nor `XDG_CONFIG_HOME` is set. Explicit agent-directory overrides and existing XDG compatibility behavior are unchanged. The no-environment default does not migrate or fall back to the old root-level config; existing users can move that file to the agent directory or set an explicit override.

Updates affected fixtures and configuration documentation. Thanks to [@lJoublanc](https://github.com/lJoublanc) for reporting the sandbox/config-path mismatch.

## Validation
- Full suite: 662 passed.
- Focused config/provider regressions passed.
- Typecheck and diff hygiene passed.
- Fresh independent review of `e26f70ef1ebdf1f52b635b28c8d4d7a7a06c5413`: no findings.

No release or tag included.
