### PR TITLE
docs: list Crawl4AI in the provider summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- List Crawl4AI in the README provider summary and the package description, which both still omitted it after the provider shipped in 0.29.0. Thanks to [@bergheim](https://github.com/bergheim) for [PR #382](https://github.com/nicobailon/pi-web-access/pull/382).
+
 ## [0.29.0] - 2026-09-10
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Pi Web Access
 
-**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Kagi, Bocha, Ollama, AnySearch, XCrawl, Valyu, xAI/Grok, Mistral, Bright Data SERP, SerpBase, SerpApi, Serper, self-hosted SearXNG, keyless DuckDuckGo, optional browser-cookie Gemini Web, Kimi Code Plan search, or bring your own API keys.**
+**Web search, content extraction, and video understanding for Pi agent. OpenAI/Codex search, zero-config Exa search, Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Kagi, Bocha, Ollama, AnySearch, XCrawl, Valyu, xAI/Grok, Mistral, Bright Data SERP, SerpBase, SerpApi, Serper, self-hosted SearXNG, self-hosted Crawl4AI extraction, keyless DuckDuckGo, optional browser-cookie Gemini Web, Kimi Code Plan search, or bring your own API keys.**
 
 [![npm version](https://img.shields.io/npm/v/pi-web-access?style=for-the-badge)](https://www.npmjs.com/package/pi-web-access)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-access",
   "version": "0.29.0",
-  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Jina, SERPdive, Kagi, Ollama, AnySearch, Bright Data SERP, SerpBase, SerpApi, SearXNG, Exa, Perplexity, Gemini, Kimi, and Mistral.",
+  "description": "Web search, URL fetching, GitHub repo cloning, PDF extraction, YouTube video understanding, and local video analysis for Pi coding agent. Supports OpenAI, Brave, Parallel, TinyFish, Search1API, Searchinfinity, Querit, Tavily, Firecrawl, Crawl4AI, Jina, SERPdive, Kagi, Ollama, AnySearch, Bright Data SERP, SerpBase, SerpApi, SearXNG, Exa, Perplexity, Gemini, Kimi, and Mistral.",
   "type": "module",
   "scripts": {
     "test": "node --test",


### PR DESCRIPTION
## Problem

The README header line and the `package.json` description each enumerate every provider the extension supports. Both still list Firecrawl and self-hosted SearXNG but not Crawl4AI, which #375 added in 0.29.0. The npm description is the first thing a reader sees, so the feature is effectively invisible there.

## Fix

- README header: `self-hosted Crawl4AI extraction`, grouped with self-hosted SearXNG rather than dropped into the search list.
- `package.json` description: `Crawl4AI`, next to Firecrawl.
- Changelog entry under Unreleased.

Deliberately unchanged: the `web_search` provider list in the README, the `provider` parameter table, and the search tool description in `index.ts`. Crawl4AI has no search API, so it does not belong in any of them. The rest of the README already covers it: fallback chain prose, the How It Works diagram, the config example, `fetchRouting.providers`, the credential-source and environment-variable lists, the extraction timeout list, and the file table.

## Verification

Documentation and metadata only, no behaviour change. `npx tsc` clean; full suite 744/745, the one failure (`failed password lookups are retried instead of cached`) fails identically on `main` in my environment. `jq` round-trips `package.json`.

Related: #375.
