### PR TITLE
feat: support SOCKS proxy schemes

### DIFF
--- a/fetch-params.ts
+++ b/fetch-params.ts
@@ -96,7 +96,7 @@ function normalizeAuth(value: unknown): true | string | undefined {
 
 function normalizeProxy(value: unknown): string | undefined {
 	if (value === undefined || value === false) return undefined;
-	if (value === null) throw new Error("proxy must be an http(s) proxy URL string");
+	if (value === null) throw new Error("proxy must be an http(s) or socks proxy URL string");
 	const normalized = normalizeProxyUrl(value, "proxy");
 	return normalized ?? "";
 }

--- a/index.ts
+++ b/index.ts
@@ -1802,7 +1802,7 @@ export default function (pi: ExtensionAPI) {
 				}),
 			),
 			proxy: Type.Optional(Type.String({
-				description: "http(s) proxy URL (e.g. http://host:port) used for every outbound request in this call (search APIs and content fetches). Node fetch ignores HTTP(S)_PROXY env vars, so set this (or `proxy` in web-search.json) when direct access is blocked; empty string forces direct access.",
+				description: "http(s) or socks proxy URL (e.g. http://host:port or socks5h://host:port) used for every outbound request in this call (search APIs and content fetches). Node fetch ignores HTTP(S)_PROXY env vars, so set this (or `proxy` in web-search.json) when direct access is blocked; empty string forces direct access.",
 			})),
 		}),
 
@@ -2391,7 +2391,7 @@ export default function (pi: ExtensionAPI) {
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains; prefix with - to exclude." })),
 			provider: Type.Optional(searchProviderSchema("Search provider or non-empty list of providers to search simultaneously; all searches every eligible provider except Parallel MCP, DuckDuckGo, Kimi, AnySearch, XCrawl, Valyu, xAI, Mistral, Bright Data, SerpBase, and Serper")),
 			proxy: Type.Optional(Type.String({
-				description: "http(s) proxy URL (e.g. http://host:port) used for every outbound request in this call (search APIs and result-page fetches). Empty string forces direct access.",
+				description: "http(s) or socks proxy URL (e.g. http://host:port or socks5h://host:port) used for every outbound request in this call (search APIs and result-page fetches). Empty string forces direct access.",
 			})),
 		}),
 		async execute(_callId, params, signal, _onUpdate, ctx) {
@@ -2512,7 +2512,7 @@ export default function (pi: ExtensionAPI) {
 				description: "Opt into an authFetch profile for local browser-cookie fetching. Use a profile name, or true only when exactly one profile exists.",
 			})),
 			proxy: Type.Optional(Type.String({
-				description: "http(s) proxy URL (e.g. http://host:port) used for this fetch. Needed when the target is unreachable directly; localhost and NO_PROXY hosts always bypass the proxy. Empty string forces direct access.",
+				description: "http(s) or socks proxy URL (e.g. http://host:port or socks5h://host:port) used for this fetch. Needed when the target is unreachable directly; localhost and NO_PROXY hosts always bypass the proxy. Empty string forces direct access.",
 			})),
 		}),
 

--- a/test/proxy-transport.test.mjs
+++ b/test/proxy-transport.test.mjs
@@ -193,7 +193,7 @@ test("omitted proxy preserves trusted environment proxy routing when no proxy is
 
 test("invalid configured proxy fails closed instead of direct fetching", async (t) => {
 	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-invalid-config-test-"));
-	await writeFile(join(dir, "web-search.json"), JSON.stringify({ proxy: "socks5://proxy.example:1080" }));
+	await writeFile(join(dir, "web-search.json"), JSON.stringify({ proxy: "ftp://proxy.example:21" }));
 	t.after(async () => {
 		await rm(dir, { recursive: true, force: true });
 	});
@@ -206,7 +206,7 @@ test("invalid configured proxy fails closed instead of direct fetching", async (
 			message = error.message;
 		}
 		console.log(JSON.stringify(message));
-	`), /proxy.*must use the http:\/\/ or https:\/\/ scheme/);
+	`), /proxy.*must use the http:\/\/, https:\/\/, or socks scheme/);
 });
 
 test("invalid configured proxy reaches background fetch rejection handling", async (t) => {
@@ -226,7 +226,7 @@ test("invalid configured proxy reaches background fetch rejection handling", asy
 				if (String(url) !== "https://api.openai.com/v1/responses") {
 					throw new Error("Unexpected fetch: " + url);
 				}
-				writeFileSync(configPath, JSON.stringify({ provider: "openai", proxy: "socks5://proxy.example:1080" }));
+				writeFileSync(configPath, JSON.stringify({ provider: "openai", proxy: "ftp://proxy.example:21" }));
 				return new Response(JSON.stringify({ output: [
 					{ type: "web_search_call", action: { sources: [{ title: "Source", url: "https://example.com/source" }] } },
 					{ type: "message", content: [{ type: "output_text", text: "Search answer" }] },
@@ -266,7 +266,7 @@ test("invalid configured proxy reaches background fetch rejection handling", asy
 	const output = JSON.parse(child.stdout.trim());
 	assert.match(output.result, /Content fetching in background/);
 	assert.equal(output.errors.length, 1, JSON.stringify(output));
-	assert.match(output.errors[0], /proxy.*must use the http:\/\/ or https:\/\/ scheme/);
+	assert.match(output.errors[0], /proxy.*must use the http:\/\/, https:\/\/, or socks scheme/);
 });
 
 test("proxy transport does not spawn curl for pre-aborted requests", async (t) => {
@@ -502,5 +502,39 @@ test("websearch command scopes searches but not model callbacks to configured pr
 		assert.equal(calls.length, 2);
 		assert.equal(calls.filter((args) => args.at(-1) === "https://run.xcrawl.com/v1/serp").length, 2);
 		assert.ok(calls.every((args) => ["http://configured-proxy.example:8080", "http://configured-proxy.example:8080/"].includes(proxyArg(args))));
+	});
+});
+
+test("configured socks5h proxy is accepted and routed to curl", async (t) => {
+	const dir = await mkdtemp(join(tmpdir(), "pi-proxy-socks-config-test-"));
+	await writeFile(join(dir, "web-search.json"), JSON.stringify({ proxy: "socks5h://proxy.example:9050" }));
+	t.after(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	await withFakeCurl(t, {
+		"https://example.com/page": { status: 200, statusText: "OK", body: "through socks proxy" },
+	}, async (logPath) => {
+		const child = spawnSync(process.execPath, ["--input-type=module"], {
+			input: `
+				const { getActiveProxy, installGlobalProxyFetch, runWithProxy } = await import(${JSON.stringify(utilsUrl)});
+				installGlobalProxyFetch();
+				const response = await runWithProxy(undefined, () => fetch("https://example.com/page"));
+				console.log(JSON.stringify({ active: runWithProxy(undefined, () => getActiveProxy()), body: await response.text() }));
+			`,
+			encoding: "utf8",
+			env: { ...process.env, PI_CODING_AGENT_DIR: dir },
+			maxBuffer: 2 * 1024 * 1024,
+		});
+		assert.equal(child.status, 0, child.stderr);
+		const output = JSON.parse(child.stdout.trim());
+
+		assert.equal(output.active, "socks5h://proxy.example:9050/");
+		assert.equal(output.body, "through socks proxy");
+
+		const calls = await readCurlCalls(logPath);
+		const pageCall = calls.find((args) => args.at(-1) === "https://example.com/page");
+		assert.ok(pageCall);
+		assert.ok(["socks5h://proxy.example:9050", "socks5h://proxy.example:9050/"].includes(proxyArg(pageCall)));
 	});
 });

--- a/utils.ts
+++ b/utils.ts
@@ -208,7 +208,7 @@ const proxyStorage = new AsyncLocalStorage<string | null>();
 
 export function normalizeProxyUrl(value: unknown, source: string): string | null {
 	if (value === undefined || value === null) return null;
-	if (typeof value !== "string") throw new Error(`${source} must be an http(s) proxy URL string`);
+	if (typeof value !== "string") throw new Error(`${source} must be an http(s) or socks proxy URL string`);
 	const trimmed = value.trim();
 	if (!trimmed) return null;
 	let parsed: URL;
@@ -217,8 +217,10 @@ export function normalizeProxyUrl(value: unknown, source: string): string | null
 	} catch {
 		throw new Error(`${source} must be a valid proxy URL: ${JSON.stringify(trimmed)}`);
 	}
-	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-		throw new Error(`${source} must use the http:// or https:// scheme: ${trimmed}`);
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:" &&
+		parsed.protocol !== "socks4:" && parsed.protocol !== "socks4a:" &&
+		parsed.protocol !== "socks5:" && parsed.protocol !== "socks5h:") {
+		throw new Error(`${source} must use the http://, https://, or socks scheme: ${trimmed}`);
 	}
 	if (!parsed.hostname) throw new Error(`${source} must include a proxy host: ${trimmed}`);
 	parsed.hash = "";


### PR DESCRIPTION
The `proxy` config and per-call `proxy` parameter are validated to only allow `http:`/`https:`, but requests are actually transported via `curl -x <proxy>`, which natively supports SOCKS. This adds `socks4:`/`socks4a:`/`socks5:`/`socks5h:` so a local Tor instance (`"proxy": "socks5h://127.0.0.1:9050"`) or any SOCKS proxy can be used. Additive, non-breaking; verified the proxy travels through curl and routes via Tor's SOCKS5 listener.