### PR TITLE
fix: classify Tavily plan exhaustion as quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Classified Tavily HTTP 432 monthly plan exhaustion as quota so configured search routing can fall back. Thanks to [@simbel](https://github.com/simbel) for issue #378.
 - Refuse to send Pi-resolved OpenAI credentials to the default official Responses endpoint when their effective provider `baseUrl` is custom; configure `openaiResponsesUrl` explicitly for gateway search. Thanks to [@projectkite](https://github.com/projectkite) for issue #367.
 - Fixed expired fetched-content payloads remaining in memory after cache pruning, preserving the retrieval window and session history. Thanks to [@MDGChamomile](https://github.com/MDGChamomile) for issue #362.
 - Fixed no-environment web-search config lookup to use Pi's agent directory (`~/.pi/agent/web-search.json`) without implicitly falling back to the legacy `~/.pi/web-search.json`. Existing `PI_CODING_AGENT_DIR` and XDG compatibility behavior remain unchanged. Thanks to [@lJoublanc](https://github.com/lJoublanc) for issue #360.

--- a/gemini-search.ts
+++ b/gemini-search.ts
@@ -312,7 +312,7 @@ function classifyProviderError(provider: ResolvedSearchProvider, err: unknown): 
 		kind = "unsupported";
 	} else if (status === 400 || status === 422) {
 		kind = "invalid-request";
-	} else if (status === 402 || status === 429) {
+	} else if (status === 402 || status === 429 || (provider === "tavily" && status === 432)) {
 		kind = "quota";
 	} else if (status !== undefined && (status === 408 || status === 425 || status >= 500)) {
 		kind = "transient";

--- a/test/search-routing.test.mjs
+++ b/test/search-routing.test.mjs
@@ -90,6 +90,36 @@ test("configured routing fails closed on quota errors not selected by fallbackOn
 	assert.deepEqual(output.calls, ["https://api.search.brave.com/res/v1/web/search?q=quota+route&count=5"]);
 });
 
+test("configured routing falls back from Tavily monthly plan exhaustion", async () => {
+	const home = await createConfig({
+		searchRouting: { providers: ["tavily", "brave"], fallbackOn: ["quota"] },
+	});
+	const child = runChild(`
+		const calls = [];
+		globalThis.fetch = async (url) => {
+			calls.push(String(url));
+			if (String(url) === "https://api.tavily.com/search") return new Response("Monthly plan usage limit exceeded", { status: 432 });
+			if (String(url).startsWith("https://api.search.brave.com/")) {
+				return new Response(JSON.stringify({ web: { results: [{ title: "Brave fallback", url: "https://example.com/brave", description: "Fallback answer" }] } }), { status: 200 });
+			}
+			throw new Error("Unexpected fetch " + url);
+		};
+		const { search } = await import(${JSON.stringify(searchModuleUrl)});
+		const result = await search("tavily quota route", { provider: "auto" });
+		console.log(JSON.stringify({ provider: result.provider, answer: result.answer, calls }));
+	`, {
+		PI_CODING_AGENT_DIR: home,
+		TAVILY_API_KEY: "tavily-test-key",
+		BRAVE_API_KEY: "brave-test-key",
+	});
+
+	assert.equal(child.status, 0, child.stderr);
+	const output = JSON.parse(child.stdout.trim());
+	assert.equal(output.provider, "brave");
+	assert.equal(output.answer, "Fallback answer\nSource: Brave fallback (https://example.com/brave)");
+	assert.deepEqual(output.calls, ["https://api.tavily.com/search", "https://api.search.brave.com/res/v1/web/search?q=tavily+quota+route&count=5"]);
+});
+
 test("auth status fails closed even when the response text looks like quota", async () => {
 	const home = await createConfig({
 		searchRouting: { providers: ["brave", "tavily"], fallbackOn: ["quota"] },


### PR DESCRIPTION
## Summary
- classify Tavily HTTP 432 monthly plan exhaustion as quota
- allow configured quota routing to continue to the next provider
- add a focused routing regression and credit the reporter

Closes #378

## Validation
- `node --test test/search-routing.test.mjs` (19/19)
- `npm run typecheck`
- fresh independent review: clean