### PR TITLE
fix: accept both (args, options, theme) and legacy (args, theme) in renderCall

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2121,7 +2121,11 @@ export default function (pi: ExtensionAPI) {
 			});
 		},
 
-		renderCall(args, theme) {
+		renderCall(args, optionsOrTheme: unknown, maybeTheme?: unknown) {
+			const theme = (maybeTheme && typeof maybeTheme === "object" && "fg" in maybeTheme ? maybeTheme : optionsOrTheme) as {
+				fg: (color: string, text: string) => string;
+				bold: (text: string) => string;
+			};
 			const input = args as { query?: unknown; queries?: unknown };
 			const rawQueryList: unknown[] = Array.isArray(input.queries)
 				? input.queries
@@ -2685,7 +2689,11 @@ export default function (pi: ExtensionAPI) {
 			});
 		},
 
-		renderCall(args, theme) {
+		renderCall(args, optionsOrTheme: unknown, maybeTheme?: unknown) {
+			const theme = (maybeTheme && typeof maybeTheme === "object" && "fg" in maybeTheme ? maybeTheme : optionsOrTheme) as {
+				fg: (color: string, text: string) => string;
+				bold: (text: string) => string;
+			};
 			const { urlList, options } = normalizeFetchContentParams(args);
 			const { prompt, timestamp, frames, model, mode, answerModel, auth } = options;
 			if (urlList.length === 0) {
@@ -3080,7 +3088,11 @@ export default function (pi: ExtensionAPI) {
 			};
 		},
 
-		renderCall(args, theme) {
+		renderCall(args, optionsOrTheme: unknown, maybeTheme?: unknown) {
+			const theme = (maybeTheme && typeof maybeTheme === "object" && "fg" in maybeTheme ? maybeTheme : optionsOrTheme) as {
+				fg: (color: string, text: string) => string;
+				bold: (text: string) => string;
+			};
 			const { responseId, query, queryIndex, url, urlIndex, offset, findText } = args as {
 				responseId: string;
 				query?: string;

--- a/test/fetch-render-call.test.mjs
+++ b/test/fetch-render-call.test.mjs
@@ -32,3 +32,17 @@ test("fetch_content renderCall falls back to url when urls is empty", () => {
 
 	assert.deepEqual(lines, ["fetch https://example.com/docs"]);
 });
+
+test("fetch_content renderCall accepts (args, options, theme) signature", () => {
+	const tool = getFetchTool();
+	const renderOptions = { expanded: false, isPartial: false };
+	const lines = tool.renderCall({
+		url: "https://example.com/docs",
+		urls: [],
+		frames: 1,
+		prompt: "",
+		model: "",
+	}, renderOptions, theme).render(120).map(line => line.trimEnd());
+
+	assert.deepEqual(lines, ["fetch https://example.com/docs"]);
+});


### PR DESCRIPTION
### Summary
In the Pi / Oh My Pi host runner, `renderCall` is invoked with three arguments:
`tool.renderCall(callArgs, renderOptions, theme)`

Previously, `renderCall` in `web_search`, `fetch_content`, and `get_search_content` declared only two parameters:
`renderCall(args, theme)`

As a result, the `theme` parameter actually received the `renderOptions` object (`{ expanded, isPartial }`), leading to:
`Tool renderer failed: TypeError: theme.bold is not a function`

This change updates the parameter signature to dynamically resolve the theme object whether invoked with 2 or 3 arguments:
`renderCall(args, optionsOrTheme: unknown, maybeTheme?: unknown)`

### Verification
- Added test case in `test/fetch-render-call.test.mjs` verifying the 3-argument signature.
- Verified test passes with Node test runner.