### PR TITLE
fix: prune expired fetched content from memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed expired fetched-content payloads remaining in memory after cache pruning, preserving the retrieval window and session history. Thanks to [@MDGChamomile](https://github.com/MDGChamomile) for issue #362.
 - Fixed no-environment web-search config lookup to use Pi's agent directory (`~/.pi/agent/web-search.json`) without implicitly falling back to the legacy `~/.pi/web-search.json`. Existing `PI_CODING_AGENT_DIR` and XDG compatibility behavior remain unchanged. Thanks to [@lJoublanc](https://github.com/lJoublanc) for issue #360.
 
 ## [0.28.0] - 2026-09-04

--- a/storage.ts
+++ b/storage.ts
@@ -426,13 +426,17 @@ function readCachedFetchData(data: StoredSearchData, now = Date.now()): StoredSe
 	}
 }
 
-export function pruneExpiredFetchCache(now = Date.now(), requestedLimits?: Partial<FetchCacheLimits>): void {
-	const limits = cacheLimits(requestedLimits);
+function pruneExpiredFetchedResults(now: number): void {
 	for (const [id, data] of storedResults) {
 		if (data.type === "fetch" && now - data.timestamp >= CACHE_TTL_MS) {
 			storedResults.set(id, unavailableFetchData(data, "Cached fetched content is missing or expired"));
 		}
 	}
+}
+
+export function pruneExpiredFetchCache(now = Date.now(), requestedLimits?: Partial<FetchCacheLimits>): void {
+	const limits = cacheLimits(requestedLimits);
+	pruneExpiredFetchedResults(now);
 	try { pruneFetchCache(now, limits); } catch {}
 }
 
@@ -441,6 +445,7 @@ export function storeResult(id: string, data: StoredSearchData): void {
 }
 
 export function storeFetchedContentResult(id: string, data: StoredSearchData & { type: "fetch"; urls: ExtractedContent[] }): StoredSearchData {
+	pruneExpiredFetchedResults(Date.now());
 	let ref: FetchCacheRef | null = null;
 	let cacheError: string | undefined;
 	try {

--- a/storage.ts
+++ b/storage.ts
@@ -428,6 +428,11 @@ function readCachedFetchData(data: StoredSearchData, now = Date.now()): StoredSe
 
 export function pruneExpiredFetchCache(now = Date.now(), requestedLimits?: Partial<FetchCacheLimits>): void {
 	const limits = cacheLimits(requestedLimits);
+	for (const [id, data] of storedResults) {
+		if (data.type === "fetch" && now - data.timestamp >= CACHE_TTL_MS) {
+			storedResults.set(id, unavailableFetchData(data, "Cached fetched content is missing or expired"));
+		}
+	}
 	try { pruneFetchCache(now, limits); } catch {}
 }
 

--- a/test/fetch-cache-storage.test.mjs
+++ b/test/fetch-cache-storage.test.mjs
@@ -15,11 +15,13 @@ const { default: initializeExtension } = await import("../index.ts");
 const {
 	clearResults,
 	deleteResult,
+	getAllResults,
 	getFetchCacheDir,
 	getResult,
 	pruneExpiredFetchCache,
 	restoreFromSession,
 	storeFetchedContentResult,
+	storeResult,
 } = await import("../storage.ts");
 
 afterEach(() => {
@@ -167,6 +169,63 @@ test("missing cache files return an actionable fetched-content error", async () 
 	const missing = await getContentTool.execute("call", { responseId: result.details.responseId, urlIndex: 0 });
 	assert.equal(missing.details.error, "Cached fetched content is missing or expired");
 	assert.match(missing.content[0].text, /Cached fetched content is missing or expired/);
+});
+
+test("cache pruning reclaims expired in-memory fetch payloads without changing the retrieval window or history", async () => {
+	await useTempAgentDir();
+	const startedAt = originalDateNow();
+	const ttl = 60 * 60 * 1000;
+	Date.now = () => startedAt;
+	const sessionEntry = storeFetchedContentResult("expired", fetchedData("expired", "expired payload"));
+	const sessionSnapshot = JSON.stringify(sessionEntry);
+	const cachePath = join(getFetchCacheDir(), sessionEntry.fetchCache.key);
+	utimesSync(cachePath, new Date(startedAt), new Date(startedAt));
+	const search = { id: "search", type: "search", timestamp: startedAt, queries: [] };
+	const research = { id: "research", type: "research", timestamp: startedAt, artifact: { answer: "keep" } };
+	storeResult(search.id, search);
+	storeResult(research.id, research);
+
+	Date.now = () => startedAt + ttl - 1;
+	pruneExpiredFetchCache();
+	assert.equal(getAllResults().find((data) => data.id === "expired").urls[0].content, "expired payload");
+	assert.equal(getResult("expired").urls[0].content, "expired payload");
+	assert.ok(readdirSync(getFetchCacheDir()).includes(sessionEntry.fetchCache.key));
+	storeFetchedContentResult("fresh", fetchedData("fresh", "fresh payload"));
+
+	Date.now = () => startedAt + ttl;
+	pruneExpiredFetchCache();
+	assert.equal(readdirSync(getFetchCacheDir()).includes(sessionEntry.fetchCache.key), false);
+	// Inspect the map before getResult can lazily expire the payload itself.
+	const results = getAllResults();
+	assert.equal(results.length, 4);
+	const expired = results.find((data) => data.id === "expired");
+	assert.equal(expired.urls[0].content, "");
+	assert.equal(expired.urls[0].error, "Cached fetched content is missing or expired");
+	assert.deepEqual(expired.urlMetadata, sessionEntry.urlMetadata);
+	assert.equal(results.find((data) => data.id === "fresh").urls[0].content, "fresh payload");
+	assert.equal(results.find((data) => data.id === "search"), search);
+	assert.equal(results.find((data) => data.id === "research"), research);
+	assert.equal(JSON.stringify(sessionEntry), sessionSnapshot);
+	assert.equal(getResult("expired").urls[0].error, "Cached fetched content is missing or expired");
+});
+
+test("cache pruning reclaims expired inline payloads even without a disk cache", async () => {
+	await useTempAgentDir();
+	const startedAt = originalDateNow();
+	Date.now = () => startedAt;
+	const legacy = fetchedData("legacy", "legacy payload");
+	restoreEntry(legacy);
+	// An invalid cache id exercises the in-memory fallback after a cache write failure.
+	const failed = storeFetchedContentResult("failed/id", fetchedData("failed/id", "fallback payload"));
+	assert.ok(failed.fetchCacheError);
+	rmSync(getFetchCacheDir(), { recursive: true, force: true });
+
+	pruneExpiredFetchCache(startedAt + 60 * 60 * 1000 - 1);
+	assert.deepEqual(getAllResults().map((data) => data.urls[0].content), ["legacy payload", "fallback payload"]);
+	pruneExpiredFetchCache(startedAt + 60 * 60 * 1000);
+	assert.deepEqual(getAllResults().map((data) => data.urls[0].content), ["", ""]);
+	assert.ok(getAllResults().every((data) => data.urls[0].error === "Cached fetched content is missing or expired"));
+	assert.equal(legacy.urls[0].content, "legacy payload");
 });
 
 test("cache pruning evicts the oldest entries by count and bytes", async () => {

--- a/test/fetch-cache-storage.test.mjs
+++ b/test/fetch-cache-storage.test.mjs
@@ -209,6 +209,39 @@ test("cache pruning reclaims expired in-memory fetch payloads without changing t
 	assert.equal(getResult("expired").urls[0].error, "Cached fetched content is missing or expired");
 });
 
+test("storing a later fetch reclaims expired in-memory payloads before retrieval", async () => {
+	await useTempAgentDir();
+	const startedAt = originalDateNow();
+	const ttl = 60 * 60 * 1000;
+	Date.now = () => startedAt;
+	const sessionEntry = storeFetchedContentResult("earlier", fetchedData("earlier", "earlier payload"));
+	const sessionSnapshot = JSON.stringify(sessionEntry);
+	const search = { id: "search", type: "search", timestamp: startedAt, queries: [] };
+	const research = { id: "research", type: "research", timestamp: startedAt, artifact: { answer: "keep" } };
+	storeResult(search.id, search);
+	storeResult(research.id, research);
+
+	Date.now = () => startedAt + ttl - 1;
+	storeFetchedContentResult("recent", fetchedData("recent", "recent payload"));
+	assert.equal(getAllResults().find((data) => data.id === "earlier").urls[0].content, "earlier payload");
+
+	Date.now = () => startedAt + ttl;
+	const laterEntry = storeFetchedContentResult("later", fetchedData("later", "later payload"));
+	assert.ok(laterEntry.fetchCache);
+	// Neither public pruning nor lazy getResult expiry should be needed.
+	const results = getAllResults();
+	assert.equal(results.length, 5);
+	const earlier = results.find((data) => data.id === "earlier");
+	assert.equal(earlier.urls[0].content, "");
+	assert.equal(earlier.urls[0].error, "Cached fetched content is missing or expired");
+	assert.deepEqual(earlier.urlMetadata, sessionEntry.urlMetadata);
+	assert.equal(results.find((data) => data.id === "recent").urls[0].content, "recent payload");
+	assert.equal(results.find((data) => data.id === "later").urls[0].content, "later payload");
+	assert.equal(results.find((data) => data.id === "search"), search);
+	assert.equal(results.find((data) => data.id === "research"), research);
+	assert.equal(JSON.stringify(sessionEntry), sessionSnapshot);
+});
+
 test("cache pruning reclaims expired inline payloads even without a disk cache", async () => {
 	await useTempAgentDir();
 	const startedAt = originalDateNow();


### PR DESCRIPTION
## Summary

- reclaim expired fetched-content payloads from the in-memory result map when cache pruning runs
- preserve the existing one-hour retrieval window, result metadata, other result types, and session-history objects
- cover exact-TTL, disk-independent, legacy, and cache-write-fallback cases

## Validation

- `node --test test/fetch-cache-storage.test.mjs test/fetch-answer-storage.test.mjs` — 16 passed
- `npm run typecheck`
- `git diff --check`
- full `npm test`, typecheck, and runtime audit passed on the exact base before this lane

Thanks to [@MDGChamomile](https://github.com/MDGChamomile) for the detailed reproduction in #362.

Closes #362
