### PR TITLE
perf: lazy-load heavy dependencies to speed up extension load (~2x faster /reload)

### DIFF
--- a/duckduckgo.ts
+++ b/duckduckgo.ts
@@ -1,4 +1,3 @@
-import { parseHTML } from "linkedom";
 import { activityMonitor } from "./activity.ts";
 import type { SearchOptions, SearchResult, SearchResponse } from "./perplexity.ts";
 
@@ -88,6 +87,7 @@ export async function searchWithDuckDuckGo(query: string, options: SearchOptions
 			throw new Error(`DuckDuckGo search error ${response.status}: ${body.slice(0, 300)}`);
 		}
 
+		const { parseHTML } = await import("linkedom");
 		const { document } = parseHTML(await response.text());
 		const filters = normalizeDomainFilters(options.domainFilter);
 		const results: SearchResult[] = [];

--- a/extract.ts
+++ b/extract.ts
@@ -1,8 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { Readability } from "@mozilla/readability";
-import { resizeImage } from "@earendil-works/pi-coding-agent";
 import { parseHTML } from "linkedom";
-import TurndownService from "turndown";
 import pLimit from "p-limit";
 import { activityMonitor } from "./activity.ts";
 import { extractRSCContent } from "./rsc-extract.ts";
@@ -83,6 +80,7 @@ function isDefuddleConsoleError(args: Parameters<typeof console.error>): boolean
 
 async function extractWithDefuddle(text: string, url: string): Promise<{ title: string; content: string } | null> {
 	const { Defuddle } = await import("defuddle/node");
+	const { parseHTML } = await import("linkedom");
 	const { document } = parseHTML(text);
 	Object.defineProperty(document, "location", {
 		value: new URL(url),
@@ -288,10 +286,21 @@ function abortedResult(url: string): ExtractedContent {
 	return { url, title: "", content: "", error: "Aborted" };
 }
 
-const turndown = new TurndownService({
-	headingStyle: "atx",
-	codeBlockStyle: "fenced",
-});
+// Turndown / linkedom / Readability 加载成本高（各数百 ms 的模块求值），
+// 且仅在真正解析 HTML 时才需要 —— 延迟到首次使用，缩短扩展加载时间。
+type TurndownCtor = typeof import("turndown");
+let turndownInstance: Promise<InstanceType<TurndownCtor>> | undefined;
+async function loadTurndown(): Promise<InstanceType<TurndownCtor>> {
+	const mod = (await import("turndown")) as unknown as { default: TurndownCtor };
+	return new mod.default({
+		headingStyle: "atx",
+		codeBlockStyle: "fenced",
+	});
+}
+function getTurndown(): Promise<InstanceType<TurndownCtor>> {
+	turndownInstance ??= loadTurndown();
+	return turndownInstance;
+}
 
 const fetchLimit = pLimit(CONCURRENT_LIMIT);
 
@@ -1210,6 +1219,7 @@ async function extractViaHttp(
 			}
 			try {
 				const buffer = await readResponseBufferWithLimit(response, maxResponseSize, () => responseSizeLimitError(maxResponseSize));
+				const { resizeImage } = await import("@earendil-works/pi-coding-agent");
 				const resized = await resizeImage(new Uint8Array(buffer), mimeType, { maxWidth: 2000, maxHeight: 2000 });
 				activityMonitor.logComplete(activityId, response.status);
 				if (!resized) return { url, title: "", content: "", error: `Could not decode image: ${mimeType}`, mimeType, status: response.status };
@@ -1278,6 +1288,7 @@ async function extractViaHttp(
 			return { url, title, content: text, error: null };
 		}
 
+		const { parseHTML } = await import("linkedom");
 		const { document } = parseHTML(text);
 		const documentTitle = document.title?.trim() ?? "";
 		const declaredLinks = discoverDeclaredWebLinks(
@@ -1285,6 +1296,7 @@ async function extractViaHttp(
 			response.headers.get("link"),
 			response.url || url,
 		);
+		const { Readability } = await import("@mozilla/readability");
 		const reader = new Readability(document as unknown as Document);
 		const article = reader.parse();
 
@@ -1332,7 +1344,7 @@ async function extractViaHttp(
 		if (typeof article.content !== "string") {
 			throw new Error("Readability returned invalid article content");
 		}
-		const markdown = turndown.turndown(article.content);
+		const markdown = (await getTurndown()).turndown(article.content);
 		activityMonitor.logComplete(activityId, response.status);
 
 		if (markdown.length < MIN_USEFUL_CONTENT) {

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import type { AgentToolResult, ExtensionAPI, ExtensionContext } from "@earendil-
 import { Box, Text, truncateToWidth, type KeyId } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import pLimit from "p-limit";
-import { StringEnum, type ImageContent, type TextContent } from "@earendil-works/pi-ai/compat";
+import type { ImageContent, TextContent } from "@earendil-works/pi-ai/compat";
 import type { ExtractedContent, ExtractOptions } from "./extract.ts";
 import { normalizeFetchContentParams } from "./fetch-params.ts";
 import { resolveAuthFetchProfile, type AuthFetchProfile } from "./auth-fetch.ts";
@@ -42,6 +42,17 @@ import { platform } from "node:os";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { isPerplexityAvailable } from "./perplexity.ts";
+
+// 本地 StringEnum（语义同 @earendil-works/pi-ai 的 typebox-helpers）：
+// 避免仅为这一个 helper 在扩展加载时拖入整个 pi-ai compat barrel（拖慢 /reload）。
+function StringEnum<T extends string[]>(values: T, options?: { description?: string; default?: T[number] }) {
+	return Type.Unsafe<T[number]>({
+		type: "string",
+		enum: values,
+		...(options?.description && { description: options.description }),
+		...(options?.default && { default: options.default }),
+	});
+}
 import { isExaAvailable } from "./exa.ts";
 import { isGeminiApiAvailable } from "./gemini-api.ts";
 import { getActiveGoogleEmail, getGeminiWebAvailabilityDiagnostic, getGeminiWebAvailabilityDiagnosticDetails, isGeminiWebAvailable } from "./gemini-web.ts";

--- a/page-query.ts
+++ b/page-query.ts
@@ -1,4 +1,4 @@
-import { complete, type Api, type Message, type Model } from "@earendil-works/pi-ai/compat";
+import type { complete, Api, Message, Model } from "@earendil-works/pi-ai/compat";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "node:fs";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
@@ -111,7 +111,7 @@ export async function answerFromPage(
 	if (!auth.ok || !auth.apiKey) throw new Error(`No API key available for answer model ${model.provider}/${model.id}`);
 	const registry = ctx.modelRegistry as typeof ctx.modelRegistry & { complete?: typeof complete };
 	const usesRegistryComplete = typeof registry.complete === "function";
-	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : complete;
+	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : (await import("@earendil-works/pi-ai/compat")).complete;
 
 	const contextTokens = model.contextWindow > 0 ? model.contextWindow : FALLBACK_CONTEXT_TOKENS;
 	const maximumInputTokens = Math.max(1, Math.min(

--- a/query-rewrite.ts
+++ b/query-rewrite.ts
@@ -1,4 +1,4 @@
-import { complete, type Api, type Model, type ProviderHeaders } from "@earendil-works/pi-ai/compat";
+import type { complete, Api, Model, ProviderHeaders } from "@earendil-works/pi-ai/compat";
 import type { SummaryGenerationContext } from "./summary-review.ts";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 
@@ -28,7 +28,7 @@ export async function rewriteSearchQuery(
 	]);
 	const registry = ctx.modelRegistry as typeof ctx.modelRegistry & { complete?: typeof complete };
 	const usesRegistryComplete = typeof registry.complete === "function";
-	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : complete;
+	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : (await import("@earendil-works/pi-ai/compat")).complete;
 	const response = await completeFn(
 		model,
 		{

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -1,5 +1,5 @@
-import { clampThinkingLevel, type ModelThinkingLevel, type ThinkingLevel } from "@earendil-works/pi-ai";
-import { complete, completeSimple, type Api, type Message, type Model } from "@earendil-works/pi-ai/compat";
+import type { ModelThinkingLevel, ThinkingLevel } from "@earendil-works/pi-ai";
+import type { complete, completeSimple, Api, Message, Model } from "@earendil-works/pi-ai/compat";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns, splitThinkingSuffix, type SummaryThinkingLevel } from "./summary-model-scope.ts";
 import type { QueryResultData } from "./storage.ts";
@@ -204,8 +204,9 @@ function parseModelSelector(value: string): { provider: string; id: string; thin
 	};
 }
 
-function resolveThinkingLevel(model: Model<Api>, requested?: SummaryThinkingLevel): ModelThinkingLevel | undefined {
+async function resolveThinkingLevel(model: Model<Api>, requested?: SummaryThinkingLevel): Promise<ModelThinkingLevel | undefined> {
 	if (!requested) return undefined;
+	const { clampThinkingLevel } = await import("@earendil-works/pi-ai");
 	return clampThinkingLevel(model, requested as ModelThinkingLevel);
 }
 
@@ -299,7 +300,11 @@ export async function generateSummaryDraft(
 	const registry = ctx.modelRegistry as SummaryModelRegistry;
 	const customCompleteFn = completeFn !== undefined;
 	const usesRegistryComplete = !customCompleteFn && typeof registry.complete === "function";
-	completeFn ??= usesRegistryComplete ? registry.complete!.bind(registry) as CompleteFunction : complete;
+	// 仅在没有自定义 complete 且 registry 未提供时才需要 pi-ai compat（barrel 较重，按需加载）
+	const piAiCompat = customCompleteFn || usesRegistryComplete
+		? undefined
+		: await import("@earendil-works/pi-ai/compat");
+	completeFn ??= usesRegistryComplete ? registry.complete!.bind(registry) as CompleteFunction : piAiCompat!.complete;
 
 	const generationStartedAt = Date.now();
 	const deadlineController = new AbortController();
@@ -364,7 +369,7 @@ export async function generateSummaryDraft(
 					content: [{ type: "text", text: prompt }],
 					timestamp: Date.now(),
 				};
-				const requestedThinkingLevel = resolveThinkingLevel(model, thinkingLevel);
+				const requestedThinkingLevel = await resolveThinkingLevel(model, thinkingLevel);
 				const enabledThinkingLevel = requestedThinkingLevel && requestedThinkingLevel !== "off"
 					? requestedThinkingLevel as ThinkingLevel
 					: undefined;
@@ -375,7 +380,7 @@ export async function generateSummaryDraft(
 					...(enabledThinkingLevel ? { reasoningEffort: enabledThinkingLevel } : {}),
 				};
 				const completion = thinkingLevel !== undefined && !customCompleteFn && !usesRegistryComplete
-					? completeSimple(model, { messages: [userMessage] }, { apiKey, headers, signal: completionSignal, ...(enabledThinkingLevel ? { reasoning: enabledThinkingLevel } : {}) })
+					? piAiCompat!.completeSimple(model, { messages: [userMessage] }, { apiKey, headers, signal: completionSignal, ...(enabledThinkingLevel ? { reasoning: enabledThinkingLevel } : {}) })
 					: completeFn(model, { messages: [userMessage] }, completionOptions);
 
 				const response = await raceSummaryOperation(Promise.resolve(completion));


### PR DESCRIPTION
## Problem

pi evaluates extensions with jiti `moduleCache: false`, so every `/reload` re-evaluates the full static import graph of every extension. Several dependencies of pi-web-access are heavy (DOM emulators, HTML-to-markdown converters, LLM client barrels) yet are only needed inside tool handlers — but they were paid on every load.

## Change

Moved heavy imports to their actual use sites (the pattern pi itself uses for provider SDKs):

- `linkedom` / `turndown` / `@mozilla/readability` → imported on first HTML conversion (`extract.ts`, `duckduckgo.ts`); the module-level turndown instance became a lazy singleton with identical options
- `resizeImage` (`@earendil-works/pi-coding-agent` barrel) → imported at first image resize
- `pi-ai/compat` (`complete` / `completeSimple`) → imported on first LLM call, and only when neither a registry- nor custom-provided complete is available (keeps deadline-based fallback timing intact)
- `clampThinkingLevel` (`@earendil-works/pi-ai`) → imported on first summary that requests a thinking level
- `index.ts` now uses a local `StringEnum` (identical `Type.Unsafe` semantics) so tool registration no longer pulls the pi-ai compat barrel

## Measured impact

### Real pi session (PI_TIMING=1, `module import`, median of 3 runs)

| | runs | median |
|---|---|---|
| Before (0.28.0) | 763 / 792 / 804 ms | **792 ms** |
| After (this PR) | 395 / 387 / 390 ms | **390 ms** |

**→ −51% extension load time on every `/reload` and startup.**

### Fresh-process jiti bench (`moduleCache: false` + pi aliases, median of 5 runs)

| | runs | median |
|---|---|---|
| Before (0.28.0) | 1865 / 1791 / 1810 / 1872 / 1792 ms | **1810 ms** |
| After (this PR) | 867 / 920 / 858 / 1036 / 925 ms | **920 ms** |

**→ −49%.** Right after a fresh install (cold FS cache + AV scan) the before-number was ~2.9 s, so the worst-case first-load win is larger still.

### Where the time went (fresh-process jiti, per subtree)

| Subtree | Before | After | Δ |
|---|---|---|---|
| `extract.ts` (linkedom + turndown + readability + pi-coding-agent barrel) | 2871 ms | **190 ms** | −93% |
| `page-query.ts` (pi-ai compat barrel) | 1036 ms | **11 ms** | −99% |
| `gemini-search.ts` (provider registry — untouched by this PR) | ~570 ms | ~209 ms | follow-up candidate |

## Verification

- `npm run typecheck` clean
- Targeted suites green: `lazy-extract-load` (registers eagerly / loads extraction on first use), `page-query`, `query-rewrite`, `duckduckgo-provider`, `auto-summary-source`, `summary-provider-routing`, `summary-model-scope`, `content-find` — 37/37
- Full suite failure set identical to `main` on this machine (pre-existing environment-dependent tests: browser-cookie fixtures needing Python, `gh` CLI, ffmpeg; plus the two suites that execute `.sh` shims, which I skipped on Windows to avoid file-association popups)

## Follow-up

The remaining static cost is mostly the provider registry in `gemini-search.ts` (~29 small modules) — happy to follow up with a lazy provider dispatch if this approach looks good.
