### PR TITLE
fix: prevent uncaughtException crash from abort() in timer/event callbacks

### DIFF
--- a/curator-server.ts
+++ b/curator-server.ts
@@ -584,7 +584,11 @@ export function startCuratorServer(
 					return;
 				}
 				const controller = new AbortController();
-				req.on("close", () => controller.abort());
+				// Guard + explicit reason so abort() never throws inside the "close"
+				// event callback (which would escape as an uncaughtException).
+				req.on("close", () => {
+					try { controller.abort("request-closed"); } catch { /* never throw */ }
+				});
 				touchHeartbeat();
 				try {
 					const rewritten = await callbacks.onRewriteQuery(query.trim(), controller.signal);

--- a/extract.ts
+++ b/extract.ts
@@ -1153,9 +1153,17 @@ async function extractViaHttp(
 
 	const controller = new AbortController();
 	const startedAt = Date.now();
-	const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+	// Pass an explicit reason and guard so abort() never constructs a
+	// DOMException or throws inside a timer/event callback. On runtimes where
+	// globalThis.DOMException is a throwing polyfill (e.g. node-domexception),
+	// a bare abort() would escape as an uncaughtException and crash the process.
+	const timeoutId = setTimeout(() => {
+		try { controller.abort("timeout"); } catch { /* never throw from timer */ }
+	}, timeoutMs);
 
-	const onAbort = () => controller.abort();
+	const onAbort = () => {
+		try { controller.abort("caller-aborted"); } catch { /* never throw */ }
+	};
 	signal?.addEventListener("abort", onAbort);
 
 	try {

--- a/summary-review.ts
+++ b/summary-review.ts
@@ -309,7 +309,16 @@ export async function generateSummaryDraft(
 	let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
 	const deadlinePromise = new Promise<typeof deadlineMarker>(resolve => {
 		deadlineTimer = setTimeout(() => {
-			deadlineController.abort();
+			// Pass an explicit reason so AbortController.abort() never constructs a
+			// DOMException internally. Some runtimes install a throwing/fake
+			// globalThis.DOMException (e.g. the node-domexception polyfill), and a
+			// throw inside this timer callback would escape as an uncaughtException
+			// and crash the host process. Guard defensively regardless.
+			try {
+				deadlineController.abort(deadlineMarker);
+			} catch {
+				// Never throw from the deadline timer callback.
+			}
 			resolve(deadlineMarker);
 		}, deadlineMs);
 	});
@@ -330,7 +339,11 @@ export async function generateSummaryDraft(
 		if (signal?.aborted) throw new Error("Aborted");
 		// Imports or synchronous providers can finish before an overdue timer runs.
 		if (deadlineController.signal.aborted || Date.now() - generationStartedAt >= deadlineMs) {
-			deadlineController.abort();
+			try {
+				deadlineController.abort(deadlineMarker);
+			} catch {
+				// Never let abort() throw here; the marker throw below is the control flow.
+			}
 			throw deadlineMarker;
 		}
 	}

--- a/test/abort-domexception-crash.test.mjs
+++ b/test/abort-domexception-crash.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const summaryUrl = new URL("../summary-review.ts", import.meta.url).href;
+
+// Regression test for a crash where a bare AbortController.abort() inside the
+// summary deadline timer constructed a DOMException via globalThis.DOMException.
+// When a runtime installs a throwing/fake DOMException (e.g. the
+// node-domexception polyfill bundled by some hosts), that throw escaped the
+// Timeout._onTimeout callback as an uncaughtException and killed the process.
+//
+// The fix passes an explicit abort reason (so abort() never builds a
+// DOMException) and guards the timer callback. This test asserts both that the
+// process survives a throwing DOMException AND that the deadline abort uses an
+// explicit reason (signal.reason is the marker, not a DOMException).
+test("summary deadline abort uses explicit reason and survives a throwing DOMException", () => {
+	const child = spawnSync(process.execPath, ["--input-type=module"], {
+		input: buildChildScript(),
+		encoding: "utf8",
+		timeout: 15_000,
+	});
+	assert.equal(child.status, 0, `${child.error ?? ""}\n${child.stderr}`);
+	assert.match(child.stdout, /SURVIVED/);
+	assert.match(child.stdout, /REASON_IS_MARKER/);
+	assert.doesNotMatch(child.stdout + child.stderr, /UNCAUGHT/);
+});
+
+function buildChildScript() {
+	// A summary model registry that always fails fast so generateSummaryDraft
+	// falls back deterministically once the deadline path is exercised.
+	const moduleSource = `
+		export const complete = () => { throw new Error("no provider"); };
+		export const completeSimple = complete;
+		export const clampThinkingLevel = (_m, l) => l;
+	`;
+	const loaderSource = `
+		export async function resolve(specifier, context, next) {
+			if (specifier === "@earendil-works/pi-ai/compat" || specifier === "@earendil-works/pi-ai") {
+				return { url: ${JSON.stringify("data:text/javascript," + encodeURIComponent(moduleSource))}, shortCircuit: true };
+			}
+			return next(specifier, context);
+		}
+	`;
+	return `
+		import { register } from "node:module";
+		import { mkdtemp, rm } from "node:fs/promises";
+		import { tmpdir } from "node:os";
+		import { join } from "node:path";
+
+		// Install a global DOMException that throws when used to build an
+		// AbortError reason — mimicking the broken node-domexception polyfill.
+		const RealDE = globalThis.DOMException;
+		globalThis.DOMException = class extends RealDE {
+			constructor(message, name) {
+				if (name === "AbortError") {
+					throw new RealDE("This operation was aborted", "AbortError");
+				}
+				super(message, name);
+			}
+		};
+
+		let crashed = false;
+		process.on("uncaughtException", (err) => {
+			crashed = true;
+			console.error("UNCAUGHT:", err && err.name, err && err.message);
+		});
+
+		register("data:text/javascript," + encodeURIComponent(${JSON.stringify(loaderSource)}), import.meta.url);
+		const agentDir = await mkdtemp(join(tmpdir(), "abort-de-crash-"));
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		try {
+			const { generateSummaryDraft } = await import(${JSON.stringify(summaryUrl)});
+
+			// Capture the reason passed to the internal deadline controller's
+			// abort() by observing the completion signal's reason after timeout.
+			const registry = {
+				find: () => undefined,
+				getAvailable: () => [],
+				getApiKeyAndHeaders: async () => ({ ok: false }),
+			};
+
+			// Track the reason on the deadline signal. generateSummaryDraft wires
+			// deadlineController.signal into AbortSignal.any; we instead verify the
+			// deadline path completed via fallback and did not crash. To assert the
+			// explicit reason, we spy on AbortController.prototype.abort.
+			let sawExplicitReason = false;
+			const origAbort = AbortController.prototype.abort;
+			AbortController.prototype.abort = function (reason) {
+				if (arguments.length > 0 && reason !== undefined) sawExplicitReason = true;
+				return origAbort.call(this, reason);
+			};
+
+			// deadlineMs = 5 forces the real timer to fire while generation is in
+			// progress; with the old bare abort() the throwing DOMException would
+			// escape the timer callback on affected runtimes.
+			const result = await generateSummaryDraft([], {
+				modelRegistry: registry, cwd: agentDir, isProjectTrusted: () => false,
+			}, undefined, undefined, undefined, undefined, 5);
+
+			AbortController.prototype.abort = origAbort;
+			// Let any deferred uncaughtException surface.
+			await new Promise((resolve) => setTimeout(resolve, 30));
+			if (crashed) {
+				console.error("CRASHED");
+				process.exit(1);
+			}
+			console.log(sawExplicitReason ? "REASON_IS_MARKER" : "NO_EXPLICIT_REASON");
+			console.log("SURVIVED", result.meta.fallbackUsed);
+		} finally {
+			await rm(agentDir, { recursive: true, force: true });
+		}
+	`;
+}


### PR DESCRIPTION
## Problem

A bare `AbortController.abort()` (called with no reason) constructs a `DOMException` via `globalThis.DOMException` to populate `signal.reason`. When the host runtime has installed a throwing/fake `DOMException` — for example the `node-domexception` polyfill that gets bundled into some downstream builds — that construction throws.

When this happens inside a `setTimeout` or a `"close"` event callback, the throw escapes the callback as an **uncaughtException** and crashes the entire host process.

Observed crash in the wild (pi coding agent):

```
pi exiting due to uncaughtException:
DOMException [AbortError]: This operation was aborted
    at new DOMException (node:internal/per_context/domexception:76:18)
    at AbortController.abort (node:internal/abort_controller:572:18)
    at Timeout._onTimeout (.../pi-web-access/summary-review.ts:312:26)
    at listOnTimeout (node:internal/timers:685:17)
```

`summary-review.ts:312` is the summary-generation deadline timer firing `deadlineController.abort()`.

## Fix

Pass an **explicit abort reason** to `abort()` so it never constructs a `DOMException` internally, and wrap the calls in `try/catch` so nothing can ever throw out of a timer or event callback:

- **`summary-review.ts`** — the deadline `setTimeout` callback and `checkSummaryDeadline()` now call `deadlineController.abort(deadlineMarker)` inside `try/catch`.
- **`extract.ts`** — the fetch-timeout timer and the caller-abort listener now pass an explicit reason and are guarded.
- **`curator-server.ts`** — the `req.on("close")` handler now passes an explicit reason and is guarded.

Using an explicit reason is also semantically nicer: `signal.reason` now carries the marker/label instead of a generic `AbortError`, and nothing in the codebase reads `.reason` in a way that depends on it being a `DOMException`.

## Testing

Added `test/abort-domexception-crash.test.mjs`, which spawns a child that:

1. installs a `globalThis.DOMException` that throws when used to build an `AbortError` (mimicking the broken polyfill),
2. spies on `AbortController.prototype.abort` to assert the deadline abort passes an explicit reason, and
3. asserts the process survives without an `uncaughtException`.

The test **fails on the unpatched code** (`NO_EXPLICIT_REASON`) and **passes with the fix** (`REASON_IS_MARKER`).

Note: on Node 24, `abort()` uses an internal `DOMException` rather than the global, so the literal crash only reproduces on affected/older runtimes — the test therefore guards the explicit-reason contract, which is what prevents the crash everywhere.

## Scope

Only `abort()` call sites that run inside timer or event callbacks (where a throw becomes an uncaughtException) were changed. Bare `abort()` calls in normal request/response call stacks are left as-is since a throw there propagates to an awaiting caller rather than crashing the process.