### PR TITLE
perf: lazy-load heavy dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 - Added SOCKS4, SOCKS4A, SOCKS5, and SOCKS5H proxy support through config and per-call overrides. Thanks to [@phillipzink](https://github.com/phillipzink) for PR #365.
 - Added 1Password service-account support for credential resolver commands by forwarding `OP_SERVICE_ACCOUNT_TOKEN`. Thanks to PR author [@Avg8888](https://github.com/Avg8888) and commit author [@xapids](https://github.com/xapids) for [PR #364](https://github.com/nicobailon/pi-web-access/pull/364).
 
+### Changed
+
+- Load extraction and AI helpers on first use to reduce extension startup work. Thanks to [@ducaoya](https://github.com/ducaoya) for PR #366.
+
 ### Fixed
 
 - Refuse to send Pi-resolved OpenAI credentials to the default official Responses endpoint when their effective provider `baseUrl` is custom; configure `openaiResponsesUrl` explicitly for gateway search. Thanks to [@projectkite](https://github.com/projectkite) for issue #367.

--- a/abortable.ts
+++ b/abortable.ts
@@ -1,0 +1,17 @@
+/** Observe cancellation while awaiting work that cannot itself be cancelled (such as import()). */
+export async function awaitWithAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return operation;
+	let onAbort: () => void = () => {};
+	const aborted = new Promise<never>((_resolve, reject) => {
+		onAbort = () => reject(new Error("Aborted"));
+		signal.addEventListener("abort", onAbort, { once: true });
+		if (signal.aborted) onAbort();
+	});
+	try {
+		const result = await Promise.race([operation, aborted]);
+		if (signal.aborted) throw new Error("Aborted");
+		return result;
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+	}
+}

--- a/duckduckgo.ts
+++ b/duckduckgo.ts
@@ -1,4 +1,3 @@
-import { parseHTML } from "linkedom";
 import { activityMonitor } from "./activity.ts";
 import type { SearchOptions, SearchResult, SearchResponse } from "./perplexity.ts";
 
@@ -88,6 +87,7 @@ export async function searchWithDuckDuckGo(query: string, options: SearchOptions
 			throw new Error(`DuckDuckGo search error ${response.status}: ${body.slice(0, 300)}`);
 		}
 
+		const { parseHTML } = await import("linkedom");
 		const { document } = parseHTML(await response.text());
 		const filters = normalizeDomainFilters(options.domainFilter);
 		const results: SearchResult[] = [];

--- a/extract.ts
+++ b/extract.ts
@@ -1,8 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { Readability } from "@mozilla/readability";
-import { resizeImage } from "@earendil-works/pi-coding-agent";
 import { parseHTML } from "linkedom";
-import TurndownService from "turndown";
 import pLimit from "p-limit";
 import { activityMonitor } from "./activity.ts";
 import { extractRSCContent } from "./rsc-extract.ts";
@@ -83,6 +80,7 @@ function isDefuddleConsoleError(args: Parameters<typeof console.error>): boolean
 
 async function extractWithDefuddle(text: string, url: string): Promise<{ title: string; content: string } | null> {
 	const { Defuddle } = await import("defuddle/node");
+	const { parseHTML } = await import("linkedom");
 	const { document } = parseHTML(text);
 	Object.defineProperty(document, "location", {
 		value: new URL(url),
@@ -288,10 +286,21 @@ function abortedResult(url: string): ExtractedContent {
 	return { url, title: "", content: "", error: "Aborted" };
 }
 
-const turndown = new TurndownService({
-	headingStyle: "atx",
-	codeBlockStyle: "fenced",
-});
+// Turndown / linkedom / Readability 加载成本高（各数百 ms 的模块求值），
+// 且仅在真正解析 HTML 时才需要 —— 延迟到首次使用，缩短扩展加载时间。
+type TurndownCtor = typeof import("turndown");
+let turndownInstance: Promise<InstanceType<TurndownCtor>> | undefined;
+async function loadTurndown(): Promise<InstanceType<TurndownCtor>> {
+	const mod = (await import("turndown")) as unknown as { default: TurndownCtor };
+	return new mod.default({
+		headingStyle: "atx",
+		codeBlockStyle: "fenced",
+	});
+}
+function getTurndown(): Promise<InstanceType<TurndownCtor>> {
+	turndownInstance ??= loadTurndown();
+	return turndownInstance;
+}
 
 const fetchLimit = pLimit(CONCURRENT_LIMIT);
 
@@ -1210,6 +1219,7 @@ async function extractViaHttp(
 			}
 			try {
 				const buffer = await readResponseBufferWithLimit(response, maxResponseSize, () => responseSizeLimitError(maxResponseSize));
+				const { resizeImage } = await import("@earendil-works/pi-coding-agent");
 				const resized = await resizeImage(new Uint8Array(buffer), mimeType, { maxWidth: 2000, maxHeight: 2000 });
 				activityMonitor.logComplete(activityId, response.status);
 				if (!resized) return { url, title: "", content: "", error: `Could not decode image: ${mimeType}`, mimeType, status: response.status };
@@ -1278,6 +1288,7 @@ async function extractViaHttp(
 			return { url, title, content: text, error: null };
 		}
 
+		const { parseHTML } = await import("linkedom");
 		const { document } = parseHTML(text);
 		const documentTitle = document.title?.trim() ?? "";
 		const declaredLinks = discoverDeclaredWebLinks(
@@ -1285,6 +1296,7 @@ async function extractViaHttp(
 			response.headers.get("link"),
 			response.url || url,
 		);
+		const { Readability } = await import("@mozilla/readability");
 		const reader = new Readability(document as unknown as Document);
 		const article = reader.parse();
 
@@ -1332,7 +1344,7 @@ async function extractViaHttp(
 		if (typeof article.content !== "string") {
 			throw new Error("Readability returned invalid article content");
 		}
-		const markdown = turndown.turndown(article.content);
+		const markdown = (await getTurndown()).turndown(article.content);
 		activityMonitor.logComplete(activityId, response.status);
 
 		if (markdown.length < MIN_USEFUL_CONTENT) {

--- a/extract.ts
+++ b/extract.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { parseHTML } from "linkedom";
+import type TurndownService from "turndown";
 import pLimit from "p-limit";
 import { activityMonitor } from "./activity.ts";
 import { extractRSCContent } from "./rsc-extract.ts";
@@ -286,18 +286,16 @@ function abortedResult(url: string): ExtractedContent {
 	return { url, title: "", content: "", error: "Aborted" };
 }
 
-// Turndown / linkedom / Readability 加载成本高（各数百 ms 的模块求值），
-// 且仅在真正解析 HTML 时才需要 —— 延迟到首次使用，缩短扩展加载时间。
-type TurndownCtor = typeof import("turndown");
-let turndownInstance: Promise<InstanceType<TurndownCtor>> | undefined;
-async function loadTurndown(): Promise<InstanceType<TurndownCtor>> {
-	const mod = (await import("turndown")) as unknown as { default: TurndownCtor };
-	return new mod.default({
+// Share first-use initialization without loading Turndown at extension startup.
+let turndownInstance: Promise<TurndownService> | undefined;
+async function loadTurndown(): Promise<TurndownService> {
+	const { default: TurndownService } = await import("turndown");
+	return new TurndownService({
 		headingStyle: "atx",
 		codeBlockStyle: "fenced",
 	});
 }
-function getTurndown(): Promise<InstanceType<TurndownCtor>> {
+function getTurndown(): Promise<TurndownService> {
 	turndownInstance ??= loadTurndown();
 	return turndownInstance;
 }

--- a/extract.ts
+++ b/extract.ts
@@ -1125,6 +1125,7 @@ async function extractViaHttp(
 	const activityId = activityMonitor.logStart({ type: "fetch", url });
 
 	const controller = new AbortController();
+	const startedAt = Date.now();
 	const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
 	const onAbort = () => controller.abort();
@@ -1397,6 +1398,13 @@ async function extractViaHttp(
 	} finally {
 		clearTimeout(timeoutId);
 		signal?.removeEventListener("abort", onAbort);
+		// Imports and CPU-bound processing need not observe the fetch signal, and
+		// can finish before an expired timer gets a turn. Guard every exit, with
+		// caller cancellation taking precedence over the internal deadline.
+		if (signal?.aborted) return abortedResult(url);
+		if (controller.signal.aborted || Date.now() - startedAt >= timeoutMs) {
+			return { url, title: "", content: "", error: "The operation was aborted." };
+		}
 	}
 }
 

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import type { AgentToolResult, ExtensionAPI, ExtensionContext } from "@earendil-
 import { Box, Text, truncateToWidth, type KeyId } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import pLimit from "p-limit";
-import { StringEnum, type ImageContent, type TextContent } from "@earendil-works/pi-ai/compat";
+import type { ImageContent, TextContent } from "@earendil-works/pi-ai/compat";
 import type { ExtractedContent, ExtractOptions } from "./extract.ts";
 import { normalizeFetchContentParams } from "./fetch-params.ts";
 import { resolveAuthFetchProfile, type AuthFetchProfile } from "./auth-fetch.ts";
@@ -42,6 +42,17 @@ import { platform } from "node:os";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { isPerplexityAvailable } from "./perplexity.ts";
+
+// 本地 StringEnum（语义同 @earendil-works/pi-ai 的 typebox-helpers）：
+// 避免仅为这一个 helper 在扩展加载时拖入整个 pi-ai compat barrel（拖慢 /reload）。
+function StringEnum<T extends string[]>(values: T, options?: { description?: string; default?: T[number] }) {
+	return Type.Unsafe<T[number]>({
+		type: "string",
+		enum: values,
+		...(options?.description && { description: options.description }),
+		...(options?.default && { default: options.default }),
+	});
+}
 import { isExaAvailable } from "./exa.ts";
 import { isGeminiApiAvailable } from "./gemini-api.ts";
 import { getActiveGoogleEmail, getGeminiWebAvailabilityDiagnostic, getGeminiWebAvailabilityDiagnosticDetails, isGeminiWebAvailable } from "./gemini-web.ts";

--- a/index.ts
+++ b/index.ts
@@ -42,17 +42,6 @@ import { platform } from "node:os";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { isPerplexityAvailable } from "./perplexity.ts";
-
-// 本地 StringEnum（语义同 @earendil-works/pi-ai 的 typebox-helpers）：
-// 避免仅为这一个 helper 在扩展加载时拖入整个 pi-ai compat barrel（拖慢 /reload）。
-function StringEnum<T extends string[]>(values: T, options?: { description?: string; default?: T[number] }) {
-	return Type.Unsafe<T[number]>({
-		type: "string",
-		enum: values,
-		...(options?.description && { description: options.description }),
-		...(options?.default && { default: options.default }),
-	});
-}
 import { isExaAvailable } from "./exa.ts";
 import { isGeminiApiAvailable } from "./gemini-api.ts";
 import { getActiveGoogleEmail, getGeminiWebAvailabilityDiagnostic, getGeminiWebAvailabilityDiagnosticDetails, isGeminiWebAvailable } from "./gemini-web.ts";
@@ -93,6 +82,16 @@ import {
 	type RecencyFilter,
 	type ResearchArtifact,
 } from "./source-check.ts";
+
+// Match pi-ai's StringEnum without loading its compat barrel during registration.
+function StringEnum<T extends string[]>(values: T, options?: { description?: string; default?: T[number] }) {
+	return Type.Unsafe<T[number]>({
+		type: "string",
+		enum: values,
+		...(options?.description && { description: options.description }),
+		...(options?.default && { default: options.default }),
+	});
+}
 
 type ExtensionTheme = ExtensionContext["ui"]["theme"];
 

--- a/page-query.ts
+++ b/page-query.ts
@@ -1,4 +1,4 @@
-import { complete, type Api, type Message, type Model } from "@earendil-works/pi-ai/compat";
+import type { complete, Api, Message, Model } from "@earendil-works/pi-ai/compat";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "node:fs";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
@@ -111,7 +111,7 @@ export async function answerFromPage(
 	if (!auth.ok || !auth.apiKey) throw new Error(`No API key available for answer model ${model.provider}/${model.id}`);
 	const registry = ctx.modelRegistry as typeof ctx.modelRegistry & { complete?: typeof complete };
 	const usesRegistryComplete = typeof registry.complete === "function";
-	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : complete;
+	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : (await import("@earendil-works/pi-ai/compat")).complete;
 
 	const contextTokens = model.contextWindow > 0 ? model.contextWindow : FALLBACK_CONTEXT_TOKENS;
 	const maximumInputTokens = Math.max(1, Math.min(

--- a/page-query.ts
+++ b/page-query.ts
@@ -3,6 +3,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "node:fs";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 import { getWebSearchConfigPath } from "./utils.ts";
+import { awaitWithAbort } from "./abortable.ts";
 
 const OUTPUT_TOKENS = 2_000;
 const INPUT_CONTEXT_FRACTION = 0.6;
@@ -111,7 +112,9 @@ export async function answerFromPage(
 	if (!auth.ok || !auth.apiKey) throw new Error(`No API key available for answer model ${model.provider}/${model.id}`);
 	const registry = ctx.modelRegistry as typeof ctx.modelRegistry & { complete?: typeof complete };
 	const usesRegistryComplete = typeof registry.complete === "function";
-	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : (await import("@earendil-works/pi-ai/compat")).complete;
+	if (signal?.aborted) throw new Error("Aborted");
+	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : (await awaitWithAbort(import("@earendil-works/pi-ai/compat"), signal)).complete;
+	if (signal?.aborted) throw new Error("Aborted");
 
 	const contextTokens = model.contextWindow > 0 ? model.contextWindow : FALLBACK_CONTEXT_TOKENS;
 	const maximumInputTokens = Math.max(1, Math.min(

--- a/query-rewrite.ts
+++ b/query-rewrite.ts
@@ -1,4 +1,4 @@
-import { complete, type Api, type Model, type ProviderHeaders } from "@earendil-works/pi-ai/compat";
+import type { complete, Api, Model, ProviderHeaders } from "@earendil-works/pi-ai/compat";
 import type { SummaryGenerationContext } from "./summary-review.ts";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 
@@ -28,7 +28,7 @@ export async function rewriteSearchQuery(
 	]);
 	const registry = ctx.modelRegistry as typeof ctx.modelRegistry & { complete?: typeof complete };
 	const usesRegistryComplete = typeof registry.complete === "function";
-	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : complete;
+	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : (await import("@earendil-works/pi-ai/compat")).complete;
 	const response = await completeFn(
 		model,
 		{

--- a/query-rewrite.ts
+++ b/query-rewrite.ts
@@ -1,5 +1,6 @@
 import type { complete, Api, Model, ProviderHeaders } from "@earendil-works/pi-ai/compat";
 import type { SummaryGenerationContext } from "./summary-review.ts";
+import { awaitWithAbort } from "./abortable.ts";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns } from "./summary-model-scope.ts";
 
 async function resolveFirstAvailableModel(
@@ -28,7 +29,9 @@ export async function rewriteSearchQuery(
 	]);
 	const registry = ctx.modelRegistry as typeof ctx.modelRegistry & { complete?: typeof complete };
 	const usesRegistryComplete = typeof registry.complete === "function";
-	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : (await import("@earendil-works/pi-ai/compat")).complete;
+	if (signal.aborted) throw new Error("Aborted");
+	const completeFn = usesRegistryComplete ? registry.complete!.bind(registry) : (await awaitWithAbort(import("@earendil-works/pi-ai/compat"), signal)).complete;
+	if (signal.aborted) throw new Error("Aborted");
 	const response = await completeFn(
 		model,
 		{

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -1,5 +1,5 @@
-import { clampThinkingLevel, type ModelThinkingLevel, type ThinkingLevel } from "@earendil-works/pi-ai";
-import { complete, completeSimple, type Api, type Message, type Model } from "@earendil-works/pi-ai/compat";
+import type { ModelThinkingLevel, ThinkingLevel } from "@earendil-works/pi-ai";
+import type { complete, completeSimple, Api, Message, Model } from "@earendil-works/pi-ai/compat";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns, splitThinkingSuffix, type SummaryThinkingLevel } from "./summary-model-scope.ts";
 import type { QueryResultData } from "./storage.ts";
@@ -204,8 +204,9 @@ function parseModelSelector(value: string): { provider: string; id: string; thin
 	};
 }
 
-function resolveThinkingLevel(model: Model<Api>, requested?: SummaryThinkingLevel): ModelThinkingLevel | undefined {
+async function resolveThinkingLevel(model: Model<Api>, requested?: SummaryThinkingLevel): Promise<ModelThinkingLevel | undefined> {
 	if (!requested) return undefined;
+	const { clampThinkingLevel } = await import("@earendil-works/pi-ai");
 	return clampThinkingLevel(model, requested as ModelThinkingLevel);
 }
 
@@ -299,7 +300,11 @@ export async function generateSummaryDraft(
 	const registry = ctx.modelRegistry as SummaryModelRegistry;
 	const customCompleteFn = completeFn !== undefined;
 	const usesRegistryComplete = !customCompleteFn && typeof registry.complete === "function";
-	completeFn ??= usesRegistryComplete ? registry.complete!.bind(registry) as CompleteFunction : complete;
+	// 仅在没有自定义 complete 且 registry 未提供时才需要 pi-ai compat（barrel 较重，按需加载）
+	const piAiCompat = customCompleteFn || usesRegistryComplete
+		? undefined
+		: await import("@earendil-works/pi-ai/compat");
+	completeFn ??= usesRegistryComplete ? registry.complete!.bind(registry) as CompleteFunction : piAiCompat!.complete;
 
 	const generationStartedAt = Date.now();
 	const deadlineController = new AbortController();
@@ -364,7 +369,7 @@ export async function generateSummaryDraft(
 					content: [{ type: "text", text: prompt }],
 					timestamp: Date.now(),
 				};
-				const requestedThinkingLevel = resolveThinkingLevel(model, thinkingLevel);
+				const requestedThinkingLevel = await resolveThinkingLevel(model, thinkingLevel);
 				const enabledThinkingLevel = requestedThinkingLevel && requestedThinkingLevel !== "off"
 					? requestedThinkingLevel as ThinkingLevel
 					: undefined;
@@ -375,7 +380,7 @@ export async function generateSummaryDraft(
 					...(enabledThinkingLevel ? { reasoningEffort: enabledThinkingLevel } : {}),
 				};
 				const completion = thinkingLevel !== undefined && !customCompleteFn && !usesRegistryComplete
-					? completeSimple(model, { messages: [userMessage] }, { apiKey, headers, signal: completionSignal, ...(enabledThinkingLevel ? { reasoning: enabledThinkingLevel } : {}) })
+					? piAiCompat!.completeSimple(model, { messages: [userMessage] }, { apiKey, headers, signal: completionSignal, ...(enabledThinkingLevel ? { reasoning: enabledThinkingLevel } : {}) })
 					: completeFn(model, { messages: [userMessage] }, completionOptions);
 
 				const response = await raceSummaryOperation(Promise.resolve(completion));

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -1,5 +1,5 @@
 import type { ModelThinkingLevel, ThinkingLevel } from "@earendil-works/pi-ai";
-import type { complete, completeSimple, Api, Message, Model } from "@earendil-works/pi-ai/compat";
+import type { complete, Api, Message, Model } from "@earendil-works/pi-ai/compat";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns, splitThinkingSuffix, type SummaryThinkingLevel } from "./summary-model-scope.ts";
 import type { QueryResultData } from "./storage.ts";
@@ -296,26 +296,21 @@ export async function generateSummaryDraft(
 	if (!ctx || !ctx.modelRegistry) {
 		throw new Error("Summary generation context unavailable");
 	}
+	if (signal?.aborted) throw new Error("Aborted");
 
 	const registry = ctx.modelRegistry as SummaryModelRegistry;
 	const customCompleteFn = completeFn !== undefined;
 	const usesRegistryComplete = !customCompleteFn && typeof registry.complete === "function";
-	// 仅在没有自定义 complete 且 registry 未提供时才需要 pi-ai compat（barrel 较重，按需加载）
-	const piAiCompat = customCompleteFn || usesRegistryComplete
-		? undefined
-		: await import("@earendil-works/pi-ai/compat");
-	completeFn ??= usesRegistryComplete ? registry.complete!.bind(registry) as CompleteFunction : piAiCompat!.complete;
+	let piAiCompat: typeof import("@earendil-works/pi-ai/compat") | undefined;
 
 	const generationStartedAt = Date.now();
 	const deadlineController = new AbortController();
 	const deadlineMarker = Symbol("summary-generation-deadline");
 	let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
-	let resolveDeadline!: () => void;
 	const deadlinePromise = new Promise<typeof deadlineMarker>(resolve => {
-		resolveDeadline = () => resolve(deadlineMarker);
 		deadlineTimer = setTimeout(() => {
 			deadlineController.abort();
-			resolveDeadline();
+			resolve(deadlineMarker);
 		}, deadlineMs);
 	});
 
@@ -331,17 +326,24 @@ export async function generateSummaryDraft(
 		? AbortSignal.any([signal, deadlineController.signal])
 		: deadlineController.signal;
 
+	function checkSummaryDeadline(): void {
+		if (signal?.aborted) throw new Error("Aborted");
+		// Imports or synchronous providers can finish before an overdue timer runs.
+		if (deadlineController.signal.aborted || Date.now() - generationStartedAt >= deadlineMs) {
+			deadlineController.abort();
+			throw deadlineMarker;
+		}
+	}
+
 	async function raceSummaryOperation<T>(operation: Promise<T>): Promise<T> {
 		// A provider may ignore AbortSignal and never settle; observe it before racing so
 		// its eventual rejection cannot become an unhandled promise rejection.
 		void operation.then(() => undefined, () => undefined);
+		checkSummaryDeadline();
 		const contenders: Promise<unknown>[] = [operation, deadlinePromise];
 		if (callerAbortPromise) contenders.push(callerAbortPromise);
 		const result = await Promise.race(contenders);
-		if (result === deadlineMarker) {
-			if (signal?.aborted) throw new Error("Aborted");
-			throw deadlineMarker;
-		}
+		checkSummaryDeadline();
 		return result as T;
 	}
 
@@ -350,12 +352,14 @@ export async function generateSummaryDraft(
 		const prompt = buildSummaryPrompt(results, feedback);
 		let resolved: Awaited<ReturnType<typeof resolveSummaryModelCandidates>>;
 		try {
+			checkSummaryDeadline();
+			if (!customCompleteFn && !usesRegistryComplete) {
+				piAiCompat = await raceSummaryOperation(import("@earendil-works/pi-ai/compat"));
+			}
+			completeFn ??= usesRegistryComplete ? registry.complete!.bind(registry) as CompleteFunction : piAiCompat!.complete;
 			resolved = await raceSummaryOperation(resolveSummaryModelCandidates(ctx, modelOverride));
 		} catch (err) {
-			if (signal?.aborted) throw new Error("Aborted");
-			if (err === deadlineMarker || deadlineController.signal.aborted) {
-				return buildFallbackSummary(results, "summary-generation-timeout", Date.now() - generationStartedAt);
-			}
+			checkSummaryDeadline();
 			const message = err instanceof Error ? err.message : String(err);
 			return buildFallbackSummary(results, `summary-model-settings-error: ${message}`, Date.now() - generationStartedAt);
 		}
@@ -369,7 +373,7 @@ export async function generateSummaryDraft(
 					content: [{ type: "text", text: prompt }],
 					timestamp: Date.now(),
 				};
-				const requestedThinkingLevel = await resolveThinkingLevel(model, thinkingLevel);
+				const requestedThinkingLevel = await raceSummaryOperation(resolveThinkingLevel(model, thinkingLevel));
 				const enabledThinkingLevel = requestedThinkingLevel && requestedThinkingLevel !== "off"
 					? requestedThinkingLevel as ThinkingLevel
 					: undefined;
@@ -379,6 +383,7 @@ export async function generateSummaryDraft(
 					...(requestedThinkingLevel ? { reasoning: requestedThinkingLevel } : {}),
 					...(enabledThinkingLevel ? { reasoningEffort: enabledThinkingLevel } : {}),
 				};
+				checkSummaryDeadline();
 				const completion = thinkingLevel !== undefined && !customCompleteFn && !usesRegistryComplete
 					? piAiCompat!.completeSimple(model, { messages: [userMessage] }, { apiKey, headers, signal: completionSignal, ...(enabledThinkingLevel ? { reasoning: enabledThinkingLevel } : {}) })
 					: completeFn(model, { messages: [userMessage] }, completionOptions);
@@ -413,10 +418,7 @@ export async function generateSummaryDraft(
 					},
 				};
 			} catch (err) {
-				if (signal?.aborted) throw new Error("Aborted");
-				if (err === deadlineMarker || deadlineController.signal.aborted) {
-					return buildFallbackSummary(results, "summary-generation-timeout", Date.now() - generationStartedAt);
-				}
+				checkSummaryDeadline();
 				if (isAbortError(err)) throw err;
 				lastError = err instanceof Error ? err.message : String(err);
 			}
@@ -427,6 +429,12 @@ export async function generateSummaryDraft(
 			lastError ? `summary-model-unavailable: ${lastError}` : "summary-model-unavailable",
 			Date.now() - generationStartedAt,
 		);
+	} catch (err) {
+		if (signal?.aborted) throw new Error("Aborted");
+		if (err === deadlineMarker) {
+			return buildFallbackSummary(results, "summary-generation-timeout", Date.now() - generationStartedAt);
+		}
+		throw err;
 	} finally {
 		if (deadlineTimer) clearTimeout(deadlineTimer);
 		if (signal && callerAbortListener) signal.removeEventListener("abort", callerAbortListener);

--- a/test/extract-cold-deadline.test.mjs
+++ b/test/extract-cold-deadline.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const extractUrl = new URL("../extract.ts", import.meta.url).href;
+for (const scenario of ["import-timer", "import-elapsed", "html-processing", "image-processing", "caller-abort"]) {
+	test(`direct extraction rejects late success: ${scenario}`, () => {
+		const loader = `
+			export async function resolve(s, c, next) {
+				if (s === "linkedom") {
+					const real = await next(s, c);
+					const source = 'export * from ' + JSON.stringify(real.url) + '; globalThis.importStarted(); await globalThis.importGate;';
+					return { url: "data:text/javascript," + encodeURIComponent(source), shortCircuit: true };
+				}
+				if (s === "turndown") {
+					const real = await next(s, c);
+					const source = 'import Real from ' + JSON.stringify(real.url) + '; export default class extends Real { turndown(html) { const result = super.turndown(html); globalThis.processing(); return result; } }';
+					return { url: "data:text/javascript," + encodeURIComponent(source), shortCircuit: true };
+				}
+				if (s === "@earendil-works/pi-coding-agent") {
+					return { url: "data:text/javascript," + encodeURIComponent('export async function resizeImage() { globalThis.processing(); return { width: 1, height: 1, data: "AA==", mimeType: "image/png" }; }'), shortCircuit: true };
+				}
+				return next(s, c);
+			}
+		`;
+		const child = spawnSync(process.execPath, ["--input-type=module"], {
+			encoding: "utf8", timeout: 10_000,
+			input: `
+				import assert from "node:assert/strict";
+				import { register } from "node:module";
+				import { mock } from "node:test";
+				import { mkdtemp, writeFile, rm } from "node:fs/promises";
+				import { tmpdir } from "node:os";
+				import { join } from "node:path";
+				register("data:text/javascript," + encodeURIComponent(${JSON.stringify(loader)}), import.meta.url);
+				const root = await mkdtemp(join(tmpdir(), "extract-cold-deadline-"));
+				process.env.PI_CODING_AGENT_DIR = root;
+				await writeFile(join(root, "web-search.json"), JSON.stringify({ fetch: { timeout: 0.1 }, fetchRouting: { providers: ["http"] } }));
+				const scenario = ${JSON.stringify(scenario)};
+				const image = scenario === "image-processing" || scenario === "caller-abort";
+				globalThis.fetch = async () => new Response(image ? "image" : '<html><head><title>Article</title></head><body><article><h1>Article</h1><p>' + 'A useful article with enough readable text for successful extraction. '.repeat(30) + '</p></article></body></html>', { headers: { "content-type": image ? "image/png" : "text/html" } });
+				const { extractContent } = await import(${JSON.stringify(extractUrl)});
+				const started = new Promise(resolve => { globalThis.importStarted = resolve; });
+				let release;
+				globalThis.importGate = new Promise(resolve => { release = resolve; });
+				const controller = new AbortController();
+				globalThis.processing = () => {
+					if (scenario.endsWith("processing") || scenario === "caller-abort") mock.timers.setTime(101);
+					if (scenario === "caller-abort") controller.abort();
+				};
+				mock.timers.enable({ apis: ["Date", "setTimeout"], now: 0 });
+				try {
+					const pending = extractContent("https://example.com/article", controller.signal, { lookup: async () => [{ address: "93.184.216.34", family: 4 }] });
+					if (!image) {
+						await started;
+						if (scenario === "import-timer") mock.timers.tick(100);
+						if (scenario === "import-elapsed") mock.timers.setTime(101);
+						release();
+					}
+					const result = await pending;
+					if (scenario === "caller-abort") assert.equal(result.error, "Aborted");
+					else assert.ok(result.error?.startsWith("The operation was aborted."), JSON.stringify(result));
+					assert.equal(result.content, "");
+					assert.equal(result.thumbnail, undefined);
+				} finally {
+					mock.timers.reset();
+					await rm(root, { recursive: true, force: true });
+				}
+			`,
+		});
+		assert.equal(child.status, 0, `${child.error ?? ""}\n${child.stderr}`);
+	});
+}

--- a/test/query-cold-abort.test.mjs
+++ b/test/query-cold-abort.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+for (const kind of ["page", "rewrite"]) {
+	for (const outcome of ["resolve", "reject"]) {
+		test(`${kind} cancels before cold compat import ${outcome}s without late completion`, () => {
+			const moduleUrl = new URL(kind === "page" ? "../page-query.ts" : "../query-rewrite.ts", import.meta.url).href;
+			const source = `
+				globalThis.importStarted();
+				await globalThis.importGate;
+				export function complete() { globalThis.calls++; return { content: [{ text: "late" }] }; }
+			`;
+			const loader = `export async function resolve(s, c, next) {
+				if (s === "@earendil-works/pi-ai/compat") return { url: ${JSON.stringify("data:text/javascript," + encodeURIComponent(source))}, shortCircuit: true };
+				return next(s, c);
+			}`;
+			const child = spawnSync(process.execPath, ["--input-type=module"], {
+				encoding: "utf8", timeout: 10_000,
+				input: `
+					import assert from "node:assert/strict";
+					import { register } from "node:module";
+					import { mkdtemp, rm } from "node:fs/promises";
+					import { tmpdir } from "node:os";
+					import { join } from "node:path";
+					register("data:text/javascript," + encodeURIComponent(${JSON.stringify(loader)}), import.meta.url);
+					const root = await mkdtemp(join(tmpdir(), "query-cold-abort-"));
+					process.env.PI_CODING_AGENT_DIR = root;
+					try {
+						const api = await import(${JSON.stringify(moduleUrl)});
+						const started = new Promise(resolve => { globalThis.importStarted = resolve; });
+						let release, reject;
+						globalThis.importGate = new Promise((yes, no) => { release = yes; reject = no; });
+						globalThis.calls = 0;
+						const model = { provider: "anthropic", id: "claude-haiku-4-5", input: ["text"], contextWindow: 10000 };
+						const ctx = { model, cwd: root, isProjectTrusted: () => false, modelRegistry: {
+							find: () => model, getAvailable: () => [model], getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test" }),
+						} };
+						const controller = new AbortController();
+						const pending = ${JSON.stringify(kind)} === "page"
+							? api.answerFromPage({ question: "Q", pageText: "P", sourceUrl: "https://example.com" }, ctx, controller.signal)
+							: api.rewriteSearchQuery("Q", ctx, controller.signal);
+						const rejected = assert.rejects(pending, /^Error: Aborted$/);
+						await started;
+						controller.abort();
+						// Import remains gated until the public operation acknowledges cancellation.
+						await rejected;
+						if (${JSON.stringify(outcome)} === "reject") reject(new Error("late import failure"));
+						else release();
+						await import("@earendil-works/pi-ai/compat").catch(() => {});
+						await new Promise(resolve => setImmediate(resolve));
+						assert.equal(globalThis.calls, 0);
+					} finally { await rm(root, { recursive: true, force: true }); }
+				`,
+			});
+			assert.equal(child.status, 0, `${child.error ?? ""}\n${child.stderr}`);
+		});
+	}
+}

--- a/test/summary-cold-deadline.test.mjs
+++ b/test/summary-cold-deadline.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const summaryUrl = new URL("../summary-review.ts", import.meta.url).href;
+
+test("pre-aborted summary rejects without creating an unhandled abort contender", async () => {
+	const { generateSummaryDraft } = await import(summaryUrl);
+	await assert.rejects(generateSummaryDraft([], { modelRegistry: {} }, AbortSignal.abort()), /Aborted/);
+	// Let node:test observe any rejected contender left behind after the public rejection.
+	await new Promise(resolve => setImmediate(resolve));
+});
+
+for (const mode of ["compat", "thinking"]) {
+	for (const scenario of ["pending-import", "expired-import", "expired-completion", "expired-throw", "expired-rejection", "caller-abort"]) {
+		test(`summary ${mode}: ${scenario} respects cancellation on cold first use`, () => {
+			const child = spawnSync(process.execPath, ["--input-type=module"], {
+				input: buildChildScript(mode, scenario),
+				encoding: "utf8",
+				timeout: 10_000,
+			});
+			assert.equal(child.status, 0, `${child.error ?? ""}\n${child.stderr}`);
+		});
+	}
+}
+
+function buildChildScript(mode, scenario) {
+	const specifier = mode === "compat" ? "@earendil-works/pi-ai/compat" : "@earendil-works/pi-ai";
+	const moduleSource = `
+		globalThis.importStarted();
+		await globalThis.importGate;
+		export const complete = (...args) => globalThis.testComplete(...args);
+		export const completeSimple = complete;
+		export const clampThinkingLevel = (_model, level) => level;
+	`;
+	const loaderSource = `
+		export async function resolve(specifier, context, next) {
+			if (specifier === ${JSON.stringify(specifier)}) return { url: ${JSON.stringify("data:text/javascript," + encodeURIComponent(moduleSource))}, shortCircuit: true };
+			return next(specifier, context);
+		}
+	`;
+	return `
+		import assert from "node:assert/strict";
+		import { mkdtemp, rm } from "node:fs/promises";
+		import { tmpdir } from "node:os";
+		import { join } from "node:path";
+		import { register } from "node:module";
+		import { mock } from "node:test";
+
+		register("data:text/javascript," + encodeURIComponent(${JSON.stringify(loaderSource)}), import.meta.url);
+		const agentDir = await mkdtemp(join(tmpdir(), "summary-cold-deadline-"));
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		const { generateSummaryDraft } = await import(${JSON.stringify(summaryUrl)});
+		const scenario = ${JSON.stringify(scenario)};
+		const importStarted = new Promise(resolve => { globalThis.importStarted = resolve; });
+		let releaseImport;
+		globalThis.importGate = new Promise(resolve => { releaseImport = resolve; });
+		let calls = 0;
+		globalThis.testComplete = (_model, _context, options) => {
+			calls++;
+			assert.equal(options.signal.aborted, false, "must not invoke an expired provider");
+			const failAfterExpiry = () => {
+				mock.timers.setTime(101);
+				throw new Error("late provider failure");
+			};
+			if (scenario === "expired-throw") failAfterExpiry();
+			if (scenario === "expired-rejection") return Promise.resolve().then(failAfterExpiry);
+			if (scenario === "expired-completion") mock.timers.setTime(101);
+			return Promise.resolve({ stopReason: "stop", content: [{ type: "text", text: "Late answer" }] });
+		};
+		const model = { provider: "test", id: "model", reasoning: true };
+		const registry = {
+			find: (provider, id) => provider === model.provider && id === model.id ? model : undefined,
+			getAvailable: () => [model],
+			getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-key" }),
+			...(${JSON.stringify(mode)} === "thinking" ? { complete: globalThis.testComplete } : {}),
+		};
+		const controller = new AbortController();
+		mock.timers.enable({ apis: ["Date", "setTimeout"], now: 0 });
+		try {
+			const pending = generateSummaryDraft([], {
+				modelRegistry: registry, cwd: agentDir, isProjectTrusted: () => false,
+			}, controller.signal, "test/model" + (${JSON.stringify(mode)} === "thinking" ? ":high" : ""), undefined, undefined, 100);
+			// Wait for cold module evaluation before advancing the clock.
+			await importStarted;
+			if (scenario === "caller-abort") {
+				controller.abort();
+				await assert.rejects(pending, /Aborted/);
+			} else {
+				if (scenario === "pending-import") {
+					mock.timers.tick(100);
+					// The module is still gated: timeout must settle without waiting for its import.
+				} else {
+					if (scenario === "expired-import") mock.timers.setTime(101);
+					releaseImport();
+				}
+				const result = await pending;
+				assert.equal(result.meta.fallbackUsed, true);
+				assert.equal(result.meta.fallbackReason, "summary-generation-timeout");
+				assert.ok(result.meta.durationMs >= 100);
+				assert.notEqual(result.summary, "Late answer");
+			}
+			releaseImport();
+			await import(${JSON.stringify(specifier)});
+			await new Promise(resolve => setImmediate(resolve));
+			assert.equal(calls, ["expired-completion", "expired-throw", "expired-rejection"].includes(scenario) ? 1 : 0, "cold import must not start completion after cancellation");
+		} finally {
+			mock.timers.reset();
+			await rm(agentDir, { recursive: true, force: true });
+		}
+	`;
+}


### PR DESCRIPTION
## Summary

- lazy-load heavy extraction and AI helpers so extension registration avoids their startup cost
- preserve schema, provider-selection, and first-use behavior
- include cold compat/thinking initialization, late success/failure, and caller cancellation in the summary deadline
- add deterministic regressions, remove the remaining eager Linkedom import, and preserve contributor authorship and changelog credit

## Validation

- focused lazy-load, summary, page-query, query-rewrite, extraction, and proxy tests passed after promotion
- `npm test` — full suite passed after composition with current main
- `npm run typecheck`
- `git diff --check`
- mandatory two challenges, deslop, simplification, and fresh independent review completed

Replacement for #366 because backlog authority does not extend to writing the contributor's fork. Thanks to [@ducaoya](https://github.com/ducaoya) for the original implementation.
