### PR TITLE
feat: add prompt-scoped curator auto-summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added a Curator action to approve the current summary and use auto-summary for later default-workflow searches in the same prompt run without persisting the choice. Thanks to [@thomak-dev](https://github.com/thomak-dev) for issue #376.
 - Added an explicit-only SerpApi Google Search provider with `serpapiApiKey` / `SERPAPI_KEY`, domain filtering, recency filtering, routing, and Curator support. Thanks to [@tanysheng](https://github.com/tanysheng) for PR #363.
 - Added SOCKS4, SOCKS4A, SOCKS5, and SOCKS5H proxy support through config and per-call overrides. Thanks to [@phillipzink](https://github.com/phillipzink) for PR #365.
 - Added 1Password service-account support for credential resolver commands by forwarding `OP_SERVICE_ACCOUNT_TOKEN`. Thanks to PR author [@Avg8888](https://github.com/Avg8888) and commit author [@xapids](https://github.com/xapids) for [PR #364](https://github.com/nicobailon/pi-web-access/pull/364).

--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ Open the search curator directly. Runs searches and lets you review, add, select
 
 Results get injected into the conversation when you approve the summary or click "Send selected results without summary". On timeout, the curator auto-submits and falls back to a deterministic summary if no approved draft is present.
 
+In summary review, **Approve + auto-summary remaining searches for this prompt** approves the current draft and makes later default `summary-review` calls in the same prompt run use `auto-summary`. Explicit per-call workflows still win. The choice survives internal model/tool turns, clears when the run settles or a new prompt/session starts, is not written to `web-search.json`, and does not affect already-open curator windows.
+
 ### /curator
 
 Toggle or configure the curator workflow at runtime.

--- a/curator-page.ts
+++ b/curator-page.ts
@@ -150,6 +150,7 @@ ${CSS}
 <button class="btn btn-secondary" id="btn-summary-regenerate">Regenerate</button>
 <button class="btn btn-secondary" id="btn-summary-preview" title="Preview rendered summary">Preview</button>
 <button class="btn btn-submit" id="btn-summary-approve">Approve</button>
+<button class="btn btn-submit" id="btn-summary-approve-remaining">Approve + auto-summary remaining searches for this prompt</button>
 </div>
 </section>
 </main>
@@ -1198,6 +1199,7 @@ main {
 }
 .summary-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
@@ -1535,6 +1537,7 @@ const SCRIPT = `(function() {
   var btnSummaryRegenerate = document.getElementById("btn-summary-regenerate");
   var btnSummaryPreview = document.getElementById("btn-summary-preview");
   var btnSummaryApprove = document.getElementById("btn-summary-approve");
+  var btnSummaryApproveRemaining = document.getElementById("btn-summary-approve-remaining");
   var successOverlay = document.getElementById("success-overlay");
   var successText = document.getElementById("success-text");
   var expiredOverlay = document.getElementById("expired-overlay");
@@ -2117,6 +2120,9 @@ const SCRIPT = `(function() {
     if (btnSummaryPreview) btnSummaryPreview.disabled = !hasDraft || stage === "generating-summary";
     if (btnSummaryApprove) {
       btnSummaryApprove.disabled = submitted || timerExpired || submitInFlight || stage === "generating-summary" || isRegenerating || !hasSelection || !hasDraft;
+    }
+    if (btnSummaryApproveRemaining) {
+      btnSummaryApproveRemaining.disabled = submitted || timerExpired || submitInFlight || stage === "generating-summary" || isRegenerating || !hasSelection || !hasDraft;
     }
 
     applyProviderInterlocks();
@@ -3209,7 +3215,7 @@ const SCRIPT = `(function() {
     requestSummary(selected);
   }
 
-  function doApprove() {
+  function doApprove(autoApproveRemainingSearches) {
     if (submitted || timerExpired || submitInFlight || stage !== "summary-review") return;
 
     var selected = getSelectedIndices();
@@ -3221,6 +3227,7 @@ const SCRIPT = `(function() {
 
     var draft = getSummaryDraftText();
     var payload = { selected: selected };
+    if (autoApproveRemainingSearches === true) payload.autoApproveRemainingSearches = true;
     if (draft.length > 0) {
       payload.summary = draft;
       payload.summaryMeta = normalizeSummaryMeta(summaryMeta, summaryMeta && summaryMeta.edited === true);
@@ -3455,6 +3462,13 @@ const SCRIPT = `(function() {
   if (btnSummaryApprove) {
     btnSummaryApprove.addEventListener("click", function() {
       doApprove();
+      resetTimer();
+    });
+  }
+
+  if (btnSummaryApproveRemaining) {
+    btnSummaryApproveRemaining.addEventListener("click", function() {
+      doApprove(true);
       resetTimer();
     });
   }

--- a/curator-run.ts
+++ b/curator-run.ts
@@ -1,0 +1,44 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export type WebSearchWorkflow = "none" | "summary-review" | "auto-summary";
+
+export function resolveWebSearchWorkflow(input: unknown, hasUI: boolean): WebSearchWorkflow {
+	const normalized = typeof input === "string" ? input.trim().toLowerCase() : "";
+	if (normalized === "auto-summary") return "auto-summary";
+	if (!hasUI) return "none";
+	if (normalized === "none") return "none";
+	return "summary-review";
+}
+
+export class CuratorRunState {
+	private autoApproveRemaining = false;
+
+	approveRemainingSearches(): void {
+		this.autoApproveRemaining = true;
+	}
+
+	reset(): void {
+		this.autoApproveRemaining = false;
+	}
+
+	resolve(requestedWorkflow: unknown, configuredWorkflow: unknown, hasUI: boolean): WebSearchWorkflow {
+		const inherited = requestedWorkflow === undefined;
+		const workflow = resolveWebSearchWorkflow(
+			inherited ? configuredWorkflow : requestedWorkflow,
+			hasUI,
+		);
+		return inherited && this.autoApproveRemaining && workflow === "summary-review"
+			? "auto-summary"
+			: workflow;
+	}
+}
+
+export function registerCuratorRunLifecycle(pi: Pick<ExtensionAPI, "on">): CuratorRunState {
+	const state = new CuratorRunState();
+	pi.on("before_agent_start", () => state.reset());
+	pi.on("agent_settled", () => state.reset());
+	pi.on("session_start", () => state.reset());
+	pi.on("session_tree", () => state.reset());
+	pi.on("session_shutdown", () => state.reset());
+	return state;
+}

--- a/curator-server.ts
+++ b/curator-server.ts
@@ -41,7 +41,7 @@ export interface IndexedCuratorSearchEntry extends CuratorSearchEntry {
 }
 
 export interface CuratorServerCallbacks {
-	onSubmit: (payload: { selectedQueryIndices: number[]; summary?: string; summaryMeta?: SummaryMeta; rawResults?: boolean }) => void;
+	onSubmit: (payload: { selectedQueryIndices: number[]; summary?: string; summaryMeta?: SummaryMeta; rawResults?: boolean; autoApproveRemainingSearches?: boolean }) => void;
 	onCancel: (reason: "user" | "timeout" | "stale") => void;
 	onProviderChange: (provider: string) => void;
 	onAddSearch: (query: string, provider?: string) => Promise<CuratorSearchEntry[]>;
@@ -642,12 +642,14 @@ export function startCuratorServer(
 					return;
 				}
 				const rawResults = (body as { rawResults?: unknown }).rawResults === true;
+				const autoApproveRemainingSearches = (body as { autoApproveRemainingSearches?: unknown }).autoApproveRemainingSearches === true;
 				sendJson(res, 200, { ok: true });
 				setImmediate(() => callbacks.onSubmit({
 					selectedQueryIndices: parsed.indices,
 					...(summary !== undefined ? { summary } : {}),
 					...(summaryMeta !== undefined ? { summaryMeta } : {}),
 					rawResults,
+					...(autoApproveRemainingSearches ? { autoApproveRemainingSearches: true } : {}),
 				}));
 				return;
 			}

--- a/index.ts
+++ b/index.ts
@@ -75,6 +75,7 @@ import { isValyuAvailable } from "./valyu.ts";
 import { isXcrawlAvailable } from "./xcrawl.ts";
 import { buildSearchErrorPlan, type SearchErrorDetails, type SearchErrorPlan } from "./render-search-error.ts";
 import { findModelWithProviderRouting, loadEnabledModelPatterns, modelMatchesEnabledPatterns, splitThinkingSuffix } from "./summary-model-scope.ts";
+import { registerCuratorRunLifecycle, resolveWebSearchWorkflow, type WebSearchWorkflow } from "./curator-run.ts";
 import {
 	buildResearchArtifact,
 	withClaimAssessment,
@@ -182,7 +183,6 @@ interface WebSearchConfig {
 	};
 }
 
-type WebSearchWorkflow = "none" | "summary-review" | "auto-summary";
 type CuratorWorkflow = "summary-review";
 export type CuratorProvider = Exclude<SearchProvider, "auto">;
 type SummaryWorkflow = "summary-review" | "auto-summary";
@@ -357,14 +357,6 @@ function normalizeCuratorTimeoutSeconds(value: unknown): number | undefined {
 	const normalized = Math.floor(value);
 	if (normalized < 1) return undefined;
 	return Math.min(normalized, MAX_CURATOR_TIMEOUT_SECONDS);
-}
-
-function resolveWorkflow(input: unknown, hasUI: boolean): WebSearchWorkflow {
-	const normalized = typeof input === "string" ? input.trim().toLowerCase() : "";
-	if (normalized === "auto-summary") return "auto-summary";
-	if (!hasUI) return "none";
-	if (normalized === "none") return "none";
-	return "summary-review";
 }
 
 function normalizeQueryList(queryList: unknown[]): string[] {
@@ -1071,6 +1063,7 @@ function handleSessionChange(ctx: ExtensionContext): void {
 
 export default function (pi: ExtensionAPI) {
 	const initConfig = loadConfigForExtensionInit();
+	const curatorRunState = registerCuratorRunLifecycle(pi);
 	installGlobalProxyFetch();
 	const toolNames = resolveToolNames(initConfig);
 	const webSearchEnabled = isToolEnabled(initConfig, "webSearch");
@@ -1572,6 +1565,7 @@ export default function (pi: ExtensionAPI) {
 					},
 					onSubmit(payload) {
 						if (pendingCurates.get(callId) !== pc) return;
+						if (payload.autoApproveRemainingSearches) curatorRunState.approveRemainingSearches();
 						searchAbort.abort();
 						const filtered = payload.selectedQueryIndices.length > 0
 							? filterByQueryIndices(payload.selectedQueryIndices, pc.searchResults)
@@ -1776,8 +1770,12 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	pi.on("session_start", async (_event, ctx) => handleSessionChange(ctx));
-	pi.on("session_tree", async (_event, ctx) => handleSessionChange(ctx));
+	pi.on("session_start", async (_event, ctx) => {
+		handleSessionChange(ctx);
+	});
+	pi.on("session_tree", async (_event, ctx) => {
+		handleSessionChange(ctx);
+	});
 
 	pi.on("session_shutdown", () => {
 		sessionActive = false;
@@ -1826,7 +1824,7 @@ export default function (pi: ExtensionAPI) {
 					: (params.query !== undefined ? expandQueryString(params.query) : []);
 				const queryList = normalizeQueryList(rawQueryList);
 				const configWorkflow = loadConfigForExtensionInit().workflow;
-				const workflow = resolveWorkflow(params.workflow ?? configWorkflow, ctx?.hasUI !== false);
+				const workflow = curatorRunState.resolve(params.workflow, configWorkflow, ctx?.hasUI !== false);
 				const shouldCurate = workflow === "summary-review";
 				const recencyFilter = normalizeRecencyFilter(params.recencyFilter);
 
@@ -3437,7 +3435,7 @@ export default function (pi: ExtensionAPI) {
 
 			let newWorkflow: WebSearchWorkflow;
 			if (arg.length === 0) {
-				const current = resolveWorkflow(loadConfigForExtensionInit().workflow, true);
+				const current = resolveWebSearchWorkflow(loadConfigForExtensionInit().workflow, true);
 				newWorkflow = current === "none" ? "summary-review" : "none";
 			} else if (arg === "on") {
 				newWorkflow = "summary-review";

--- a/test/auto-summary-source.test.mjs
+++ b/test/auto-summary-source.test.mjs
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
+import { resolveWebSearchWorkflow } from "../curator-run.ts";
 
 const indexSrc = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
 const readmeSrc = readFileSync(new URL("../README.md", import.meta.url), "utf8");
 
 test("web_search accepts auto-summary workflow in schema and config resolution", () => {
-	assert.match(indexSrc, /type WebSearchWorkflow = "none" \| "summary-review" \| "auto-summary"/);
 	assert.match(indexSrc, /StringEnum\(\["none", "summary-review", "auto-summary"\]/);
-	assert.match(indexSrc, /normalized === "auto-summary"/);
+	assert.equal(resolveWebSearchWorkflow("auto-summary", true), "auto-summary");
 	assert.match(indexSrc, /arg === "none" \|\| arg === "summary-review" \|\| arg === "auto-summary"/);
 });
 

--- a/test/curator-run.test.mjs
+++ b/test/curator-run.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { CuratorRunState, registerCuratorRunLifecycle } from "../curator-run.ts";
+
+test("approval changes only inherited summary-review workflows for the current prompt", () => {
+	const state = new CuratorRunState();
+	state.approveRemainingSearches();
+
+	assert.equal(state.resolve(undefined, undefined, true), "auto-summary");
+	assert.equal(state.resolve(undefined, "summary-review", true), "auto-summary");
+	assert.equal(state.resolve(undefined, "none", true), "none");
+	assert.equal(state.resolve(undefined, "auto-summary", true), "auto-summary");
+
+	for (const explicit of ["none", "auto-summary", "summary-review"]) {
+		assert.equal(state.resolve(explicit, "summary-review", true), explicit);
+	}
+});
+
+test("registered lifecycle preserves approval across internal turns and resets at run boundaries", async () => {
+	const handlers = new Map();
+	const state = registerCuratorRunLifecycle({
+		on(event, handler) { handlers.set(event, handler); },
+	});
+
+	await handlers.get("before_agent_start")?.({}, {});
+	state.approveRemainingSearches();
+
+	// A multi-tool agent loop crosses these internal boundaries. They must not
+	// clear a preference selected while handling the original user prompt.
+	await handlers.get("turn_end")?.({}, {});
+	await handlers.get("turn_start")?.({}, {});
+	assert.equal(state.resolve(undefined, "summary-review", true), "auto-summary");
+	assert.equal(state.resolve("summary-review", "none", true), "summary-review");
+
+	await handlers.get("agent_settled")?.({}, {});
+	assert.equal(state.resolve(undefined, "summary-review", true), "summary-review");
+
+	state.approveRemainingSearches();
+	await handlers.get("session_tree")?.({}, {});
+	assert.equal(state.resolve(undefined, "summary-review", true), "summary-review");
+});
+
+test("extension reload clears auto-approval", () => {
+	const state = new CuratorRunState();
+	state.approveRemainingSearches();
+	const reloadedExtensionState = new CuratorRunState();
+	assert.equal(reloadedExtensionState.resolve(undefined, "summary-review", true), "summary-review");
+});
+
+test("run approval is in-memory and does not modify web-search.json", () => {
+	const root = mkdtempSync(join(tmpdir(), "pi-curator-run-"));
+	const configPath = join(root, "web-search.json");
+	const original = '{"workflow":"summary-review"}\n';
+	writeFileSync(configPath, original, "utf8");
+
+	const state = new CuratorRunState();
+	state.approveRemainingSearches();
+	assert.equal(state.resolve(undefined, "summary-review", true), "auto-summary");
+	assert.equal(readFileSync(configPath, "utf8"), original);
+});

--- a/test/curator-server-timeout.test.mjs
+++ b/test/curator-server-timeout.test.mjs
@@ -298,3 +298,35 @@ test("curator state replay keeps all-provider entries that share one slot", asyn
 		handle.close();
 	}
 });
+
+test("curator exposes and signals approve remaining searches for this prompt", async () => {
+	const { startCuratorServer } = await loadServer();
+	let resolveSubmit;
+	const submitPromise = new Promise((resolve) => { resolveSubmit = resolve; });
+	const callbacks = baseCallbacks(() => {});
+	callbacks.onSubmit = resolveSubmit;
+	const handle = await startCuratorServer(baseOptions(20), callbacks);
+
+	try {
+		const pageResponse = await fetch(handle.url);
+		assert.equal(pageResponse.status, 200);
+		assert.match(await pageResponse.text(), /Approve \+ auto-summary remaining searches for this prompt/);
+
+		const response = await fetch(new URL("/submit", handle.url), {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				token: "test-token",
+				selected: [0],
+				summary: "Approved draft",
+				autoApproveRemainingSearches: true,
+			}),
+		});
+		assert.equal(response.status, 200);
+		const payload = await withTimeout(submitPromise, "approve remaining submit");
+		assert.equal(payload.summary, "Approved draft");
+		assert.equal(payload.autoApproveRemainingSearches, true);
+	} finally {
+		handle.close();
+	}
+});


### PR DESCRIPTION
## Summary

Adds a Curator action that approves the current draft and uses `auto-summary` for later default-workflow searches in the same prompt-driven agent run.

- explicit per-call workflows remain authoritative
- the preference survives internal model/tool turns
- it resets at prompt-run and session boundaries
- it remains in memory and never writes `web-search.json`
- already-open parallel Curator windows are unchanged

Thanks to [@thomak-dev](https://github.com/thomak-dev) for #376.

Fixes #376.

## Validation

- focused Curator lifecycle/server tests — 16/16 passed
- `npm run typecheck` — passed
- `npm test` — 726/726 passed
- `npm run audit:runtime` — 0 vulnerabilities
- `git diff --check origin/main` — passed
